### PR TITLE
feat: Complete comparison migration with frontmatter and components

### DIFF
--- a/content/comparisons/en/cocobolo-vs-cristobal.mdx
+++ b/content/comparisons/en/cocobolo-vs-cristobal.mdx
@@ -5,6 +5,13 @@ slug: "cocobolo-vs-cristobal"
 species: ["cocobolo", "cristobal"]
 keyDifference: "Cocobolo is critically endangered small tree (15-25 m) with orange-red heartwood and CITES protection, while Cristóbal is near-threatened canopy tree (25-40 m) with purple heartwood and wider distribution—both valuable but fundamentally different conservation and size profiles."
 description: "Compare Cocobolo and Cristóbal premium rosewood species in Costa Rica, understanding their critical differences in size, wood color, conservation status, and identification features."
+featuredImages:
+  - "/images/trees/cocobolo.jpg"
+  - "/images/trees/cristobal.jpg"
+confusionRating: 2
+comparisonTags: ["size", "trunk", "bark", "leaves", "habitat"]
+seasonalNote: "Best distinguished by tree size and trunk form year-round; wood color diagnostic when cut"
+difficulty: "easy"
 publishedAt: "2026-01-12"
 ---
 
@@ -19,6 +26,58 @@ Costa Rica's dry forests host two of Central America's most valuable timber spec
   threatened and faces international trade restrictions. Never harvest without
   proper permits.
 </Callout>
+
+<SideBySideImages
+  leftImage="/images/trees/cocobolo.jpg"
+  rightImage="/images/trees/cristobal.jpg"
+  leftLabel="Cocobolo"
+  rightLabel="Cristóbal"
+  caption="Small gnarly tree vs tall straight canopy tree"
+/>
+
+<QuickDecisionFlow
+  steps={[
+    {
+      question: "What is the tree size?",
+      options: [
+        {
+          answer: "Small tree, 15-25 m tall, short irregular trunk",
+          result: "Likely Cocobolo",
+        },
+        {
+          answer: "Large tree, 25-40 m tall, tall straight trunk",
+          result: "Likely Cristóbal",
+        },
+      ],
+    },
+    {
+      question: "Check the bark and trunk form",
+      options: [
+        {
+          answer: "Rough, deeply fissured bark; often multi-stemmed",
+          result: "Cocobolo",
+        },
+        {
+          answer: "Smooth to slightly fissured bark; single straight trunk",
+          result: "Cristóbal",
+        },
+      ],
+    },
+    {
+      question: "If you have cut wood, what is the heartwood color?",
+      options: [
+        {
+          answer: "Orange-red to deep red with black marbling, very oily",
+          result: "Definitely Cocobolo",
+        },
+        {
+          answer: "Purple-brown to dark reddish-brown, less oily",
+          result: "Definitely Cristóbal",
+        },
+      ],
+    },
+  ]}
+/>
 
 ---
 

--- a/content/comparisons/en/corteza-amarilla-vs-roble-de-sabana.mdx
+++ b/content/comparisons/en/corteza-amarilla-vs-roble-de-sabana.mdx
@@ -5,6 +5,13 @@ slug: "corteza-amarilla-vs-roble-de-sabana"
 species: ["corteza-amarilla", "roble-de-sabana"]
 keyDifference: "Corteza Amarilla explodes in brilliant golden-yellow flowers, while Roble de Sabana blooms in delicate pink - both deciduous Bignoniaceae trees flowering in dry season."
 description: "Learn to distinguish between Handroanthus ochraceus (Corteza Amarilla) and Tabebuia rosea (Roble de Sabana), two spectacular flowering trees that paint Costa Rica's dry season landscapes."
+featuredImages:
+  - "/images/trees/corteza-amarilla.jpg"
+  - "/images/trees/roble-de-sabana.jpg"
+confusionRating: 1
+comparisonTags: ["flowers", "bark", "size", "habitat"]
+seasonalNote: "Most easily distinguished during flowering season (Mar-May) when flower color is unmistakable"
+difficulty: "easy"
 publishedAt: "2026-01-12"
 ---
 
@@ -17,6 +24,45 @@ Both Corteza Amarilla and Roble de Sabana are beloved Bignoniaceae trees that tr
   **Corteza Amarilla**. Delicate pink to lavender flowers? That's **Roble de
   Sabana**.
 </Callout>
+
+<SideBySideImages
+  leftImage="/images/trees/corteza-amarilla.jpg"
+  rightImage="/images/trees/roble-de-sabana.jpg"
+  leftLabel="Corteza Amarilla"
+  rightLabel="Roble de Sabana"
+  caption="Golden-yellow flowers vs pink flowers"
+/>
+
+<QuickDecisionFlow
+  steps={[
+    {
+      question: "What color are the flowers?",
+      options: [
+        {
+          answer: "Brilliant golden-yellow, vivid and bright",
+          result: "Corteza Amarilla",
+        },
+        {
+          answer: "Pink to lavender, delicate and soft",
+          result: "Roble de Sabana",
+        },
+      ],
+    },
+    {
+      question: "Check the bark color",
+      options: [
+        {
+          answer: "Yellowish-brown to gray, with yellow inner bark",
+          result: "Corteza Amarilla",
+        },
+        {
+          answer: "Dark gray to brown, gray-brown throughout",
+          result: "Roble de Sabana",
+        },
+      ],
+    },
+  ]}
+/>
 
 ---
 

