### PR TITLE
fix(ci): generate Prisma client for type checking

### DIFF
--- a/.github/workflows/content-build-tests.yml
+++ b/.github/workflows/content-build-tests.yml
@@ -4,22 +4,22 @@ on:
   pull_request:
     branches: [main]
     paths:
-      - 'content/**/*.mdx'
-      - 'src/components/mdx/**'
-      - 'contentlayer.config.ts'
-      - 'src/**/*.tsx'
-      - 'src/**/*.ts'
+      - "content/**/*.mdx"
+      - "src/components/mdx/**"
+      - "contentlayer.config.ts"
+      - "src/**/*.tsx"
+      - "src/**/*.ts"
   push:
     branches: [main]
     paths:
-      - 'content/**/*.mdx'
-      - 'src/components/mdx/**'
+      - "content/**/*.mdx"
+      - "src/components/mdx/**"
 
 jobs:
   content-validation:
     name: Validate Content & Test Build
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -27,40 +27,46 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm ci
 
+      - name: Generate Prisma Client (for types)
+        run: npx prisma generate
+        env:
+          # Use dummy URL for type generation - not actually connecting to a database
+          DATABASE_URL: "postgresql://dummy:dummy@localhost:5432/dummy?schema=public"
+
       - name: Build Contentlayer
         run: npm run contentlayer
         continue-on-error: false
-        
+
       - name: Check for Contentlayer warnings/errors
         run: |
           # Run contentlayer and capture output
           output=$(npm run contentlayer 2>&1)
           echo "$output"
-          
+
           # Check for parsing errors
           if echo "$output" | grep -q "failed with.*Error"; then
             echo "❌ Contentlayer parsing errors detected!"
             exit 1
           fi
-          
+
           # Check for warnings
           if echo "$output" | grep -q "Warning.*problem"; then
             echo "⚠️  Contentlayer warnings detected - review them carefully"
             # Don't fail on warnings, just notify
           fi
-          
+
           echo "✅ Contentlayer built successfully"
 
       - name: Run content validation tests
         run: npm run test:run -- tests/content-validation.test.ts
-        
-      - name: Run MDX component tests  
+
+      - name: Run MDX component tests
         run: npm run test:run -- tests/mdx-components.test.tsx
 
       - name: Type check
@@ -71,7 +77,7 @@ jobs:
         env:
           # Ensure build fails on errors, not just warnings
           CI: true
-          
+
       - name: Check build output
         run: |
           if [ ! -d ".next" ]; then

--- a/src/app/api/contributions/route.ts
+++ b/src/app/api/contributions/route.ts
@@ -327,33 +327,35 @@ export async function GET(request: NextRequest) {
     const total = Number(countResult[0]?.count || 0);
 
     // Transform to camelCase
-    const transformedContributions = contributions.map((c) => ({
-      id: c.id,
-      type: c.type,
-      treeSlug: c.tree_slug,
-      targetField: c.target_field,
-      title: c.title,
-      description: c.description,
-      evidence: c.evidence,
-      scientificName: c.scientific_name,
-      commonNameEn: c.common_name_en,
-      commonNameEs: c.common_name_es,
-      family: c.family,
-      proposedImages: c.proposed_images,
-      contributorName: isAdmin ? c.contributor_name : null, // Hide from non-admins
-      contributorEmail: isAdmin ? c.contributor_email : null, // Hide from non-admins
-      sessionId: c.session_id,
-      userId: c.user_id,
-      status: c.status,
-      priority: c.priority,
-      reviewedBy: c.reviewed_by,
-      reviewedAt: c.reviewed_at,
-      reviewNotes: c.review_notes,
-      resolvedPrId: c.resolved_pr_id,
-      locale: c.locale,
-      createdAt: c.created_at,
-      updatedAt: c.updated_at,
-    }));
+    const transformedContributions = contributions.map(
+      (c: ContributionRow) => ({
+        id: c.id,
+        type: c.type,
+        treeSlug: c.tree_slug,
+        targetField: c.target_field,
+        title: c.title,
+        description: c.description,
+        evidence: c.evidence,
+        scientificName: c.scientific_name,
+        commonNameEn: c.common_name_en,
+        commonNameEs: c.common_name_es,
+        family: c.family,
+        proposedImages: c.proposed_images,
+        contributorName: isAdmin ? c.contributor_name : null, // Hide from non-admins
+        contributorEmail: isAdmin ? c.contributor_email : null, // Hide from non-admins
+        sessionId: c.session_id,
+        userId: c.user_id,
+        status: c.status,
+        priority: c.priority,
+        reviewedBy: c.reviewed_by,
+        reviewedAt: c.reviewed_at,
+        reviewNotes: c.review_notes,
+        resolvedPrId: c.resolved_pr_id,
+        locale: c.locale,
+        createdAt: c.created_at,
+        updatedAt: c.updated_at,
+      })
+    );
 
     return NextResponse.json({
       contributions: transformedContributions,


### PR DESCRIPTION
Fix CI type checking failures by generating Prisma client with a dummy DATABASE_URL. Also fixes implicit any type error in contributions route.

## Summary by Sourcery

Ensure CI type checking passes by generating the Prisma client during content build tests and tightening typing in the contributions API route.

Bug Fixes:
- Specify the ContributionRow type when transforming contributions in the API route to fix an implicit any type error.
- Generate the Prisma client in the content build tests workflow using a dummy DATABASE_URL so type checking succeeds in CI.

CI:
- Update the content build tests GitHub Actions workflow to generate the Prisma client before running contentlayer, tests, type checking, and build.