### PR TITLE
Potential fix for code scanning alert no. 37: Incomplete multi-character sanitization

### DIFF
--- a/src/lib/validation/json-ld.ts
+++ b/src/lib/validation/json-ld.ts
@@ -223,9 +223,6 @@ function sanitizeString(value: string): string {
     // Use \s+ for whitespace before > to handle </script >, </script\t>, etc.
     clean = clean.replace(/<script[\s\S]*?>[\s\S]*?<\/script[\s\S]*?>/gis, "");
 
-    // Remove style tags (handle all whitespace)
-    clean = clean.replace(/<style[\s\S]*?>[\s\S]*?<\/style[\s\S]*?>/gis, "");
-
     // Remove event handler attributes safely (handles quoted and unquoted values)
     clean = removeEventHandlerAttributes(clean);
 
@@ -235,6 +232,10 @@ function sanitizeString(value: string): string {
     clean = clean.replace(/vbscript:/gi, "");
     clean = clean.replace(/data:/gi, ""); // Comprehensive - removes all data: URIs
   }
+
+  // Ensure no residual <style or </style sequences remain (case-insensitive, with optional whitespace)
+  clean = clean.replace(/<\s*style/gi, "");
+  clean = clean.replace(/<\/\s*style/gi, "");
 
   // Remove fullwidth variants (Unicode lookalikes)
   clean = clean.replace(/[＜＞＆]/g, "");

--- a/src/lib/validation/json-ld.ts
+++ b/src/lib/validation/json-ld.ts
@@ -238,11 +238,17 @@ function sanitizeString(value: string): string {
   const removeStyleSequences = (input: string): string => {
     let output = input;
     // Remove complete <style>...</style> tags (including attributes and newlines)
-    output = output.replace(/<\s*style\b[\s\S]*?>/gi, "");
-    output = output.replace(/<\/\s*style\b[\s\S]*?>/gi, "");
-    // As a fallback, strip any remaining bare <style or </style fragments
-    output = output.replace(/<\s*style/gi, "");
-    output = output.replace(/<\/\s*style/gi, "");
+    // and any remaining <style / </style fragments. Apply repeatedly until no
+    // further changes occur to avoid incomplete multi-character sanitization.
+    let previous: string;
+    do {
+      previous = output;
+      output = output.replace(/<\s*style\b[\s\S]*?>/gi, "");
+      output = output.replace(/<\/\s*style\b[\s\S]*?>/gi, "");
+      // As a fallback, strip any remaining bare <style or </style fragments
+      output = output.replace(/<\s*style/gi, "");
+      output = output.replace(/<\/\s*style/gi, "");
+    } while (output !== previous);
     return output;
   };
 

--- a/src/lib/validation/json-ld.ts
+++ b/src/lib/validation/json-ld.ts
@@ -235,10 +235,20 @@ function sanitizeString(value: string): string {
 
   // Ensure no residual <style or </style sequences remain (case-insensitive, with optional whitespace)
   // Apply repeatedly in case earlier replacements create new <style / </style sequences
+  const removeStyleSequences = (input: string): string => {
+    let output = input;
+    // Remove complete <style>...</style> tags (including attributes and newlines)
+    output = output.replace(/<\s*style\b[\s\S]*?>/gi, "");
+    output = output.replace(/<\/\s*style\b[\s\S]*?>/gi, "");
+    // As a fallback, strip any remaining bare <style or </style fragments
+    output = output.replace(/<\s*style/gi, "");
+    output = output.replace(/<\/\s*style/gi, "");
+    return output;
+  };
+
   while (true) {
     const beforeStyleClean = clean;
-    clean = clean.replace(/<\s*style/gi, "");
-    clean = clean.replace(/<\/\s*style/gi, "");
+    clean = removeStyleSequences(clean);
     if (clean === beforeStyleClean) {
       break;
     }

--- a/src/lib/validation/json-ld.ts
+++ b/src/lib/validation/json-ld.ts
@@ -234,8 +234,15 @@ function sanitizeString(value: string): string {
   }
 
   // Ensure no residual <style or </style sequences remain (case-insensitive, with optional whitespace)
-  clean = clean.replace(/<\s*style/gi, "");
-  clean = clean.replace(/<\/\s*style/gi, "");
+  // Apply repeatedly in case earlier replacements create new <style / </style sequences
+  while (true) {
+    const beforeStyleClean = clean;
+    clean = clean.replace(/<\s*style/gi, "");
+    clean = clean.replace(/<\/\s*style/gi, "");
+    if (clean === beforeStyleClean) {
+      break;
+    }
+  }
 
   // Remove fullwidth variants (Unicode lookalikes)
   clean = clean.replace(/[＜＞＆]/g, "");


### PR DESCRIPTION
Potential fix for [https://github.com/sandgraal/Costa-Rica-Tree-Atlas/security/code-scanning/37](https://github.com/sandgraal/Costa-Rica-Tree-Atlas/security/code-scanning/37)

In general, the problem comes from trying to remove entire multi-character patterns like `<style...>...</style>` with a single complex regex, plus a fixed number of passes. Even with three iterations, there are inputs where removals expose new `<style` sequences that are never removed. To fix this without changing functionality broadly, we should avoid relying on multi-character “balanced tag” patterns for styles and instead sanitize at the character level so that dangerous tag boundaries (`<style`, `</style>`, `<script`, etc.) cannot survive. The simplest robust strategy is to strip occurrences of `<style` and `</style` (case-insensitive) directly, or to strip all `<`/`>` characters entirely. Since this sanitizer is already aggressively destructive and is not preserving safe HTML, removing `<style`/`</style` sequences explicitly is a minimal, targeted change that addresses CodeQL’s concern without altering other behavior.

The single best targeted fix here is:

- Keep the existing `for` loop and script tag removal as-is.
- Remove the multi-character `<style...>...</style>` pattern replacement inside the loop.
- After the loop, add explicit replacements that remove any remaining `<style` and `</style` sequences in a case-insensitive way. This ensures that even if pathological input manages to leave behind partial or nested constructs where `<style` survives, they will be removed in a final, single-character-based pass.

Concretely:

- In `sanitizeString` in `src/lib/validation/json-ld.ts`, remove or neutralize line 227 that uses `/\<style[\s\S]*?>[\s\S]*?<\/style[\s\S]*?>/gis`.
- After the loop that runs three passes (after line 237), add:

  ```ts
  clean = clean.replace(/<\s*style/gi, "");
  clean = clean.replace(/<\/\s*style/gi, "");
  ```

  This catches `<style`, `< style`, `</style`, `</ style`, with any case combination.

No new imports or helper functions are required; we only need to modify `sanitizeString` within the shown snippet.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Harden sanitization of JSON-LD strings against incomplete multi-character style tag removal.

Bug Fixes:
- Ensure all <style and </style sequences are fully stripped from sanitized strings, preventing residual style tag fragments from surviving multiple passes.

Enhancements:
- Replace the previous single regex-based style tag removal with an iterative style sequence cleaner that repeatedly strips style tags and fragments until no more changes occur.