--- a/content/comparisons/en/coyol-vs-pejibaye.mdx
+++ b/content/comparisons/en/coyol-vs-pejibaye.mdx
@@ -5,6 +5,13 @@ slug: "coyol-vs-pejibaye"
 species: ["coyol", "pejibaye"]
 keyDifference: "Coyol has wickedly long trunk spines (up to 20cm) and hard-shelled fruits, while Pejibaye forms clumps of multiple stems with softer flesh fruits."
 description: "Learn to distinguish between Acrocomia aculeata (Coyol) and Bactris gasipaes (Pejibaye), two spiny palms with culturally important edible fruits."
+featuredImages:
+  - "/images/trees/coyol.jpg"
+  - "/images/trees/pejibaye.jpg"
+confusionRating: 2
+comparisonTags: ["trunk", "fruit", "size", "habitat"]
+seasonalNote: "Growth form visible year-round; fruiting season differs (Coyol: Dec-May; Pejibaye: Sep-Feb)"
+difficulty: "easy"
 publishedAt: "2026-01-12"
 ---
 
@@ -17,6 +24,55 @@ Both Coyol and Pejibaye are armed palms with fearsome spines and delicious edibl
   it's **Pejibaye**. Single trunk with extremely long spines (8-20 cm)? That's
   **Coyol**.
 </Callout>
+
+<SideBySideImages
+  leftImage="/images/trees/coyol.jpg"
+  rightImage="/images/trees/pejibaye.jpg"
+  leftLabel="Coyol"
+  rightLabel="Pejibaye"
+  caption="Single trunk with long spines vs clumping stems"
+/>
+
+<QuickDecisionFlow
+  steps={[
+    {
+      question: "How many stems does the palm have?",
+      options: [
+        { answer: "Single trunk, solitary palm", result: "Likely Coyol" },
+        {
+          answer: "Multiple stems (10-30) clustered together",
+          result: "Likely Pejibaye",
+        },
+      ],
+    },
+    {
+      question: "Examine the spines on the trunk",
+      options: [
+        {
+          answer: "Extremely long spines (8-20 cm), scattered on trunk",
+          result: "Coyol",
+        },
+        {
+          answer: "Dense rings of spines (5-15 cm) every 5-20 cm",
+          result: "Pejibaye",
+        },
+      ],
+    },
+    {
+      question: "If fruits are present, what do they look like?",
+      options: [
+        {
+          answer: "Round, 2-5 cm, very hard shell (like mini coconut)",
+          result: "Definitely Coyol",
+        },
+        {
+          answer: "Oval, 4-6 cm, orange-red, no hard shell",
+          result: "Definitely Pejibaye",
+        },
+      ],
+    },
+  ]}
+/>
 
 ---
 

--- a/content/comparisons/en/higueron-vs-matapalo.mdx
+++ b/content/comparisons/en/higueron-vs-matapalo.mdx
@@ -5,6 +5,13 @@ slug: "higueron-vs-matapalo"
 species: ["higueron", "matapalo"]
 keyDifference: "Higuerón (Ficus insipida) is a single species with specific characteristics, while Matapalo refers to multiple Ficus species (F. obtusifolia, F. pertusa, etc.) that share the strangling growth habit."
 description: "Learn to distinguish between Higuerón (Ficus insipida) and other Matapalo strangler figs in Costa Rica, understanding their ecology and identifying features."
+featuredImages:
+  - "/images/trees/higueron.jpg"
+  - "/images/trees/matapalo.jpg"
+confusionRating: 4
+comparisonTags: ["trunk", "roots", "fruit", "habitat"]
+seasonalNote: "Strangling pattern visible year-round; figs produced continuously but timing varies"
+difficulty: "challenging"
 publishedAt: "2026-01-12"
 ---
 
@@ -18,6 +25,45 @@ Costa Rica's strangler figs are among the most ecologically important and visual
   species that grow as stranglers, including F. obtusifolia, F. pertusa, F.
   citrifolia, and others. All are strangler figs, but not all are Higuerón!
 </Callout>
