### PR TITLE
Potential fix for code scanning alert no. 3: Useless comparison test

### DIFF
--- a/src/app/[locale]/education/certificate/CertificateClient.tsx
+++ b/src/app/[locale]/education/certificate/CertificateClient.tsx
@@ -121,7 +121,7 @@ function CertificateContent({ locale }: CertificateClientProps) {
             <ul className="space-y-2 text-sm">
               <li className="flex items-center gap-2">
                 <span className="w-5 h-5 rounded-full bg-muted flex items-center justify-center text-xs">
-                  {completedLessons >= 1 ? "✓" : "1"}
+                  1
                 </span>
                 {t.lessonsReq}
               </li>


### PR DESCRIPTION
Potential fix for [https://github.com/sandgraal/Costa-Rica-Tree-Atlas/security/code-scanning/3](https://github.com/sandgraal/Costa-Rica-Tree-Atlas/security/code-scanning/3)

In general, to fix a useless comparison that is always true or always false, you either remove the condition entirely or restructure the surrounding logic so that the condition can actually vary. Here, because we are specifically inside an `if (completedLessons === 0)` branch, the comparison `completedLessons >= 1` can never be true, so the branch using it is effectively dead code. The simplest fix that preserves existing runtime behavior is to remove the conditional expression and replace it with the constant value that is actually rendered: `"1"`.

Concretely, in `src/app/[locale]/education/certificate/CertificateClient.tsx`, locate the `if (completedLessons === 0)` block and within it the `<span>` where the content is currently `{completedLessons >= 1 ? "✓" : "1"}`. Replace that ternary expression with the literal `"1"`. No imports or new definitions are needed; this is a purely local change that clarifies intent and removes the redundant comparison without altering any visible behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Eliminate a useless comparison in the certificate lessons indicator that could never evaluate to true.