### PR TITLE
fix(images): prefer whole-tree featured photos and seed from gallery candidates

### DIFF
--- a/.github/workflows/nightly-image-cleanup.yml
+++ b/.github/workflows/nightly-image-cleanup.yml
@@ -73,7 +73,7 @@ jobs:
         run: npm run images:download:force
 
       - name: Check for better featured images
-        if: steps.mode.outputs.mode == 'refresh' || steps.mode.outputs.mode == 'full'
+        if: steps.mode.outputs.mode == 'refresh' || steps.mode.outputs.mode == 'full' || steps.mode.outputs.mode == 'auto'
         run: npm run images:refresh
 
       - name: Refresh gallery images with broken or low-quality photos

--- a/context/context.md
+++ b/context/context.md
@@ -18,7 +18,7 @@
 - Lint: `npm run lint`
 - Format: `npm run format`
 - Image audit: `npm run images:audit`, `npm run images:audit:gallery`
-- Image repair: `npm run images:download`, `npm run images:refresh`, `npm run images:refresh:gallery`
+- Image repair: `npm run images:download`, `npm run images:refresh`, `npm run images:refresh:gallery`, `npm run images:cleanup`
 
 ## Key Paths by Feature
 - Tree content (MDX): `content/trees/en/*.mdx`, `content/trees/es/*.mdx`
@@ -26,6 +26,12 @@
 - Image maintenance scripts: `scripts/manage-tree-images.mjs`, `scripts/cleanup-tree-images.mjs`
 - Nightly maintenance workflow: `.github/workflows/nightly-image-cleanup.yml`
 - MDX components: `src/components/mdx/`
+- Tree detail page: `src/app/[locale]/trees/[slug]/page.tsx`
+
+## Code Search Notes
+- Gallery rendering: `src/components/mdx/index.tsx` (`ImageCard`, `ImageGallery`).
+- Featured image maintenance: `scripts/manage-tree-images.mjs` (`downloadImages`, `refreshImages`, `scoreFeaturedCandidate`).
+- Nightly image workflow: `.github/workflows/nightly-image-cleanup.yml` (modes `auto`, `full`).
 
 ## Known Constraints & Feature Flags
 - Optional analytics and APIs are configured via `.env.example`.

--- a/context/links.md
+++ b/context/links.md
@@ -1,4 +1,4 @@
 # Issue & PR History
 
-- No issue/PR links found in-repo for the keywords "nightly image", "image cleanup", or "image maintenance".
+- No issue/PR links found in-repo for the keywords "nightly image", "image cleanup", "image maintenance", "pilon", or "gallery".
 - Git remote is not configured in this workspace, so GitHub issue/PR searches could not be performed.

--- a/docs/IMAGE_RESOURCES.md
+++ b/docs/IMAGE_RESOURCES.md
@@ -27,7 +27,7 @@ All image attributions are tracked in `/public/images/trees/attributions.json`. 
 | `npm run images:audit:gallery`         | Check status of all gallery images       |
 | `npm run images:download`              | Download missing/broken featured images  |
 | `npm run images:download:force`        | Re-download all featured images          |
-| `npm run images:refresh`               | Check for better quality featured images |
+| `npm run images:refresh`               | Refresh featured images when better photos exist |
 | `npm run images:refresh:gallery`       | Update gallery images with better photos |
 | `npm run images:refresh:gallery:force` | Force refresh all gallery images         |
 
@@ -46,7 +46,7 @@ npm run images:download
 # Download with force - Re-download ALL featured images
 npm run images:download:force
 
-# Refresh - Check iNaturalist for potentially better featured images
+# Refresh - Update featured images if better photos exist
 npm run images:refresh
 
 # Refresh Gallery - Update gallery images with high-quality, diverse photos
@@ -79,12 +79,13 @@ The image management script (`scripts/manage-tree-images.mjs`):
    - Searches iNaturalist API for the tree's taxon
    - Fetches research-grade photos (Costa Rica first, then global)
    - Downloads highest-voted photos
+   - Prefers full-tree/whole-canopy shots when available (based on observation text, photo position, and dimensions)
    - Resizes to 1200px width (using Sharp, ImageMagick, or sips)
    - Saves as optimized JPEG (85% quality)
    - Updates both EN and ES MDX frontmatter
    - Records attribution in `attributions.json`
 