+
+<SideBySideImages
+  leftImage="/images/trees/higueron.jpg"
+  rightImage="/images/trees/matapalo.jpg"
+  leftLabel="Higuerón"
+  rightLabel="Matapalo"
+  caption="Specific species vs general strangler fig term"
+/>
+
+<QuickDecisionFlow
+  steps={[
+    {
+      question: "How did the tree start growing?",
+      options: [
+        {
+          answer: "Often from ground up, massive buttress roots",
+          result: "Likely Higuerón (F. insipida)",
+        },
+        {
+          answer: "Started in canopy, hollow lattice trunk from strangling",
+          result: "Likely Matapalo (various Ficus spp.)",
+        },
+      ],
+    },
+    {
+      question: "Examine the figs (fruits)",
+      options: [
+        {
+          answer: "Small (1-1.5 cm), yellowish-green, prolific",
+          result: "Higuerón",
+        },
+        {
+          answer: "Varies: 0.8-2 cm, can be red, purple, or black when ripe",
+          result: "Matapalo (species varies)",
+        },
+      ],
+    },
+  ]}
+/>
 
 ---
 

--- a/content/comparisons/en/ojoche-vs-javillo.mdx
+++ b/content/comparisons/en/ojoche-vs-javillo.mdx
@@ -5,6 +5,13 @@ slug: "ojoche-vs-javillo"
 species: ["ojoche", "javillo"]
 keyDifference: "Ojoche is exceptionally safe with edible seeds, while Javillo is one of the most dangerous trees in the Americas with caustic sap and explosive pods."
 description: "Learn to distinguish between Brosimum alicastrum (safe superfood) and Hura crepitans (highly toxic danger tree)—two tall rainforest trees with opposite safety profiles."
+featuredImages:
+  - "/images/trees/ojoche.jpg"
+  - "/images/trees/javillo.jpg"
+confusionRating: 1
+comparisonTags: ["trunk", "fruit", "size", "habitat"]
+seasonalNote: "Trunk spines visible year-round; CRITICAL SAFETY distinction at all times"
+difficulty: "easy"
 publishedAt: "2026-01-12"
 ---
 
@@ -17,6 +24,45 @@ Two tall rainforest giants that share similar habitats and heights, but represen
   = EXTREMELY DANGEROUS (toxic sap, explosive pods, fatal seeds) This is perhaps
   the most important tree ID you can learn in Costa Rica.
 </Callout>
+
+<SideBySideImages
+  leftImage="/images/trees/ojoche.jpg"
+  rightImage="/images/trees/javillo.jpg"
+  leftLabel="Ojoche (SAFE)"
+  rightLabel="Javillo (DANGER)"
+  caption="Smooth safe trunk vs spine-covered dangerous trunk"
+/>
+
+<QuickDecisionFlow
+  steps={[
+    {
+      question: "Does the trunk have spines?",
+      options: [
+        {
+          answer: "NO SPINES - smooth light gray bark, safe to touch",
+          result: "Ojoche (SAFE - edible seeds)",
+        },
+        {
+          answer: "COVERED IN SHARP CONICAL SPINES (1-5cm)",
+          result: "Javillo (DANGER - stay away!)",
+        },
+      ],
+    },
+    {
+      question: "What type of fruits/seeds do you see?",
+      options: [
+        {
+          answer: "Small round fleshy fruits (1-2 cm), nutritious brown seeds",
+          result: "Definitely Ojoche (safe superfood)",
+        },
+        {
+          answer: "Large pumpkin-shaped capsules (8-15 cm) - EXPLOSIVE",
+          result: "Definitely Javillo (EXTREME DANGER)",
+        },
+      ],
+    },
+  ]}
+/>
 
 ---
 

--- a/content/comparisons/en/zapote-vs-nispero.mdx
+++ b/content/comparisons/en/zapote-vs-nispero.mdx
@@ -5,6 +5,13 @@ slug: "zapote-vs-nispero"
 species: ["zapote", "nispero"]
 keyDifference: "Zapote (Mamey Sapote) has large salmon-pink flesh with sweet potato notes and smooth brown skin, while Níspero (Sapodilla) has smaller brown caramel-sweet flesh with rough sandpaper-like skin—both delicious but distinctly different eating experiences."
 description: "Compare Zapote (Mamey Sapote) and Níspero (Sapodilla) fruit trees in Costa Rica, understanding their flavors, growing requirements, harvest times, and which fits your garden."
+featuredImages:
+  - "/images/trees/zapote.jpg"
+  - "/images/trees/nispero.jpg"
+confusionRating: 2
+comparisonTags: ["fruit", "size", "bark", "leaves"]
+seasonalNote: "Different fruiting seasons - Zapote (Nov-Feb) vs Níspero (Feb-Apr); both edible when ripe"
+difficulty: "easy"
 publishedAt: "2026-01-12"
 ---
 
@@ -20,6 +27,52 @@ Two of Costa Rica's most beloved native fruit trees belong to the same botanical
   fruit). **Níspero** (Sapodilla) is sometimes confused with **Níspero Japonés**
   (Loquat, _Eriobotrya japonica_)—completely different families!
 </Callout>
