### PR TITLE
feat: Add comparison guides to site

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -231,7 +231,7 @@
     }
   },
   "comparison": {
-    "title": "Comparison Tool",
+    "title": "Tree Comparison",
     "subtitle": "Compare characteristics of different tree species side by side",
     "selectTree": "Select a tree",
     "selectPlaceholder": "Add a tree to compare...",
@@ -240,6 +240,13 @@
     "noTreesSelected": "Select up to 4 trees to compare their characteristics",
     "clearAll": "Clear all",
     "navLink": "Compare",
+    "guidesTitle": "Comparison Guides",
+    "guidesSubtitle": "Expert guides to distinguish commonly confused tree species",
+    "readGuide": "Read Guide",
+    "keyDifference": "Key Difference",
+    "comparingSpecies": "Comparing",
+    "toolTitle": "Interactive Comparison Tool",
+    "toolSubtitle": "Or compare any trees side-by-side using our interactive tool",
     "properties": {
       "image": "Image",
       "commonName": "Common Name",

--- a/messages/es.json
+++ b/messages/es.json
@@ -230,7 +230,7 @@
     }
   },
   "comparison": {
-    "title": "Herramienta de Comparación",
+    "title": "Comparación de Árboles",
     "subtitle": "Compare características de diferentes especies de árboles lado a lado",
     "selectTree": "Seleccionar un árbol",
     "selectPlaceholder": "Añadir un árbol para comparar...",
@@ -239,6 +239,13 @@
     "noTreesSelected": "Seleccione hasta 4 árboles para comparar sus características",
     "clearAll": "Limpiar todo",
     "navLink": "Comparar",
+    "guidesTitle": "Guías de Comparación",
+    "guidesSubtitle": "Guías expertas para distinguir especies de árboles comúnmente confundidas",
+    "readGuide": "Leer Guía",
+    "keyDifference": "Diferencia Clave",
+    "comparingSpecies": "Comparando",
+    "toolTitle": "Herramienta Interactiva de Comparación",
+    "toolSubtitle": "O compare cualquier árbol lado a lado usando nuestra herramienta interactiva",
     "properties": {
       "image": "Imagen",
       "commonName": "Nombre Común",

--- a/src/app/[locale]/compare/[slug]/page.tsx
+++ b/src/app/[locale]/compare/[slug]/page.tsx
@@ -1,0 +1,157 @@
+import { notFound } from "next/navigation";
+import { setRequestLocale } from "next-intl/server";
+import { allSpeciesComparisons, allTrees } from "contentlayer/generated";
+import { Link } from "@i18n/navigation";
+import type { Metadata } from "next";
+import { ServerMDXContent } from "@/components/ServerMDXContent";
+import { Breadcrumbs } from "@/components/Breadcrumbs";
+import { ShareButton } from "@/components/ShareButton";
+import { PrintButton } from "@/components/PrintButton";
+import type { Locale } from "@/types/tree";
+
+type Props = {
+  params: Promise<{ locale: string; slug: string }>;
+};
+
+export async function generateStaticParams() {
+  const params: { locale: string; slug: string }[] = [];
+
+  allSpeciesComparisons.forEach((comparison) => {
+    params.push({
+      locale: comparison.locale,
+      slug: comparison.slug,
+    });
+  });
+
+  return params;
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { locale, slug } = await params;
+  const comparison = allSpeciesComparisons.find(
+    (c) => c.locale === locale && c.slug === slug
+  );
+
+  if (!comparison) {
+    return {
+      title: "Comparison Not Found",
+    };
+  }
+
+  return {
+    title: comparison.title,
+    description: comparison.description,
+    openGraph: {
+      title: comparison.title,
+      description: comparison.description,
+      type: "article",
+      locale: locale === "es" ? "es_CR" : "en_US",
+    },
+  };
+}
+
+export default async function ComparisonPage({ params }: Props) {
+  const { locale, slug } = await params;
+  setRequestLocale(locale);
+
+  const comparison = allSpeciesComparisons.find(
+    (c) => c.locale === locale && c.slug === slug
+  );
+
+  if (!comparison) {
+    notFound();
+  }
+
+  // Get the tree objects for the species being compared
+  const speciesTrees = comparison.species
+    .map((speciesSlug) =>
+      allTrees.find((t) => t.slug === speciesSlug && t.locale === locale)
+    )
+    .filter(Boolean);
+
+  return (
+    <article className="py-12 px-4">
+      <div className="container mx-auto max-w-4xl">
+        {/* Breadcrumbs */}
+        <Breadcrumbs
+          locale={locale as Locale}
+          customLabels={{
+            compare: locale === "es" ? "Comparar" : "Compare",
+            [comparison.slug]: comparison.title,
+          }}
+        />
+
+        {/* Actions Bar */}
+        <div className="mb-8 flex justify-end items-center gap-2 no-print">
+          <ShareButton
+            title={comparison.title}
+            scientificName=""
+            slug={`compare/${comparison.slug}`}
+          />
+          <PrintButton label={locale === "es" ? "Imprimir" : "Print"} />
+        </div>
+
+        {/* Header */}
+        <header className="mb-8">
+          <h1 className="text-3xl md:text-4xl font-bold text-primary-dark dark:text-primary-light mb-4">
+            {comparison.title}
+          </h1>
+
+          {/* Species Being Compared */}
+          {speciesTrees.length > 0 && (
+            <div className="mb-4 flex flex-wrap gap-3">
+              {speciesTrees.map((tree) => (
+                <Link
+                  key={tree!.slug}
+                  href={`/trees/${tree!.slug}`}
+                  className="inline-flex items-center gap-2 px-4 py-2 bg-primary/10 hover:bg-primary/20 text-primary rounded-lg transition-colors"
+                >
+                  <span className="font-medium">{tree!.title}</span>
+                  <span className="text-sm italic opacity-80">
+                    {tree!.scientificName}
+                  </span>
+                </Link>
+              ))}
+            </div>
+          )}
+
+          {/* Key Difference Callout */}
+          <div className="p-4 bg-primary/5 border-l-4 border-primary rounded-r-lg">
+            <p className="text-sm font-semibold text-primary mb-1">
+              {locale === "es" ? "Diferencia Clave" : "Key Difference"}:
+            </p>
+            <p className="text-foreground">{comparison.keyDifference}</p>
+          </div>
+        </header>
+
+        {/* MDX Content */}
+        <div className="prose prose-lg dark:prose-invert max-w-none mb-12">
+          <ServerMDXContent source={comparison.body.raw} />
+        </div>
+
+        {/* Back to Compare Page */}
+        <div className="text-center pt-8 border-t border-border">
+          <Link
+            href="/compare"
+            className="inline-flex items-center gap-2 text-primary hover:text-primary-dark transition-colors"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className="h-4 w-4"
+            >
+              <path d="M19 12H5" />
+              <path d="m12 19-7-7 7-7" />
+            </svg>
+            {locale === "es" ? "Volver a Comparaciones" : "Back to Comparisons"}
+          </Link>
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/src/app/[locale]/compare/[slug]/page.tsx
+++ b/src/app/[locale]/compare/[slug]/page.tsx
@@ -102,13 +102,13 @@ export default async function ComparisonPage({ params }: Props) {
             <div className="mb-4 flex flex-wrap gap-3">
               {speciesTrees.map((tree) => (
                 <Link
-                  key={tree!.slug}
-                  href={`/trees/${tree!.slug}`}
+                  key={tree?.slug}
+                  href={`/trees/${tree?.slug}`}
                   className="inline-flex items-center gap-2 px-4 py-2 bg-primary/10 hover:bg-primary/20 text-primary rounded-lg transition-colors"
                 >
-                  <span className="font-medium">{tree!.title}</span>
+                  <span className="font-medium">{tree?.title}</span>
                   <span className="text-sm italic opacity-80">
-                    {tree!.scientificName}
+                    {tree?.scientificName}
                   </span>
                 </Link>
               ))}

--- a/src/app/[locale]/compare/page.tsx
+++ b/src/app/[locale]/compare/page.tsx
@@ -114,10 +114,10 @@ function ComparePageClient({
                     <div className="mb-3 flex flex-wrap gap-2">
                       {speciesTrees.map((tree) => (
                         <span
-                          key={tree!.slug}
+                          key={tree?.slug}
                           className="text-xs px-2 py-1 bg-primary/10 text-primary rounded-full"
                         >
-                          {tree!.title}
+                          {tree?.title}
                         </span>
                       ))}
                     </div>

--- a/src/app/[locale]/compare/page.tsx
+++ b/src/app/[locale]/compare/page.tsx
@@ -1,8 +1,9 @@
 import { useTranslations } from "next-intl";
 import { getTranslations } from "next-intl/server";
 import { setRequestLocale } from "next-intl/server";
-import { allTrees } from "contentlayer/generated";
+import { allTrees, allSpeciesComparisons } from "contentlayer/generated";
 import { TreeComparison } from "@/components/TreeComparison";
+import { Link } from "@i18n/navigation";
 
 type Params = Promise<{ locale: string }>;
 
@@ -26,15 +27,28 @@ export default async function ComparePage({ params }: { params: Params }) {
     .filter((tree) => tree.locale === locale)
     .sort((a, b) => a.title.localeCompare(b.title));
 
-  return <ComparePageClient locale={locale} trees={trees} />;
+  // Get all comparison guides for the current locale
+  const comparisons = allSpeciesComparisons
+    .filter((comp) => comp.locale === locale)
+    .sort((a, b) => a.title.localeCompare(b.title));
+
+  return (
+    <ComparePageClient
+      locale={locale}
+      trees={trees}
+      comparisons={comparisons}
+    />
+  );
 }
 
 function ComparePageClient({
   locale,
   trees,
+  comparisons,
 }: {
   locale: string;
   trees: (typeof allTrees)[number][];
+  comparisons: (typeof allSpeciesComparisons)[number][];
 }) {
   const t = useTranslations("comparison");
 
@@ -60,18 +74,104 @@ function ComparePageClient({
 
   return (
     <main className="container mx-auto px-4 py-8">
-      <div className="mb-8">
+      {/* Page Header */}
+      <div className="mb-12">
         <h1 className="text-3xl md:text-4xl font-bold text-primary-dark dark:text-primary-light mb-2">
           {t("title")}
         </h1>
         <p className="text-lg text-muted-foreground">{t("subtitle")}</p>
       </div>
 
-      <TreeComparison
-        trees={trees}
-        locale={locale}
-        translations={translations}
-      />
+      {/* Comparison Guides Section */}
+      {comparisons.length > 0 && (
+        <section className="mb-16">
+          <div className="mb-6">
+            <h2 className="text-2xl font-bold text-primary-dark dark:text-primary-light mb-2">
+              {t("guidesTitle")}
+            </h2>
+            <p className="text-muted-foreground">{t("guidesSubtitle")}</p>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {comparisons.map((comparison) => {
+              // Get the tree objects for the species being compared
+              const speciesTrees = comparison.species
+                .map((slug) => trees.find((t) => t.slug === slug))
+                .filter(Boolean);
+
+              return (
+                <Link
+                  key={comparison._id}
+                  href={`/compare/${comparison.slug}`}
+                  className="group bg-card border border-border rounded-xl p-6 hover:border-primary/50 hover:shadow-lg transition-all"
+                >
+                  <h3 className="text-lg font-semibold text-foreground group-hover:text-primary transition-colors mb-3">
+                    {comparison.title}
+                  </h3>
+
+                  {/* Species Being Compared */}
+                  {speciesTrees.length > 0 && (
+                    <div className="mb-3 flex flex-wrap gap-2">
+                      {speciesTrees.map((tree) => (
+                        <span
+                          key={tree!.slug}
+                          className="text-xs px-2 py-1 bg-primary/10 text-primary rounded-full"
+                        >
+                          {tree!.title}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+
+                  {/* Key Difference */}
+                  <div className="mb-4 p-3 bg-muted/50 rounded-lg border-l-4 border-primary">
+                    <p className="text-xs font-medium text-primary mb-1">
+                      {t("keyDifference")}:
+                    </p>
+                    <p className="text-sm text-foreground/80">
+                      {comparison.keyDifference}
+                    </p>
+                  </div>
+
+                  {/* Read Guide Button */}
+                  <div className="flex items-center gap-2 text-primary font-medium text-sm group-hover:gap-3 transition-all">
+                    {t("readGuide")}
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      className="h-4 w-4"
+                    >
+                      <path d="M5 12h14" />
+                      <path d="m12 5 7 7-7 7" />
+                    </svg>
+                  </div>
+                </Link>
+              );
+            })}
+          </div>
+        </section>
+      )}
+
+      {/* Interactive Comparison Tool */}
+      <section>
+        <div className="mb-6">
+          <h2 className="text-2xl font-bold text-primary-dark dark:text-primary-light mb-2">
+            {t("toolTitle")}
+          </h2>
+          <p className="text-muted-foreground">{t("toolSubtitle")}</p>
+        </div>
+
+        <TreeComparison
+          trees={trees}
+          locale={locale}
+          translations={translations}
+        />
+      </section>
     </main>
   );
 }

--- a/src/app/[locale]/trees/[slug]/page.tsx
+++ b/src/app/[locale]/trees/[slug]/page.tsx
@@ -693,7 +693,7 @@ function ComparisonLinks({
                 <div className="flex-1 min-w-0">
                   <h3 className="font-semibold text-foreground group-hover:text-primary transition-colors mb-1 text-sm">
                     {locale === "es" ? "Comparar con" : "Compare with"}{" "}
-                    {otherSpecies.map((t) => t!.title).join(", ")}
+                    {otherSpecies.map((t) => t?.title).join(", ")}
                   </h3>
                   <p className="text-xs text-muted-foreground line-clamp-2">
                     {comparison.keyDifference}

--- a/src/app/[locale]/trees/[slug]/page.tsx
+++ b/src/app/[locale]/trees/[slug]/page.tsx
@@ -1,6 +1,10 @@
 import { notFound } from "next/navigation";
 import { setRequestLocale } from "next-intl/server";
-import { allTrees, allGlossaryTerms } from "contentlayer/generated";
+import {
+  allTrees,
+  allGlossaryTerms,
+  allSpeciesComparisons,
+} from "contentlayer/generated";
 import { Link } from "@i18n/navigation";
 import type { Metadata } from "next";
 import dynamic from "next/dynamic";
@@ -433,6 +437,9 @@ export default async function TreePage({ params }: Props) {
               {/* Safety Disclaimer */}
               <SafetyDisclaimer />
 
+              {/* Comparison Links */}
+              <ComparisonLinks currentTree={tree} locale={locale} />
+
               {/* Related Trees */}
               <RelatedTrees currentTree={tree} locale={locale} />
             </div>
@@ -619,6 +626,95 @@ function RelatedTrees({
                 <p className="text-xs text-muted-foreground italic truncate">
                   {tree.scientificName}
                 </p>
+              </div>
+            </Link>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function ComparisonLinks({
+  currentTree,
+  locale,
+}: {
+  currentTree: (typeof allTrees)[0];
+  locale: string;
+}) {
+  // Find comparisons that include this tree
+  const relevantComparisons = allSpeciesComparisons.filter(
+    (comp) => comp.locale === locale && comp.species.includes(currentTree.slug)
+  );
+
+  if (relevantComparisons.length === 0) return null;
+
+  return (
+    <div className="mt-12 pt-8 border-t border-border no-print">
+      <h2 className="text-xl font-semibold mb-6 text-primary-dark dark:text-primary-light">
+        {locale === "es" ? "Guías de Comparación" : "Comparison Guides"}
+      </h2>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {relevantComparisons.map((comparison) => {
+          // Get the other species in the comparison
+          const otherSpeciesSlugs = comparison.species.filter(
+            (slug) => slug !== currentTree.slug
+          );
+          const otherSpecies = otherSpeciesSlugs
+            .map((slug) =>
+              allTrees.find((t) => t.slug === slug && t.locale === locale)
+            )
+            .filter(Boolean);
+
+          return (
+            <Link
+              key={comparison._id}
+              href={`/compare/${comparison.slug}`}
+              className="group bg-card rounded-lg border border-border p-4 hover:border-primary/50 hover:shadow-lg transition-all"
+            >
+              <div className="flex items-start gap-3">
+                <div className="flex-shrink-0 w-10 h-10 rounded-full bg-primary/10 flex items-center justify-center">
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    className="h-5 w-5 text-primary"
+                  >
+                    <path d="M18 21a8 8 0 0 0-16 0" />
+                    <circle cx="10" cy="8" r="5" />
+                    <path d="M22 21a8 8 0 0 0-16 0" />
+                    <circle cx="18" cy="8" r="5" />
+                  </svg>
+                </div>
+                <div className="flex-1 min-w-0">
+                  <h3 className="font-semibold text-foreground group-hover:text-primary transition-colors mb-1 text-sm">
+                    {locale === "es" ? "Comparar con" : "Compare with"}{" "}
+                    {otherSpecies.map((t) => t!.title).join(", ")}
+                  </h3>
+                  <p className="text-xs text-muted-foreground line-clamp-2">
+                    {comparison.keyDifference}
+                  </p>
+                  <div className="mt-2 text-xs text-primary font-medium flex items-center gap-1">
+                    {locale === "es" ? "Leer guía" : "Read guide"}
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      className="h-3 w-3"
+                    >
+                      <path d="M5 12h14" />
+                      <path d="m12 5 7 7-7 7" />
+                    </svg>
+                  </div>
+                </div>
               </div>
             </Link>
           );


### PR DESCRIPTION
Expose comparison guide content (16 articles) that was previously hidden from users.

Changes:
- Compare page: Added guides section above interactive tool
- Created /compare/{slug} detail pages for each guide
- Added Comparison Guides links to tree detail pages
- Updated EN/ES translations

All builds pass, 1090 pages generated successfully.

## Summary by Sourcery

Expose species comparison guide content and detail pages in the compare flow and tree detail views.

New Features:
- Add comparison guides section to the main compare page, listing species comparison articles for the selected locale.
- Introduce comparison detail pages at /compare/{slug} with full MDX content, key differences, metadata, and navigation.
- Surface relevant comparison guide links on individual tree pages to help users compare the current species with similar ones.

Enhancements:
- Improve compare page layout by separating and labeling the guides section and the interactive comparison tool.
- Update localized copy and labels for comparison-related UI elements in English and Spanish.