-3. **Refresh Mode**: Compares current images against iNaturalist to find potentially better photos (higher vote counts).
+3. **Refresh Mode**: Compares current images against iNaturalist to find better photos (higher vote counts) and replaces featured images when a better photo is found.
 
 #### Gallery Images
 
@@ -129,7 +130,7 @@ You can manually run the workflow from GitHub Actions with these modes:
 - `audit-gallery` - Check gallery images only
 - `download` - Download missing featured images
 - `download-force` - Re-download all featured images
-- `refresh` - Check for better featured images
+- `refresh` - Update featured images when better photos are found
 - `refresh-gallery` - Update gallery images with better photos
 - `full` - Run all audits and fixes
 

--- a/src/components/mdx/index.tsx
+++ b/src/components/mdx/index.tsx
@@ -516,6 +516,7 @@ export function ImageCard({
   sourceUrl,
   onClick,
 }: ImageCardProps) {
+  const isRemote = src.startsWith("http");
   const content = (
     <figure className="bg-card rounded-xl overflow-hidden border border-border not-prose group">
       <div className="aspect-[4/3] bg-muted relative">
@@ -527,6 +528,7 @@ export function ImageCard({
           className={`object-cover ${onClick ? "group-hover:scale-105 transition-transform duration-300" : ""}`}
           placeholder="blur"
           blurDataURL={BLUR_DATA_URL}
+          unoptimized={isRemote}
         />
         {onClick && (
           <div className="absolute inset-0 bg-black/0 group-hover:bg-black/20 transition-colors flex items-center justify-center">


### PR DESCRIPTION
### Motivation
- Featured images were sometimes close-up or unrepresentative shots (e.g., Pilón) and need to favor full-tree/recognizable photos.  
- Existing refresh logic relied mostly on vote counts and could miss gallery whole-tree photos that better represent the tree.  
- Improve automated selection so nightly refreshes more reliably replace poor featured images with representative alternatives.  

### Description
- Add whole-tree/detail detection patterns and a `scoreFeaturedCandidate` heuristic to rank photos by votes, dimensions, aspect ratio, "first photo" signal, and whole-tree hints.  
- Add `buildInatPhotoUrl`, `selectFeaturedFromGallery`, and wire gallery whole-tree candidates into `processTree` so downloads are seeded from gallery picks when available.  
- Use the new scoring in `getTopPhotos`/`extractPhotos`, include `downloadUrl`/`largeUrl`/`description`/`isFirst` in photo objects, and persist `votes` and `photoId` into `attributions.json`.  
- Update refresh flow to compare stored `votes` and refresh when a clearly better photo exists, and set `unoptimized` on remote `Image` usages in `ImageCard` to avoid Next.js optimizer failures; also update `docs/IMAGE_RESOURCES.md` and `context/context.md`.  

### Testing
- Ran a lightweight repository secret scan via `rg -n "BEGIN PRIVATE KEY|PRIVATE KEY|API_KEY|SECRET|TOKEN"`, which completed successfully.  
- No network-dependent image-downloads or CI image processing were run in this environment due to sandboxed network restrictions, so end-to-end download/refresh behavior was not executed here.  
- Changes are limited to selection logic, metadata shape, and docs so behavior should be verifiable by running `npm run images:refresh -- --tree=<name>` in an environment with network access and CI (recommended to validate on `pilon`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ef216e5d08323a1312ae109d03efe)

## Summary by Sourcery

Improve automated featured tree image selection to favor high-quality whole-tree photos and integrate better refresh behavior and docs updates.

Enhancements:
- Introduce a scoring heuristic and whole-tree/detail detection to rank candidate photos for featured images.
- Prefer whole-tree gallery photos as seeds for featured image downloads while de-duplicating against other candidates.
- Track additional photo metadata, including votes and photo IDs, in attribution data and refresh logic.
- Refine the image refresh flow to actually update MDX featured images when clearly better photos exist and persist updated attributions.
- Disable Next.js optimization for remote gallery images to avoid optimizer failures.
- Clarify image maintenance commands and add contextual pointers to key image-related code paths in project documentation.

CI:
- Allow the nightly image cleanup workflow to run the featured image refresh step in the new `auto` mode as well as existing modes.