+
+<SideBySideImages
+  leftImage="/images/trees/zapote.jpg"
+  rightImage="/images/trees/nispero.jpg"
+  leftLabel="Zapote (Mamey Sapote)"
+  rightLabel="Níspero (Sapodilla)"
+  caption="Large pink-fleshed fruit vs small caramel-sweet fruit"
+/>
+
+<QuickDecisionFlow
+  steps={[
+    {
+      question: "What size and color is the fruit flesh?",
+      options: [
+        {
+          answer: "Large fruit (10-25 cm), salmon-pink to reddish flesh",
+          result: "Zapote (Mamey Sapote)",
+        },
+        {
+          answer: "Small fruit (5-10 cm), yellowish-brown flesh",
+          result: "Níspero (Sapodilla)",
+        },
+      ],
+    },
+    {
+      question: "Check the fruit skin texture",
+      options: [
+        { answer: "Brown, smooth to slightly rough", result: "Zapote" },
+        {
+          answer: "Russet-brown, VERY rough sandpaper texture",
+          result: "Níspero",
+        },
+      ],
+    },
+    {
+      question: "Cut the fruit stem - how much latex flows?",
+      options: [
+        { answer: "Minimal white latex", result: "Definitely Zapote" },
+        {
+          answer: "ABUNDANT sticky white latex (chicle!)",
+          result: "Definitely Níspero",
+        },
+      ],
+    },
+  ]}
+/>
 
 ---
 

--- a/content/comparisons/es/almendro-vs-gavilan.mdx
+++ b/content/comparisons/es/almendro-vs-gavilan.mdx
@@ -10,7 +10,7 @@ featuredImages:
   - "/images/trees/gavilan.jpg"
 confusionRating: 3
 comparisonTags: ["leaves", "fruit", "size", "habitat", "trunk"]
-seasonalNote: "Frutos ayudan dic-mar (almendro) vs vainas explosivas en estación seca (gavilán); tipo de hoja funciona todo el año."
+seasonalNote: "Los frutos ayudan a identificarlo dic-mar (almendro) vs vainas explosivas en estación seca (gavilán); el tipo de hoja funciona todo el año."
 difficulty: "moderate"
 publishedAt: "2026-01-18"
 ---

--- a/content/comparisons/es/almendro-vs-gavilan.mdx
+++ b/content/comparisons/es/almendro-vs-gavilan.mdx
@@ -5,6 +5,13 @@ slug: "almendro-vs-gavilan"
 species: ["almendro", "gavilan"]
 keyDifference: "El Almendro tiene hojas pinnadas y drupas de una sola semilla, se eleva 40-60m con importancia crítica para la Lapa Verde. El Gavilán tiene hojas bipinnadas y vainas masivas explosivas, domina bosques del Caribe mediante fijación de nitrógeno."
 description: "Aprenda a distinguir Dipteryx panamensis (Almendro) de Pentaclethra macroloba (Gavilán), dos grandes leguminosas de dosel con diferentes roles ecológicos en los bosques lluviosos de tierras bajas de Costa Rica."
+featuredImages:
+  - "/images/trees/almendro.jpg"
+  - "/images/trees/gavilan.jpg"
+confusionRating: 3
+comparisonTags: ["leaves", "fruit", "size", "habitat", "trunk"]
+seasonalNote: "Frutos ayudan dic-mar (almendro) vs vainas explosivas en estación seca (gavilán); tipo de hoja funciona todo el año."
+difficulty: "moderate"
 publishedAt: "2026-01-18"
 ---
 
@@ -18,6 +25,36 @@ Tanto el Almendro como el Gavilán son impresionantes árboles leguminosos que d
   (25-35m), hojas doblemente pinnadas (plumosas), vainas planas explosivas
   enormes (25-50cm), fija nitrógeno, a menudo dominante.
 </Callout>
+
+<SideBySideImages
+  leftImage="/images/trees/almendro.jpg"
+  rightImage="/images/trees/gavilan.jpg"
+  leftLabel="Almendro"
+  rightLabel="Gavilán"
+  caption="Hojas pinnadas una vez vs follaje bipinnado plumoso"
+/>
+
+<QuickDecisionFlow
+  steps={[
+    {
+      question: "¿Las hojas son doblemente pinnadas y plumosas?",
+      options: [
+        { answer: "Muchos folíolos diminutos", result: "Gavilán" },
+        { answer: "5-9 folíolos grandes", result: "Almendro" },
+      ],
+    },
+    {
+      question: "¿Ve vainas planas enormes?",
+      options: [
+        { answer: "Vainas explosivas de 25-50 cm", result: "Gavilán" },
+        {
+          answer: "Drupas individuales con aroma a vainilla",
+          result: "Almendro",
+        },
+      ],
+    },
+  ]}
+/>
 
 ---
 

