### PR TITLE
Potential fix for code scanning alert no. 2: Incomplete string escaping or encoding

### DIFF
--- a/scripts/fix-accordion-format.mjs
+++ b/scripts/fix-accordion-format.mjs
@@ -93,7 +93,9 @@ function parseInlineTable(text) {
 
 function createDataTable(headers, rows) {
   const escapedRows = rows.map((row) => {
-    return row.map((cell) => cell.replace(/"/g, '\\"'));
+    return row.map(
+      (cell) => cell.replace(/\\/g, "\\\\").replace(/"/g, '\\"')
+    );
   });
 
   const rowsStr = escapedRows


### PR DESCRIPTION
Potential fix for [https://github.com/sandgraal/Costa-Rica-Tree-Atlas/security/code-scanning/2](https://github.com/sandgraal/Costa-Rica-Tree-Atlas/security/code-scanning/2)

In general, when manually escaping strings for inclusion in code string literals, you must escape backslashes *before* escaping other meta-characters like quotes; otherwise, a backslash might combine with a following character to form an unintended escape sequence. For this specific function, `createDataTable` constructs JSX/JavaScript array literals using `["${row[0]}", "${row[1]}"]`. The safest minimal fix is to escape backslashes (`\`) and double quotes (`"`) inside each `cell` so that every occurrence of these characters becomes a safe, literal representation in the generated code.

Concretely, in `scripts/fix-accordion-format.mjs`, within `createDataTable`, change the `escapedRows` computation so that each `cell` is first processed with `.replace(/\\/g, "\\\\")` to double any backslashes, and then quotes are escaped with `.replace(/"/g, '\\"')`. The order matters: escaping backslashes first ensures they do not interfere with later escaping of quotes. No additional imports are required; this uses only built-in JavaScript regex and string replacement.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Ensure backslashes and double quotes in table cell values are fully escaped before embedding them into generated JavaScript/JSX literals to prevent malformed escape sequences.