### PR TITLE
docs: Expand Comenegro EN content (108 to 761 lines)

### DIFF
--- a/content/trees/en/comenegro.mdx
+++ b/content/trees/en/comenegro.mdx
@@ -103,6 +103,659 @@ featuredImage: "/images/trees/comenegro.jpg"
   ]}
 />
 
+---
+
 ## Overview
 
-Comenegro is a remarkable tropical tree that stands out in Central American forests for its beautiful peeling bark and significant ethnobotanical history. The tree's common name "Comenegro" means "eat black" in Spanish, possibly referring to the dark outer bark, though the inner bark reveals stunning golden colors. Native peoples and later settlers discovered the bark's powerful medicinal properties - so bitter that even tiny amounts can be tasted.
+_Simarouba glauca_, commonly known as Comenegro or Paradise Tree, is a medium to large deciduous tree native to tropical regions from Mexico through Central America to northern South America and the Caribbean. In Costa Rica, it grows primarily in the lowland dry forests of Guanacaste and the Pacific slope, where it is valued for its distinctive copper-colored bark and medicinal properties.
+
+The Comenegro is immediately recognizable by its smooth, copper to golden bark that peels in irregular patches, revealing lighter-colored underbark. This characteristic makes it one of the most visually distinctive trees in Costa Rican dry forests, especially during the dry season when it drops its leaves and the bark stands out dramatically.
+
+The tree has a long history of medicinal use. Its bark, leaves, and seeds contain bitter compounds (quassinoids) that have been used for centuries by indigenous peoples and in colonial medicine to treat digestive disorders, fevers, and parasitic infections. The bitter taste is so characteristic that the tree's bark was once exported to Europe as "Simaruba bark" or "dysentery bark."
+
+Beyond its medicinal value, the Comenegro is increasingly recognized as an important species for reforestation, particularly in degraded dry forest areas. Its exceptional drought tolerance, rapid growth, and ability to thrive in poor soils make it an ideal candidate for ecological restoration and agroforestry systems.
+
+---
+
+## Taxonomy
+
+<Callout type="info" title="Scientific Classification">
+  **Family**: Simaroubaceae (Quassia family) **Genus**: _Simarouba_ — derived
+  from "simarouba," the indigenous Caribbean name for the tree **Species**:
+  _glauca_ — from Latin meaning "bluish-gray" or "whitish," referring to the
+  pale undersides of the leaves
+</Callout>
+
+### Common Names
+
+<Accordion title="Regional Names">
+  | Language/Region | Common Names | |-----------------|--------------| |
+  **Costa Rica** | Comenegro, Aceituno, Negrito | | **Mexico** | Pasak (Maya),
+  Negrito, Aceituno | | **Guatemala** | Pasak, Negrito, Jocote de Mico | |
+  **Honduras** | Negrito, Aceituno | | **Nicaragua** | Talchocote, Negrito,
+  Aceituno | | **Panama** | Aceituno, Simaruba | | **Cuba** | Palo blanco,
+  Gavilán | | **English** | Paradise Tree, Bitterwood, Dysentery Bark Tree | |
+  **Trade/Scientific** | Simaruba, Marupá |
+</Accordion>
+
+### Etymology
+
+- **Simarouba**: Derived from "simarouba" or "simaruba," the Carib indigenous name used in the Caribbean islands
+- **glauca**: Latin term meaning "sea-green," "bluish-gray," or "whitish," describing the pale, glaucous undersides of the leaves
+- **Comenegro**: Spanish name used in Costa Rica; literal meaning "eat black" — origin unclear but may relate to the dark fruits or intensely bitter (black) taste
+
+### Taxonomic Notes
+
+The genus _Simarouba_ contains approximately 6 species distributed from Florida through Central America to northern South America and the Caribbean. _S. glauca_ is the most widespread species. A closely related species, _S. amara_, occurs in wetter rainforest environments.
+
+The Simaroubaceae family (Quassia family) is known for producing intensely bitter compounds called quassinoids, which have various medicinal properties. Other notable members include _Quassia amara_ and _Ailanthus altissima_ (Tree of Heaven).
+
+---
+
+## Physical Description
+
+### Bark
+
+The bark is the most distinctive feature of the Comenegro and allows year-round identification:
+
+- **Color**: Smooth, copper to golden-bronze, sometimes with greenish or grayish tones
+- **Texture**: Thin, papery bark that peels in irregular patches, revealing lighter cream-colored underbark
+- **Pattern**: Mottled appearance from different bark ages; older areas darker, newly exposed areas lighter
+- **Inner bark**: Light colored with extremely bitter taste
+
+The smooth, peeling copper bark is diagnostic and distinguishes _S. glauca_ from most other dry forest trees.
+
+### Leaves
+
+<QuickRef
+  title="Leaf Characteristics"
+  items={[
+    { label: "Length", value: "20-40 cm" },
+    { label: "Type", value: "Pinnately compound" },
+    { label: "Arrangement", value: "Alternate" },
+    { label: "Leaflets", value: "7-15" },
+  ]}
+/>
+
+**Detailed Description**:
+
+- **Leaf type**: Pinnately compound with 7-15 leaflets
+- **Leaflet size**: 5-12 cm long, 2-5 cm wide
+- **Leaflet shape**: Elliptic to oblong, with rounded or slightly notched tips
+- **Margin**: Entire (smooth edges)
+- **Upper surface**: Dark green, glossy
+- **Lower surface**: Distinctly pale, glaucous (whitish-gray) — this is the source of the species name "glauca"
+- **Petiole**: 5-10 cm long
+- **Texture**: Leathery (coriaceous)
+
+The pale undersides of the leaves are quite noticeable, especially when wind rustles the foliage, creating a shimmering effect.
+
+### Flowers
+
+<QuickRef
+  title="Flower Characteristics"
+  items={[
+    { label: "Color", value: "White to cream" },
+    { label: "Size", value: "5-8 mm diameter" },
+    { label: "Season", value: "February-April" },
+    { label: "Sexuality", value: "Dioecious" },
+  ]}
+/>
+
+**Detailed Description**:
+
+- **Type**: Small, 5-petaled flowers
+- **Color**: White to yellowish-white or cream
+- **Arrangement**: Terminal panicles (branched clusters), 15-30 cm long
+- **Sexual system**: Dioecious (separate male and female trees)
+- **Fragrance**: Mild, pleasant scent that attracts pollinators
+- **Pollinators**: Various insects, including bees and flies
+
+Flowering typically occurs during the dry season (February-April) when the tree may be partially or fully leafless, making the flower clusters quite visible.
+
+### Fruit
+
+<QuickRef
+  title="Fruit Characteristics"
+  items={[
+    { label: "Type", value: "Drupe" },
+    { label: "Size", value: "1.5-2 cm long" },
+    { label: "Color", value: "Purple-black when ripe" },
+    { label: "Ripening", value: "May-July" },
+  ]}
+/>
+
+**Detailed Description**:
+
+- **Type**: Drupe (fleshy fruit with single seed)
+- **Shape**: Ovoid (egg-shaped)
+- **Size**: 1.5-2 cm long, about 1 cm wide
+- **Color**: Green when immature, ripening to deep purple-black
+- **Flesh**: Thin, oily pulp surrounding single seed
+- **Seeds**: 1-1.5 cm long, flattened
+- **Dispersal**: Birds (especially toucans, guans, and other frugivores)
+
+The dark fruits are an important food source for forest birds, which disperse the seeds. Fruit production is abundant in good years.
+
+### Dimensions
+
+- **Height**: 15-25 m at maturity (occasionally to 30 m in optimal conditions)
+- **DBH (trunk diameter)**: 40-80 cm
+- **Crown**: Spreading, rounded to irregular; 10-15 m diameter
+- **Growth form**: Single trunk with well-developed crown
+- **Root system**: Deep taproot with extensive lateral roots; very drought-adapted
+
+---
+
+## Distribution & Habitat
+
+### Global Distribution
+
+_Simarouba glauca_ has a wide natural distribution across the Neotropics:
+
+- **North**: Southern Florida (USA), Mexico (Yucatan Peninsula, Pacific coast)
+- **Central America**: Throughout all countries from Guatemala to Panama
+- **Caribbean**: Cuba, Jamaica, Hispaniola, Puerto Rico, Lesser Antilles
+- **South America**: Venezuela, Colombia, Ecuador (Pacific coast), possibly northern Peru
+
+The species has been introduced and naturalized in tropical regions of Africa and Asia for reforestation and medicinal purposes.
+
+### Distribution in Costa Rica
+
+In Costa Rica, the Comenegro is found primarily in:
+
+- **Guanacaste Province**: Throughout the dry forest zone from sea level to about 600 m
+- **Puntarenas Province**: Northern and central Pacific coast regions
+- **San José Province**: Lower Pacific slope (Valle del General)
+- **Alajuela Province**: Lower elevations near the Pacific
+
+**Elevational range**: Sea level to approximately 1,000 m (most common below 600 m)
+
+### Where to See This Tree
+
+<Callout type="success" title="Best Locations in Costa Rica">
+  **Santa Rosa National Park** — Common throughout the dry forest trails;
+  excellent specimens along main paths **Palo Verde National Park** — Abundant
+  in the dry forest areas **Rincón de la Vieja National Park** — Lower elevation
+  dry forest zones **Barra Honda National Park** — Present in dry forest on
+  limestone **Lomas Barbudal Biological Reserve** — Good populations in mature
+  dry forest **Private reserves in Guanacaste** — Many ecotourism properties
+  have labeled specimens
+</Callout>
+
+### Habitat & Ecology
+
+**Primary Habitat**: Tropical dry forest and moist deciduous forest
+
+**Ecological Characteristics**:
+
+- **Climate tolerance**: Strongly seasonal tropical climate with distinct dry season (4-6 months)
+- **Rainfall**: 1,000-2,500 mm annually (tolerates as low as 750 mm)
+- **Temperature**: Mean annual 24-28°C; tolerates temperatures up to 40°C
+- **Soil**: Highly adaptable; grows in sandy, clay, rocky, and even degraded soils
+- **Drainage**: Prefers well-drained soils; does not tolerate waterlogging
+- **Light**: Full sun; not shade tolerant
+
+**Ecological Role**:
+
+1. **Drought adaptation**: One of the most drought-tolerant native trees; survives extended dry seasons
+2. **Wildlife food source**: Fruits eaten by many bird species (toucans, guans, parrots, tanagers)
+3. **Pioneer species**: Colonizes disturbed areas and degraded lands
+4. **Nurse tree**: Provides shade for more shade-tolerant species to establish
+5. **Pollinator support**: Flowers provide nectar for bees and other insects
+6. **Soil improvement**: Deep roots bring nutrients to surface; leaf litter adds organic matter
+
+**Associated Forest Species**:
+
+In Costa Rican dry forests, Comenegro grows alongside:
+
+- _Enterolobium cyclocarpum_ (Guanacaste Tree)
+- _Guazuma ulmifolia_ (Guácimo)
+- _Bursera simaruba_ (Indio Desnudo)
+- _Tabebuia ochracea_ (Cortez Amarillo)
+- _Cedrela odorata_ (Spanish Cedar)
+- _Swietenia macrophylla_ (Mahogany)
+- _Dalbergia retusa_ (Cocobolo)
+- Various _Lonchocarpus_ species
+
+In more humid areas, it may occur with:
+
+- _Anacardium excelsum_ (Espavel)
+- _Spondias mombin_ (Jobo)
+- _Ceiba pentandra_ (Ceiba)
+- _Ficus_ species
+
+---
+
+## Uses & Applications
+
+### Medicinal Uses
+
+<Callout type="warning" title="Important Safety Notice">
+  The medicinal information below is provided for educational purposes only. The
+  bark and leaves of Simarouba glauca contain potent bioactive compounds. Do not
+  self-medicate with this plant. Consult qualified healthcare professionals
+  before using any traditional remedies.
+</Callout>
+
+**Traditional Medicine**:
+
+The extremely bitter bark has been used medicinally for centuries:
+
+- **Digestive disorders**: Bark tea for diarrhea, dysentery, stomach upset, and intestinal parasites
+- **Fever reduction**: Traditionally used as febrifuge (fever reducer), especially for malaria
+- **Tonic**: Bark decoction as general health tonic and appetite stimulant
+- **Liver ailments**: Used to treat various liver conditions in folk medicine
+- **Skin conditions**: Bark preparations applied externally for skin infections
+
+**Active Compounds**:
+
+- **Quassinoids**: Bitter compounds with antimicrobial, antiparasitic, and antitumor properties
+- **Ailanthone and similar compounds**: Show activity against various pathogens
+- **Triterpenes**: Various therapeutic properties
+
+**Modern Research**:
+
+Scientific studies have investigated:
+
+- Antimalarial activity of bark extracts
+- Antitumor potential of quassinoids
+- Antiparasitic effects against intestinal parasites
+- Antiviral properties
+- Potential applications in cancer research
+
+**Historical Importance**:
+
+During the 17th-19th centuries, "Simaruba bark" was an important export commodity from the Caribbean and Central America to Europe. It was officially listed in the London Pharmacopoeia (1788) and other European pharmaceutical references as a treatment for dysentery and fever.
+
+### Timber & Wood Products
+
+**Wood Characteristics**:
+
+- **Grain**: Straight to slightly interlocked
+- **Color**: Pale yellow-white to cream
+- **Density**: Light and soft (specific gravity 0.35-0.45)
+- **Workability**: Excellent—easy to saw, plane, and work
+- **Durability**: Low natural durability; not resistant to rot or insects
+
+**Traditional and Commercial Uses**:
+
+- **Matches**: Historically an important use; the light, soft wood is ideal for matchsticks and matchboxes
+- **Boxes and crates**: Used for shipping boxes, fruit crates, and light packaging
+- **Pulp and paper**: Suitable for pulp production
+- **Plywood**: Used in plywood core
+- **Carving**: Easy to carve; used for small crafts and utilitarian items
+- **Fuel**: Used as firewood, though not preferred due to better fast-growth potential
+
+The wood is too light and soft for construction or furniture, but its ease of working and uniform texture make it valuable for specialized applications.
+
+### Agroforestry Applications
+
+The Comenegro is increasingly recognized for agroforestry systems:
+
+- **Shade tree**: Used in coffee and cacao plantations for dappled shade
+- **Living fences**: Can be planted as living fence posts
+- **Alley cropping**: Incorporated in alley cropping systems; leaf litter improves soil
+- **Fodder**: Leaves occasionally used as supplemental livestock fodder (though bitter)
+- **Soil improvement**: Deep roots extract nutrients; leaf litter adds organic matter
+
+### Reforestation & Restoration
+
+**Excellent Reforestation Species** because:
+
+1. **Rapid growth**: Grows quickly on degraded lands
+2. **Drought tolerance**: Survives dry season stress that kills other planted trees
+3. **Poor soil tolerance**: Establishes on marginal, eroded, or rocky soils
+4. **Easy propagation**: Both seeds and cuttings are viable
+5. **Wildlife attraction**: Fruits attract seed-dispersing birds that bring other native species
+6. **Nurse tree**: Creates shade for more demanding species to establish below
+
+Used extensively in tropical dry forest restoration projects in Costa Rica and throughout Central America.
+
+### Other Uses
+
+- **Ornamental**: Planted as a shade tree for its attractive copper bark and spreading crown
+- **Honey production**: Flowers visited by bees
+- **Erosion control**: Deep roots stabilize slopes
+
+---
+
+## Cultural & Historical Significance
+
+### Indigenous Knowledge
+
+Indigenous peoples throughout the tree's range recognized the medicinal properties of Comenegro bark. The Mayan name "Pasak" refers to the bitter medicine derived from the bark. Indigenous healers used carefully prepared bark extracts to treat stomach ailments, fevers, and parasitic infections long before European contact.
+
+### Colonial Medicine Trade
+
+During the colonial period (17th-19th centuries), Comenegro bark became an important export commodity from the Caribbean and Central America to Europe. Known as "Simaruba bark" or "dysentery bark," it was shipped to European ports where it was sold to pharmacies and physicians.
+
+The bark's reputation for treating tropical dysentery made it valuable during an era when tropical diseases were poorly understood and effective treatments were rare. It was officially listed in the London Pharmacopoeia (1788) and other European pharmaceutical references.
+
+### Regional Importance
+
+In Costa Rica and Central America:
+
+- **Traditional medicine**: Still used in rural areas for digestive problems, though less common with access to modern medicine
+- **Forest identity**: The distinctive copper bark makes it a recognizable component of dry forest landscapes
+- **Reforestation symbol**: Now seen as an important native species for ecological restoration
+
+### Cultural Names
+
+The name "Comenegro" (literally "eat black") is curious—its exact origin is unclear but may refer to the dark purple fruits or possibly the intensely bitter (black) taste of the bark. Other common names like "Bitterwood" and the genus name from indigenous "simaruba" all emphasize the bitter medicinal properties that have defined human relationships with this tree for centuries.
+
+---
+
+## Conservation Status
+
+<Callout type="success" title="Least Concern">
+  Simarouba glauca is assessed as **Least Concern (LC)** by the IUCN. The
+  species has a very wide geographic distribution across the tropics and remains
+  common in many areas. However, local populations in heavily deforested regions
+  have declined.
+</Callout>
+
+### Current Status
+
+Globally, the species is not threatened and maintains extensive populations throughout its wide range. In Costa Rica, it remains relatively common in protected dry forests and is not considered at risk nationally.
+
+### Threats
+
+Despite its "Least Concern" status, the Comenegro faces localized pressures:
+
+1. **Habitat loss**: Conversion of dry forests to cattle pasture and agriculture (particularly in Guanacaste) has reduced total habitat
+2. **Dry forest decline**: Tropical dry forests are one of the most threatened ecosystems in Costa Rica and globally; only about 2% of Costa Rica's original dry forest remains
+3. **Bark harvesting**: Historical overexploitation for medicinal bark depleted some local populations, though this is now rare
+4. **Fire**: Increased fire frequency in degraded dry forests can damage populations
+
+### Protection Measures
+
+The Comenegro benefits from conservation efforts:
+
+- Protected in numerous national parks and reserves, particularly dry forest protected areas (Santa Rosa, Palo Verde, Barra Honda)
+- Included in dry forest restoration projects throughout Guanacaste and northwestern Costa Rica
+- Promoted in agroforestry systems as an alternative to clearcutting
+- Seeds and germplasm maintained in forestry programs
+- Growing recognition of value for climate-adapted reforestation (drought tolerance valuable as climate changes)
+
+### Conservation Outlook
+
+The species' wide distribution, drought tolerance, rapid growth, and ease of propagation make it of low conservation concern. Its increasing use in reforestation may actually expand its distribution. The primary conservation concern is maintaining overall dry forest ecosystem integrity rather than the species itself.
+
+---
+
+## Cultivation
+
+### Propagation
+
+**From Seed**:
+
+Seeds should be collected from ripe fruits (dark purple to black) in May-July. This is the most common propagation method.
+
+- **Collection**: Gather fallen fruits under parent trees or collect directly from tree
+- **Processing**: Remove fleshy pulp by mashing and washing; seeds are small and flattened
+- **Viability**: Seeds remain viable for several months if stored dry and cool; best results with fresh seeds
+- **Sowing**: Plant seeds 1-2 cm deep in nursery beds or containers filled with well-draining sandy mix
+- **Germination**: Relatively good germination rates (50-70%); germination begins in 2-4 weeks and continues for 1-3 months
+- **Pre-treatment**: Soaking seeds in water for 24 hours before sowing may improve germination
+
+**From Cuttings**:
+
+The Comenegro can be propagated from cuttings, though this is less common:
+
+- **Material**: Use semi-hardwood stem cuttings 15-25 cm long, 1-2 cm diameter
+- **Preparation**: Remove leaves except 1-2 at tip; treat cut end with rooting hormone
+- **Planting**: Insert cuttings 1/3 to 1/2 their length into rooting medium (sand or sand/peat mix)
+- **Care**: Maintain high humidity with misting or plastic cover; provide bright shade
+- **Rooting**: Roots develop in 4-8 weeks; success rates variable (30-60%)
+
+**Direct Seeding**:
+
+In reforestation projects, direct seeding (planting seeds directly in the field) is sometimes used, though survival rates are lower than transplanting nursery seedlings.
+
+### Nursery Care
+
+**Seedling Management**:
+
+- **Shade**: Provide 50% shade for first 2-3 months, then gradually increase light
+- **Watering**: Keep soil moist but not waterlogged; water daily during dry weather
+- **Containers**: Use bags or pots at least 15-20 cm deep to accommodate taproot
+- **Transplanting**: Seedlings ready for transplanting when 30-50 cm tall (4-6 months)
+- **Hardening**: Gradually expose to full sun 2-3 weeks before planting out
+
+### Site Selection
+
+Choose appropriate sites for successful establishment:
+
+- **Climate**: Tropical lowland zones with warm temperatures
+- **Elevation**: Sea level to 1,000 m; best below 600 m
+- **Rainfall**: Areas receiving 1,000-2,500 mm annual rainfall with defined dry season
+- **Soil**: Adapts to almost any well-drained soil, including poor, rocky, or shallow soils
+- **Light**: Full sun essential for good growth
+- **Exposure**: Tolerates exposed, hot sites once established
+
+The Comenegro is excellent for degraded sites, eroded slopes, and marginal agricultural lands unsuitable for many other species.
+
+### Planting
+
+1. **Timing**: Plant at the start of rainy season (May-June) for best establishment
+2. **Site preparation**: Clear competing vegetation in 1 m radius; no soil amendment needed even on poor sites
+3. **Hole**: Dig planting hole larger than container (30 x 30 x 30 cm minimum)
+4. **Planting**: Remove container carefully to preserve taproot; plant at same depth as in nursery container
+5. **Firming**: Gently firm soil around roots to eliminate air pockets
+6. **Watering**: Water thoroughly after planting; create shallow basin around tree to capture rain
+7. **Mulch**: Apply organic mulch (leaves, grass, wood chips) around base to retain moisture and suppress weeds
+
+### Spacing
+
+- **Timber/pulp production**: 4-5 m spacing (400-625 trees/hectare)—not commonly done due to soft wood
+- **Agroforestry/shade**: 8-12 m spacing (70-155 trees/hectare)
+- **Mixed reforestation**: 5-10 m spacing with other native species
+- **Landscaping/ornamental**: 10-15 m from structures and other large trees
+
+### Care Requirements
+
+<QuickRef
+  title="Care Needs"
+  items={[
+    { label: "Light", value: "Full sun required" },
+    { label: "Water", value: "Moderate when young, low once established" },
+    { label: "Temperature", value: "Warm tropical (24-30°C)" },
+    { label: "Soil", value: "Highly adaptable, well-drained" },
+  ]}
+/>
+
+**Watering**:
+
+- **First year**: Water during dry periods (every 1-2 weeks if no rain)
+- **Second year**: Minimal supplemental watering needed; only during severe drought
+- **Established**: No watering needed; tree is extremely drought tolerant
+
+**Fertilization**:
+Generally not necessary even on poor soils. On highly degraded sites, light application of organic compost during first year may boost growth, but tree grows well without amendment.
+
+**Weed Control**:
+Essential during first 1-2 years. Maintain weed-free circle of 1 m radius around young trees. After 2-3 years, tree grows fast enough to shade out most competition.
+
+**Pruning**:
+Minimal pruning needed. For timber production, prune lower branches to 2-3 m height as tree grows. Remove dead or damaged branches. Generally low maintenance.
+
+**Pest/Disease Management**:
+The Comenegro is notably resistant to pests and diseases. Few serious problems have been reported. The bitter compounds in bark and leaves likely deter many herbivores.
+
+### Common Cultivation Problems
+
+1. **Poor establishment in deep shade**:
+   - **Solution**: Comenegro requires full sun; not suitable for understory planting
+2. **Slow growth in poorly drained soils**:
+   - **Solution**: Improve drainage; plant on slight mound; choose better site
+3. **Seedling mortality from drought in first dry season**:
+   - **Solution**: Provide supplemental water during establishment year; apply heavy mulch
+4. **Leaf drop during dry season (normal)**:
+   - **Solution**: No action required; tree will releaf naturally with rains; this is normal deciduous behavior
+5. **Irregular germination**:
+   - **Solution**: Plant multiple seeds; extend germination observation period to 3 months
+
+### Growth Expectations
+
+- **Year 1**: 50-100 cm growth; focus on root establishment
+- **Years 2-5**: 1-2 m/year growth; rapid vertical growth
+- **Years 5-10**: 1-1.5 m/year; crown development begins
+- **Years 10-15**: 0.5-1 m/year; tree approaches mature size (8-15 m)
+- **Maturity**: 15-25 years to reach full size (15-25 m height)
+
+Growth rates vary significantly with soil, rainfall, and care. Trees on moist, fertile sites grow faster than those on poor, dry sites, but even marginal sites produce reasonable growth.
+
+---
+
+## Similar Species
+
+The Comenegro has distinctive characteristics but can potentially be confused with some species:
+
+### Simarouba amara (Bitter Cedar)
+
+**Key differences**:
+
+- _S. amara_ occurs in wetter rainforests, not dry forests (rainfall zones 1,500-4,000 mm)
+- _S. amara_ has more leaflets (10-20 vs. 7-15)
+- _S. amara_ has smooth gray bark, not copper-colored
+- _S. glauca_ is more drought-tolerant and deciduous
+- In Costa Rica, _S. amara_ is found in Caribbean lowland rainforests while _S. glauca_ is most common in seasonally dry forests
+
+Both species have bitter bark used medicinally, but _S. glauca_ (Comenegro) has the distinctive copper/golden bark.
+
+### Bursera simaruba (Gumbo Limbo / Indio Desnudo)
+
+**Similar features**: Both have smooth, peeling bark with copper/reddish tones
+
+**Key differences**:
+
+- _Bursera simaruba_ bark is more reddish-brown and peels in thin papery sheets (like paper)
+- _B. simaruba_ has compound leaves with fewer, larger leaflets (5-9 leaflets)
+- _B. simaruba_ has resinous sap (turpentine smell)
+- _Simarouba glauca_ bark/leaves are bitter (not resinous)
+- _B. simaruba_ propagates extremely easily from large cuttings (stakes root)
+
+Both are common dry forest trees, but bark texture and leaf characteristics distinguish them.
+
+### Swietenia macrophylla (Mahogany)
+
+**Similar features**: Both have compound leaves and are valued timber trees
+
+**Key differences**:
+
+- _Swietenia_ bark is dark gray-brown and furrowed, not smooth copper
+- _Swietenia_ leaves are larger with more leaflets
+- _Swietenia_ has large woody capsule fruits (10-15 cm long)
+- _Simarouba_ has small purple drupes (1.5-2 cm)
+- _Swietenia_ wood is heavy, hard, and very valuable; _Simarouba_ wood is light and soft
+- Habitats differ: _Swietenia_ in moist forests; _Simarouba glauca_ in drier forests
+
+### Other Pinnate-leaved Trees
+
+Several other Costa Rican trees have pinnately compound leaves:
+
+- **_Spondias_ species** (Jobo, Jocote) — Different bark, larger leaflets, different fruits
+- **_Cedrela odorata_** (Spanish Cedar) — Aromatic wood (not bitter), different bark
+- **_Gliricidia sepium_** (Mother of Cacao) — Smaller tree, pink flowers, smooth gray bark
+
+**Diagnostic Identification Features of _Simarouba glauca_**:
+
+1. Smooth copper-golden bark that peels in patches
+2. Intensely bitter taste of bark and leaves (do not taste unknown trees, but historical identification method)
+3. Compound leaves with whitish (glaucous) undersides
+4. Small dark purple fruits
+5. Deciduous habit in dry season
+6. Dry forest habitat preference
+
+---
+
+## Identification Guide
+
+### Field Identification Key
+
+1. **Habitat**: Tropical dry forest or seasonal moist forest (0-1,000 m) → consistent with _S. glauca_
+2. **Bark**: Smooth, copper-colored, peeling in patches → diagnostic for _S. glauca_
+3. **Leaves**: Pinnately compound, 7-15 leaflets, whitish beneath → consistent
+4. **Deciduous**: Drops all leaves in dry season → confirms
+5. **Fruits** (if present): Small dark purple drupes → confirms _Simarouba_
+6. **Bitter taste**: Bark and leaves intensely bitter → diagnostic (though taste test should be done with caution and experience)
+
+### Seasonal Identification
+
+- **November-February** (Dry season): Leafless or losing leaves; distinctive copper bark very visible
+- **February-April** (Late dry): Flowering; white flower clusters on bare or newly leafing branches
+- **April-May** (Early wet): Leaf flush; fresh new leaves bronze-reddish
+- **May-July** (Wet season): Fruiting; purple fruits ripen
+- **May-November** (Wet season): Fully leafed; whitish leaf undersides visible
+
+### Bark Identification
+
+The smooth copper-colored bark that peels is diagnostic and allows year-round identification, even when tree is leafless. The copper-golden color with mottled cream patches where bark has peeled is unmistakable once learned.
+
+---
+
+## External Resources
+
+<ExternalLinksGrid>
+  <ExternalLink
+    title="iNaturalist - Simarouba glauca"
+    url="https://www.inaturalist.org/taxa/83855-Simarouba-glauca"
+    description="Community observations and photos from throughout its range"
+  />
+  <ExternalLink
+    title="Plants of the World Online - Kew"
+    url="https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:588914-1"
+    description="Comprehensive botanical database entry"
+  />
+  <ExternalLink
+    title="World Flora Online"
+    url="https://www.worldfloraonline.org/taxon/wfo-0000329685"
+    description="Taxonomic information and global distribution"
+  />
+  <ExternalLink
+    title="Useful Tropical Plants Database"
+    url="https://tropical.theferns.info/viewtropical.php?id=Simarouba+glauca"
+    description="Detailed uses and cultivation information"
+  />
+  <ExternalLink
+    title="CABI Invasive Species Compendium"
+    url="https://www.cabidigitallibrary.org/doi/10.1079/cabicompendium.49796"
+    description="Comprehensive species profile including uses"
+  />
+  <ExternalLink
+    title="Tropicos - Simarouba"
+    url="http://www.tropicos.org/Name/28800001"
+    description="Herbarium specimens and botanical information"
+  />
+</ExternalLinksGrid>
+
+---
+
+## References
+
+1. De Candolle, A.P. (1811). Simarouba glauca. In: Annales du Muséum National d'Histoire Naturelle, Paris.
+
+2. Hammel, B.E., Grayum, M.H., Herrera, C., & Zamora, N. (eds.) (2007). _Manual de Plantas de Costa Rica, Vol. VI: Dicotyledoneae (Haloragaceae–Phytolaccaceae)_. Missouri Botanical Garden Press, St. Louis.
+
+3. Janzen, D.H. (ed.) (1983). _Costa Rican Natural History_. University of Chicago Press. [Section on Simarouba glauca, pp. 288-289]
+
+4. Ocampo, R. & Maffioli, A. (1987). _El uso de algunas plantas silvestres en Costa Rica_. Editorial Tecnológica de Costa Rica, Cartago.
+
+5. Standley, P.C. (1923). Trees and shrubs of Mexico. _Contributions from the United States National Herbarium_ 23(3): 449-515.
+
+6. Fournier, L.A. & García, J. (1998). _Nombres vernáculos y científicos de árboles de Costa Rica_. Editorial Guayacán, San José, Costa Rica.
+
+7. Clayton, J.W., Fernando, E.S., Soltis, P.S., & Soltis, D.E. (2007). Molecular phylogeny of the tree-of-heaven family (Simaroubaceae) based on chloroplast and nuclear markers. _International Journal of Plant Sciences_ 168(9): 1325-1339.
+
+8. Jiménez, Q. (1999). _Árboles maderables de Costa Rica: ecología y silvicultura_. Instituto Nacional de Biodiversidad (INBio), Santo Domingo de Heredia, Costa Rica.
+
+9. O'Neill, M.J., Bray, D.H., Boardman, P., et al. (1987). Plants as sources of antimalarial drugs, Part 4. Activity of Brucea javanica fruits against chloroquine-resistant Plasmodium falciparum and quassinoids as the likely antimalarial constituents. _Journal of Natural Products_ 50(1): 41-48.
+
+10. Holdridge, L.R., Poveda, L.J., & Jiménez, Q. (1997). _Árboles de Costa Rica, Vol. I_. Centro Científico Tropical, San José, Costa Rica.
+
+11. Janzen, D.H. & Liesner, R. (1980). Annotated check-list of plants of lowland Guanacaste Province, Costa Rica, exclusive of grasses and non-vascular cryptogams. _Brenesia_ 18: 15-90.
+
+12. Gentry, A.H. (1993). _A Field Guide to the Families and Genera of Woody Plants of Northwest South America_. Conservation International, Washington D.C.
+
+13. The IUCN Red List of Threatened Species. (2024). _Simarouba glauca_. Version 2024.1. https://www.iucnredlist.org


### PR DESCRIPTION
Expands the critically underdeveloped English Comenegro page from 108 to 761 lines (96% parity with Spanish 795 lines). Adds Taxonomy, Physical Description, Distribution, Uses, Cultural Significance, Conservation, Cultivation, Similar Species, and Identification Guide sections.

## Summary by Sourcery

Expand and restructure the English Comenegro tree page into a comprehensive species profile aligned with the Spanish version, covering taxonomy, morphology, ecology, uses, cultivation, and conservation.

Documentation:
- Greatly expand the English Comenegro page with detailed sections on taxonomy, physical description, distribution and habitat, uses, cultural significance, conservation status, cultivation, similar species, and field identification.
- Add external resource links and formal literature references for further reading on Simarouba glauca.