--- a/content/comparisons/es/cocobolo-vs-cristobal.mdx
+++ b/content/comparisons/es/cocobolo-vs-cristobal.mdx
@@ -5,6 +5,13 @@ slug: "cocobolo-vs-cristobal"
 species: ["cocobolo", "cristobal"]
 keyDifference: "El Cocobolo es un árbol pequeño críticamente amenazado (15-25 m) con duramen rojo-naranja y protección CITES, mientras que el Cristóbal es un árbol de dosel casi amenazado (25-40 m) con duramen púrpura y distribución más amplia—ambos valiosos pero con perfiles fundamentalmente diferentes de conservación y tamaño."
 description: "Compare las especies de palo de rosa premium Cocobolo y Cristóbal en Costa Rica, comprendiendo sus diferencias críticas en tamaño, color de madera, estado de conservación y características de identificación."
+featuredImages:
+  - "/images/trees/cocobolo.jpg"
+  - "/images/trees/cristobal.jpg"
+confusionRating: 2
+comparisonTags: ["size", "trunk", "bark", "leaves", "habitat"]
+seasonalNote: "Mejor distinguido por tamaño de árbol y forma de tronco durante todo el año; color de madera diagnóstico cuando está cortado"
+difficulty: "easy"
 publishedAt: "2026-01-12"
 ---
 
@@ -19,6 +26,60 @@ Los bosques secos de Costa Rica albergan dos de las especies maderables más val
   mucho más amenazado y enfrenta restricciones comerciales internacionales.
   Nunca coseche sin los permisos adecuados.
 </Callout>
+
+<SideBySideImages
+  leftImage="/images/trees/cocobolo.jpg"
+  rightImage="/images/trees/cristobal.jpg"
+  leftLabel="Cocobolo"
+  rightLabel="Cristóbal"
+  caption="Árbol pequeño y nudoso vs árbol alto de dosel recto"
+/>
+
+<QuickDecisionFlow
+  steps={[
+    {
+      question: "¿Cuál es el tamaño del árbol?",
+      options: [
+        {
+          answer: "Árbol pequeño, 15-25 m de altura, tronco corto irregular",
+          result: "Probablemente Cocobolo",
+        },
+        {
+          answer: "Árbol grande, 25-40 m de altura, tronco alto y recto",
+          result: "Probablemente Cristóbal",
+        },
+      ],
+    },
+    {
+      question: "Revise la corteza y forma del tronco",
+      options: [
+        {
+          answer:
+            "Corteza áspera, profundamente fisurada; a menudo multi-tallos",
+          result: "Cocobolo",
+        },
+        {
+          answer: "Corteza lisa a ligeramente fisurada; tronco recto único",
+          result: "Cristóbal",
+        },
+      ],
+    },
+    {
+      question: "Si tiene madera cortada, ¿cuál es el color del duramen?",
+      options: [
+        {
+          answer:
+            "Naranja-rojo a rojo profundo con marmoleado negro, muy aceitoso",
+          result: "Definitivamente Cocobolo",
+        },
+        {
+          answer: "Púrpura-marrón a marrón rojizo oscuro, menos aceitoso",
+          result: "Definitivamente Cristóbal",
+        },
+      ],
+    },
+  ]}
+/>
 
 ---
 

--- a/content/comparisons/es/corteza-amarilla-vs-roble-de-sabana.mdx
+++ b/content/comparisons/es/corteza-amarilla-vs-roble-de-sabana.mdx
@@ -5,6 +5,13 @@ slug: "corteza-amarilla-vs-roble-de-sabana"
 species: ["corteza-amarilla", "roble-de-sabana"]
 keyDifference: "La Corteza Amarilla explota en flores amarillo-doradas brillantes, mientras que el Roble de Sabana florece en rosa delicado - ambos árboles deciduos Bignoniaceae que florecen en estación seca."
 description: "Aprenda a distinguir entre Handroanthus ochraceus (Corteza Amarilla) y Tabebuia rosea (Roble de Sabana), dos árboles florales espectaculares que pintan los paisajes de Costa Rica durante la estación seca."
+featuredImages:
+  - "/images/trees/corteza-amarilla.jpg"
+  - "/images/trees/roble-de-sabana.jpg"
+confusionRating: 1
+comparisonTags: ["flowers", "bark", "size", "habitat"]
+seasonalNote: "Más fácil de distinguir durante la temporada de floración (mar-may) cuando el color de las flores es inconfundible"
+difficulty: "easy"
 publishedAt: "2026-01-12"
 ---
 
@@ -17,6 +24,45 @@ Tanto la Corteza Amarilla como el Roble de Sabana son amados árboles Bignoniace
   **Corteza Amarilla**. ¿Flores rosadas a lavanda delicadas? Es **Roble de
   Sabana**.
 </Callout>
