### PR TITLE
fix: revert performance optimizations that hurt LCP/TBT

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -4,7 +4,6 @@ import { routing } from "@i18n/routing";
 import { getMessages, setRequestLocale } from "next-intl/server";
 import { headers } from "next/headers";
 import { Geist, Geist_Mono } from "next/font/google";
-import Script from "next/script";
 import { Header } from "@/components/Header";
 import { Footer } from "@/components/Footer";
 import { StoreProvider, QueryProvider } from "@/components/providers";
@@ -120,11 +119,16 @@ export default async function LocaleLayout({ children, params }: Props) {
   return (
     <html lang={locale}>
       <head>
-        {/* Theme script - MUST be first to prevent flash */}
-        {/* Using Next.js Script with id to avoid dangerouslySetInnerHTML XSS warnings */}
-        <Script id="theme-script" strategy="beforeInteractive" nonce={nonce}>
-          {THEME_SCRIPT}
-        </Script>
+        {/*
+          Theme script - MUST be first to prevent flash
+          Security: Safe to use dangerouslySetInnerHTML here because THEME_SCRIPT
+          is a static string with no user input - only compile-time constants.
+        */}
+        <script
+          nonce={nonce}
+          // eslint-disable-next-line react/no-danger
+          dangerouslySetInnerHTML={{ __html: THEME_SCRIPT }}
+        />
 
         {/* Site-wide structured data */}
         <SafeJsonLd

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -4,35 +4,8 @@ import { allTrees } from "contentlayer/generated";
 import { SafeImage } from "@/components/SafeImage";
 import { SafeJsonLd } from "@/components/SafeJsonLd";
 import { RecentlyViewedList } from "@/components/RecentlyViewedList";
-import dynamic from "next/dynamic";
+import { FeaturedTreesSection } from "@/components/FeaturedTreesSection";
 import type { Locale } from "@/types/tree";
-
-// Dynamic imports for below-fold components to reduce initial bundle
-const FeaturedTreesSection = dynamic(
-  () =>
-    import("@/components/FeaturedTreesSection").then(
-      (mod) => mod.FeaturedTreesSection
-    ),
-  {
-    loading: () => (
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-        {Array.from({ length: 6 }).map((_, i) => (
-          <div
-            key={i}
-            className="bg-card rounded-xl overflow-hidden animate-pulse"
-          >
-            <div className="aspect-video bg-muted" />
-            <div className="p-4 space-y-2">
-              <div className="h-5 bg-muted rounded w-3/4" />
-              <div className="h-4 bg-muted rounded w-1/2" />
-            </div>
-          </div>
-        ))}
-      </div>
-    ),
-    ssr: true,
-  }
-);
 
 type Props = {
   params: Promise<{ locale: string }>;

--- a/src/lib/theme/theme-script.ts
+++ b/src/lib/theme/theme-script.ts
@@ -7,8 +7,12 @@ import { STORE_KEY } from "@/lib/store";
  * The script reads from localStorage and sets theme classes/attributes
  * before the browser paints, preventing any flash of incorrect theme.
  *
- * Exported as a constant string to be used with Next.js Script component,
- * avoiding dangerouslySetInnerHTML which triggers XSS warnings.
+ * Security note: This script is safe to use with dangerouslySetInnerHTML because:
+ * 1. The content is a static string defined at build time
+ * 2. No user input is interpolated into the script
+ * 3. The only variable (STORE_KEY) is a compile-time constant
+ *
+ * @security codacy-disable Generic Object Injection Sink
  */
 export const THEME_SCRIPT = `
 (function() {


### PR DESCRIPTION
## Summary

Reverts the performance "optimizations" from PR #190 that actually made Lighthouse scores worse:

- **LCP**: 5.7s → 6.2s (worse)
- **TBT**: 410ms → 670ms (worse)
- **Overall score**: 50 → 42 (worse)

## Changes

### Reverted:
1. **Dynamic import** for `FeaturedTreesSection` → back to static import
2. **Next.js Script component** for theme → back to inline `<script>` with `dangerouslySetInnerHTML`

### Why this hurt performance:
- `FeaturedTreesSection` is above the fold, so dynamic importing adds overhead without benefit
- `strategy="beforeInteractive"` still blocks rendering but adds Next.js Script wrapper overhead
- Regular inline scripts in `<head>` are faster for critical blocking code like theme initialization

### What remains from PR #190:
- ✅ DataTable supports both `string[][]` and `Record<string,string>[]` formats (fixes arrayan page crash)
- ✅ Prototype pollution prevention using `Object.entries()` + `Map`
- ✅ Test file updated to use `THEME_SCRIPT` constant

## Security Note

The Codacy XSS warning for `dangerouslySetInnerHTML` is a false positive since `THEME_SCRIPT` is a static string with no user input - only compile-time constants are interpolated.

## Summary by Sourcery

Revert previous performance-related changes that degraded Lighthouse metrics while keeping unrelated improvements from the earlier PR.

Bug Fixes:
- Restore static import of the above-the-fold FeaturedTreesSection to avoid dynamic import overhead on the homepage.
- Reinstate an inline theme initialization script instead of using the Next.js Script component to improve critical rendering performance.

Enhancements:
- Document the security rationale for using THEME_SCRIPT with dangerouslySetInnerHTML and annotate it to suppress false-positive security warnings.