+
+<SideBySideImages
+  leftImage="/images/trees/corteza-amarilla.jpg"
+  rightImage="/images/trees/roble-de-sabana.jpg"
+  leftLabel="Corteza Amarilla"
+  rightLabel="Roble de Sabana"
+  caption="Flores amarillo-doradas vs flores rosadas"
+/>
+
+<QuickDecisionFlow
+  steps={[
+    {
+      question: "¿De qué color son las flores?",
+      options: [
+        {
+          answer: "Amarillo-dorado brillante, vívido y luminoso",
+          result: "Corteza Amarilla",
+        },
+        {
+          answer: "Rosa a lavanda, delicadas y suaves",
+          result: "Roble de Sabana",
+        },
+      ],
+    },
+    {
+      question: "Revise el color de la corteza",
+      options: [
+        {
+          answer: "Amarillo-marrón a gris, con corteza interna amarilla",
+          result: "Corteza Amarilla",
+        },
+        {
+          answer: "Gris oscuro a marrón, gris-marrón en todo",
+          result: "Roble de Sabana",
+        },
+      ],
+    },
+  ]}
+/>
 
 ---
 

--- a/content/comparisons/es/coyol-vs-pejibaye.mdx
+++ b/content/comparisons/es/coyol-vs-pejibaye.mdx
@@ -5,6 +5,13 @@ slug: "coyol-vs-pejibaye"
 species: ["coyol", "pejibaye"]
 keyDifference: "El Coyol tiene espinas larguísimas en el tronco (hasta 20 cm) y frutos de cáscara dura, mientras que el Pejibaye forma grupos de múltiples tallos con frutos de pulpa suave."
 description: "Aprenda a distinguir entre Acrocomia aculeata (Coyol) y Bactris gasipaes (Pejibaye), dos palmas espinosas con frutos comestibles culturalmente importantes."
+featuredImages:
+  - "/images/trees/coyol.jpg"
+  - "/images/trees/pejibaye.jpg"
+confusionRating: 2
+comparisonTags: ["trunk", "fruit", "size", "habitat"]
+seasonalNote: "Forma de crecimiento visible todo el año; temporada de fructificación difiere (Coyol: dic-may; Pejibaye: sep-feb)"
+difficulty: "easy"
 publishedAt: "2026-01-12"
 ---
 
@@ -17,6 +24,59 @@ Tanto el Coyol como el Pejibaye son palmas armadas con espinas temibles y frutos
   **Pejibaye**. ¿Tronco único con espinas extremadamente largas (8-20 cm)? Es
   **Coyol**.
 </Callout>
+
+<SideBySideImages
+  leftImage="/images/trees/coyol.jpg"
+  rightImage="/images/trees/pejibaye.jpg"
+  leftLabel="Coyol"
+  rightLabel="Pejibaye"
+  caption="Tronco único con espinas largas vs tallos agrupados"
+/>
+
+<QuickDecisionFlow
+  steps={[
+    {
+      question: "¿Cuántos tallos tiene la palma?",
+      options: [
+        {
+          answer: "Tronco único, palma solitaria",
+          result: "Probablemente Coyol",
+        },
+        {
+          answer: "Múltiples tallos (10-30) agrupados",
+          result: "Probablemente Pejibaye",
+        },
+      ],
+    },
+    {
+      question: "Examine las espinas en el tronco",
+      options: [
+        {
+          answer:
+            "Espinas extremadamente largas (8-20 cm), dispersas en el tronco",
+          result: "Coyol",
+        },
+        {
+          answer: "Anillos densos de espinas (5-15 cm) cada 5-20 cm",
+          result: "Pejibaye",
+        },
+      ],
+    },
+    {
+      question: "Si hay frutos presentes, ¿cómo se ven?",
+      options: [
+        {
+          answer: "Redondos, 2-5 cm, cáscara muy dura (como coco pequeño)",
+          result: "Definitivamente Coyol",
+        },
+        {
+          answer: "Ovalados, 4-6 cm, naranja-rojo, sin cáscara dura",
+          result: "Definitivamente Pejibaye",
+        },
+      ],
+    },
+  ]}
+/>
 
 ---
 

--- a/content/comparisons/es/higueron-vs-matapalo.mdx
+++ b/content/comparisons/es/higueron-vs-matapalo.mdx
@@ -5,6 +5,13 @@ slug: "higueron-vs-matapalo"
 species: ["higueron", "matapalo"]
 keyDifference: "Higuerón (Ficus insipida) es una especie única con características específicas, mientras que Matapalo se refiere a múltiples especies de Ficus (F. obtusifolia, F. pertusa, etc.) que comparten el hábito de crecimiento estrangulador."
 description: "Aprenda a distinguir entre Higuerón (Ficus insipida) y otros Matapalos estranguladores en Costa Rica, comprendiendo su ecología y características identificadoras."
+featuredImages:
+  - "/images/trees/higueron.jpg"
+  - "/images/trees/matapalo.jpg"
+confusionRating: 4
+comparisonTags: ["trunk", "roots", "fruit", "habitat"]
+seasonalNote: "Patrón estrangulador visible todo el año; higos producidos continuamente pero el tiempo varía"
+difficulty: "challenging"
 publishedAt: "2026-01-12"
 ---
 
@@ -19,6 +26,47 @@ Los higos estranguladores de Costa Rica están entre los árboles más important
   obtusifolia, F. pertusa, F. citrifolia, y otros. ¡Todos son higos
   estranguladores, pero no todos son Higuerón!
 </Callout>
+
+<SideBySideImages
+  leftImage="/images/trees/higueron.jpg"
+  rightImage="/images/trees/matapalo.jpg"
+  leftLabel="Higuerón"
+  rightLabel="Matapalo"
+  caption="Especie específica vs término general de higo estrangulador"
+/>
+
+<QuickDecisionFlow
+  steps={[
+    {
+      question: "¿Cómo comenzó a crecer el árbol?",
+      options: [
+        {
+          answer: "A menudo desde el suelo, grandes raíces tablares",
+          result: "Probablemente Higuerón (F. insipida)",
+        },
+        {
+          answer:
+            "Comenzó en el dosel, tronco enrejado hueco por estrangulamiento",
+          result: "Probablemente Matapalo (varias spp. Ficus)",
+        },
+      ],
+    },
+    {
+      question: "Examine los higos (frutos)",
+      options: [
+        {
+          answer: "Pequeños (1-1.5 cm), verde-amarillento, prolífico",
+          result: "Higuerón",
+        },
+        {
+          answer:
+            "Varía: 0.8-2 cm, puede ser rojo, púrpura, o negro cuando maduro",
+          result: "Matapalo (especie varía)",
+        },
+      ],
+    },
+  ]}
+/>
 
 ---
 

--- a/content/comparisons/es/ojoche-vs-javillo.mdx
+++ b/content/comparisons/es/ojoche-vs-javillo.mdx
@@ -5,6 +5,13 @@ slug: "ojoche-vs-javillo"
 species: ["ojoche", "javillo"]
 keyDifference: "El Ojoche es excepcionalmente seguro con semillas comestibles, mientras que el Javillo es uno de los árboles más peligrosos de las Américas con savia cáustica y cápsulas explosivas."
 description: "Aprenda a distinguir entre Brosimum alicastrum (superalimento seguro) y Hura crepitans (árbol de peligro altamente tóxico)—dos árboles altos de bosque lluvioso con perfiles de seguridad opuestos."
+featuredImages:
+  - "/images/trees/ojoche.jpg"
+  - "/images/trees/javillo.jpg"
+confusionRating: 1
+comparisonTags: ["trunk", "fruit", "size", "habitat"]
+seasonalNote: "Espinas del tronco visibles todo el año; distinción de SEGURIDAD CRÍTICA en todo momento"
+difficulty: "easy"
 publishedAt: "2026-01-12"
 ---
 
@@ -18,6 +25,47 @@ Dos gigantes del bosque lluvioso que comparten hábitats y alturas similares, pe
   explosivas, semillas fatales) Esta es quizás la identificación de árboles más
   importante que puede aprender en Costa Rica.
 </Callout>
+
+<SideBySideImages
+  leftImage="/images/trees/ojoche.jpg"
+  rightImage="/images/trees/javillo.jpg"
+  leftLabel="Ojoche (SEGURO)"
+  rightLabel="Javillo (PELIGRO)"
+  caption="Tronco liso y seguro vs tronco cubierto de espinas peligrosas"
+/>
+
+<QuickDecisionFlow
+  steps={[
+    {
+      question: "¿El tronco tiene espinas?",
+      options: [
+        {
+          answer: "SIN ESPINAS - corteza lisa gris claro, seguro al tacto",
+          result: "Ojoche (SEGURO - semillas comestibles)",
+        },
+        {
+          answer: "CUBIERTO DE ESPINAS CÓNICAS AFILADAS (1-5cm)",
+          result: "Javillo (¡PELIGRO - manténgase alejado!)",
+        },
+      ],
+    },
+    {
+      question: "¿Qué tipo de frutos/semillas ve?",
+      options: [
+        {
+          answer:
+            "Pequeños frutos carnosos redondos (1-2 cm), semillas marrones nutritivas",
+          result: "Definitivamente Ojoche (superalimento seguro)",
+        },
+        {
+          answer:
+            "Grandes cápsulas con forma de calabaza (8-15 cm) - EXPLOSIVAS",
+          result: "Definitivamente Javillo (PELIGRO EXTREMO)",
+        },
+      ],
+    },
+  ]}
+/>
 
 ---
 

--- a/content/comparisons/es/zapote-vs-nispero.mdx
+++ b/content/comparisons/es/zapote-vs-nispero.mdx
@@ -5,6 +5,13 @@ slug: "zapote-vs-nispero"
 species: ["zapote", "nispero"]
 keyDifference: "El Zapote (Mamey Sapote) tiene carne grande rosa-salmón con notas de camote y piel café lisa, mientras que el Níspero (Sapodilla) tiene carne café más pequeña dulce-caramelo con piel áspera como lija—ambos deliciosos pero experiencias de consumo distintamente diferentes."
 description: "Compare árboles frutales Zapote (Mamey Sapote) y Níspero (Sapodilla) en Costa Rica, entendiendo sus sabores, requisitos de cultivo, tiempos de cosecha, y cuál se adapta a su jardín."
+featuredImages:
+  - "/images/trees/zapote.jpg"
+  - "/images/trees/nispero.jpg"
+confusionRating: 2
+comparisonTags: ["fruit", "size", "bark", "leaves"]
+seasonalNote: "Temporadas de fructificación diferentes - Zapote (nov-feb) vs Níspero (feb-abr); ambos comestibles cuando maduros"
+difficulty: "easy"
 publishedAt: "2026-01-12"
 ---
 
@@ -12,9 +19,64 @@ publishedAt: "2026-01-12"
 
 Dos de los árboles frutales nativos más queridos de Costa Rica pertenecen a la misma familia botánica (Sapotaceae) y comparten condiciones de cultivo similares, pero sus frutas ofrecen experiencias de sabor completamente diferentes. El **Zapote** (_Pouteria sapota_), conocido internacionalmente como Mamey Sapote, produce frutas grandes con carne impresionante rosa-salmón. El **Níspero** (_Manilkara zapota_), la Sapodilla o Árbol de Chicle, produce frutas cafés más pequeñas con dulzura deliciosa de caramelo. Ambos hacen batidos excepcionales, pero elegir entre ellos depende de sus preferencias de sabor, espacio y paciencia.
 
+<Callout type="info" title="¡Nombres Confusos!">
+  **ADVERTENCIA:** "¡Zapote" se refiere a múltiples árboles no relacionados en
+  América Latina! Esta guía discute **Mamey Sapote** (_Pouteria sapota_), el que
+  tiene carne rosa/roja. No confundir con Zapote Negro (Diospyros digyna, fruta
+  de pudín de chocolate) o Zapote Blanco (Casimiroa edulis, fruta como natilla).
+  **Níspero** (Sapodilla) a veces se confunde con **Níspero Japonés** (Níspero,
+  _Eriobotrya japonica_)—¡familias completamente diferentes!
+</Callout>
+
+<SideBySideImages
+  leftImage="/images/trees/zapote.jpg"
+  rightImage="/images/trees/nispero.jpg"
+  leftLabel="Zapote (Mamey Sapote)"
+  rightLabel="Níspero (Sapodilla)"
+  caption="Fruta grande de carne rosa vs fruta pequeña dulce-caramelo"
+/>
+
+<QuickDecisionFlow
+  steps={[
+    {
+      question: "¿Qué tamaño y color tiene la carne de la fruta?",
+      options: [
+        {
+          answer: "Fruta grande (10-25 cm), carne rosa-salmón a rojiza",
+          result: "Zapote (Mamey Sapote)",
+        },
+        {
+          answer: "Fruta pequeña (5-10 cm), carne amarillo-café",
+          result: "Níspero (Sapodilla)",
+        },
+      ],
+    },
+    {
+      question: "Revise la textura de la piel de la fruta",
+      options: [
+        { answer: "Café, lisa a ligeramente áspera", result: "Zapote" },
+        {
+          answer: "Café rojizo, textura MUY áspera como lija",
+          result: "Níspero",
+        },
+      ],
+    },
+    {
+      question: "Corte el tallo de la fruta - ¿cuánto látex fluye?",
+      options: [
+        { answer: "Látex blanco mínimo", result: "Definitivamente Zapote" },
+        {
+          answer: "¡Látex blanco pegajoso ABUNDANTE (chicle)!",
+          result: "Definitivamente Níspero",
+        },
+      ],
+    },
+  ]}
+/>
+
 Para la comparación completa detallada con tablas, pros/contras, y guías de cultivo, consulte la [versión en inglés](/en/compare/zapote-vs-nispero).
 
-## Características Principales
+---
 
 ### Tamaño y Apariencia de Fruta
 


### PR DESCRIPTION
Completes comparison guide migration by adding required frontmatter fields (featuredImages, confusionRating, comparisonTags, seasonalNote, difficulty) and interactive components (SideBySideImages, QuickDecisionFlow) to all remaining comparison guides. Updates both English and Spanish versions for: cocobolo-vs-cristobal, corteza-amarilla-vs-roble-de-sabana, coyol-vs-pejibaye, higueron-vs-matapalo, ojoche-vs-javillo, zapote-vs-nispero. Completes almendro-vs-gavilan Spanish version. All comparisons now follow standardized template.

## Summary by Sourcery

Standardize remaining tree comparison guides with metadata and interactive decision aids across English and Spanish content.

New Features:
- Add featuredImages, confusionRating, comparisonTags, seasonalNote, and difficulty frontmatter fields to all remaining comparison guides in English and Spanish.
- Introduce SideBySideImages visual comparison blocks and QuickDecisionFlow step-by-step identification flows to the updated guides.

Enhancements:
- Align Spanish almendro-vs-gavilan comparison with the standardized template used by other guides.