### PR TITLE
feat(content): enhance carboncillo species page with Acacia reclassification and charcoal science

### DIFF
--- a/content/trees/en/carboncillo.mdx
+++ b/content/trees/en/carboncillo.mdx
@@ -39,7 +39,7 @@ fruitingSeason:
   - "may"
 featuredImage: "/images/trees/carboncillo.jpg"
 publishedAt: "2024-12-20"
-updatedAt: "2026-01-11"
+updatedAt: "2026-01-14"
 # Safety Information
 toxicityLevel: "low"
 toxicParts:
@@ -56,14 +56,15 @@ skinContactDetails: "Thorns can cause puncture wounds. Handle with care."
 safetyNotes: "SHARP SPINES on branches—caution when handling or near children. Widely used as cattle fodder with good safety record. Legume seeds in Fabaceae family often contain mild alkaloids—avoid consuming raw seeds. Standard wood dust precautions. Otherwise safe native tree for reforestation and agroforestry."
 ---
 
-# Carboncillo (Feather-leaved Acacia)
+# Carboncillo
 
-<Callout type="success" title="The Charcoal Tree">
-  **Carboncillo** (_Acacia pennatula_) gets its name from "carbón"
-  (charcoal)—this small tree produces some of the finest charcoal in Central
-  America. Beyond fuel, it's a workhorse of Guanacaste's dry-forest pastoral
-  systems: fixing nitrogen, feeding cattle during drought, providing living
-  fences, and defining the spiny silhouette of Costa Rica's "Wild West."
+<Callout type="success" title="The Charcoal Tree of Guanacaste">
+  **Carboncillo** (_Acacia pennatula_) takes its name from "carbón" (charcoal) —
+  this small but tough tree produces some of the finest charcoal in Central
+  America. Beyond fuel, it is a workhorse of Guanacaste's dry-forest pastoral
+  systems: fixing atmospheric nitrogen, feeding cattle through brutal drought,
+  providing thorny living fences, and defining the spiny silhouette of Costa
+  Rica's pastoral lowlands. Where grasses fail, the Carboncillo endures.
 </Callout>
 
 <TwoColumn>
@@ -77,7 +78,9 @@ safetyNotes: "SHARP SPINES on branches—caution when handling or near children.
     { label: "Max Height", value: "8-15 m (25-50 ft)" },
     { label: "Crown Spread", value: "6-10 m" },
     { label: "Conservation", value: "Least Concern" },
-    { label: "Known For", value: "Charcoal, fodder" },
+    { label: "Flowering", value: "December-March" },
+    { label: "Fruiting", value: "February-May" },
+    { label: "Key Traits", value: "N₂-fixing, thorns, charcoal" },
   ]}
 />
 
@@ -100,7 +103,7 @@ safetyNotes: "SHARP SPINES on branches—caution when handling or near children.
 <ImageGallery>
   <ImageCard
     src="https://inaturalist-open-data.s3.amazonaws.com/photos/153983689/medium.jpg"
-    alt="Acacia pennatula - Whole tree"
+    alt="Acacia pennatula - Whole tree in dry pasture"
     title="Whole tree"
     credit="(c) Sune Holt, some rights reserved (CC BY-NC)"
     license="CC BY-NC"
@@ -108,32 +111,32 @@ safetyNotes: "SHARP SPINES on branches—caution when handling or near children.
   />
   <ImageCard
     src="https://inaturalist-open-data.s3.amazonaws.com/photos/153983682/medium.jpg"
-    alt="Acacia pennatula - Leaves"
-    title="Leaves"
+    alt="Acacia pennatula - Feathery bipinnate leaves"
+    title="Feathery leaves"
     credit="(c) Sune Holt, some rights reserved (CC BY-NC)"
     license="CC BY-NC"
     sourceUrl="https://www.inaturalist.org/taxa/349260-Vachellia-pennatula/browse_photos"
   />
   <ImageCard
     src="https://inaturalist-open-data.s3.amazonaws.com/photos/153983676/medium.jpg"
-    alt="Acacia pennatula - Habitat"
-    title="Habitat"
+    alt="Acacia pennatula - Dry forest habitat"
+    title="Dry forest habitat"
     credit="no rights reserved"
     license="CC BY-NC"
     sourceUrl="https://www.inaturalist.org/taxa/349260-Vachellia-pennatula/browse_photos"
   />
   <ImageCard
     src="https://inaturalist-open-data.s3.amazonaws.com/photos/153983177/medium.jpg"
-    alt="Acacia pennatula - Whole tree"
-    title="Whole tree"
+    alt="Acacia pennatula - Mature tree silhouette"
+    title="Mature tree"
     credit="(c) María Eugenia Mendiola González, some rights reserved (CC BY-NC-SA)"
     license="CC BY-NC"
     sourceUrl="https://www.inaturalist.org/taxa/349260-Vachellia-pennatula/browse_photos"
   />
   <ImageCard
     src="https://inaturalist-open-data.s3.amazonaws.com/photos/133896070/medium.jpeg"
-    alt="Acacia pennatula - Leaves"
-    title="Leaves"
+    alt="Acacia pennatula - Leaf detail"
+    title="Leaf detail"
     credit="(c) Sune Holt, some rights reserved (CC BY-NC)"
     license="CC BY-NC"
     sourceUrl="https://www.inaturalist.org/taxa/349260-Vachellia-pennatula/browse_photos"
@@ -151,348 +154,608 @@ safetyNotes: "SHARP SPINES on branches—caution when handling or near children.
 ## Taxonomy and Classification
 
 <PropertiesGrid>
-  <PropertyCard title="Kingdom" value="Plantae" />
-  <PropertyCard title="Clade" value="Angiosperms" />
-  <PropertyCard title="Clade" value="Eudicots" />
-  <PropertyCard title="Order" value="Fabales" />
-  <PropertyCard title="Family" value="Fabaceae" />
-  <PropertyCard title="Genus" value="Acacia" />
-  <PropertyCard title="Species" value="A. pennatula" />
+  <PropertyCard icon="👑" label="Kingdom" value="Plantae" />
+  <PropertyCard
+    icon="🌸"
+    label="Clade"
+    value="Angiosperms / Eudicots / Rosids"
+  />
+  <PropertyCard icon="🌿" label="Order" value="Fabales" />
+  <PropertyCard icon="🪴" label="Family" value="Fabaceae" />
+  <PropertyCard icon="🔬" label="Subfamily" value="Caesalpinioideae" />
+  <PropertyCard icon="🌳" label="Genus" value="Vachellia (formerly Acacia)" />
+  <PropertyCard icon="📋" label="Species" value="V. pennatula" />
+  <PropertyCard
+    icon="✍️"
+    label="Authority"
+    value="(Schltdl. & Cham.) Seigler & Ebinger"
+  />
 </PropertiesGrid>
-
-<Callout type="info" title="Name Origins">
-  - **Acacia**: From Greek "akantha" meaning thorn - **pennatula**: Latin
-  meaning "little feather" - describes the delicate compound leaves -
-  **Carboncillo**: Spanish diminutive of "carbón" (charcoal) - Taxonomic note:
-  May be classified as Vachellia pennatula by some authorities
-</Callout>
 
 ### Common Names
 
 <DataTable
   headers={["Language/Region", "Common Name(s)", "Meaning"]}
-  rows={[
+  data={[
     ["English", "Feather-leaved Acacia", "Leaf appearance"],
     ["Spanish (Costa Rica)", "Carboncillo, Carbonero", "Charcoal tree"],
-    ["Spanish (Mexico)", "Tepame, Huizache", "Regional names"],
+    ["Spanish (Mexico)", "Tepame, Huizache", "Indigenous names"],
     ["Spanish (Guatemala)", "Espino, Subin", "Thorny tree"],
+    ["Spanish (Honduras)", "Carbón, Carbonero", "Charcoal"],
   ]}
 />
 
+### The Acacia Reclassification
+
+<Accordion title="Taxonomic History">
+  <AccordionItem title="The 'Acacia Wars'">
+    The genus _Acacia_ was once one of the largest tree genera in the world,
+    with over 1,300 species across Africa, Australia, and the Americas. In 2005,
+    a controversial decision at the International Botanical Congress in Vienna
+    "retypified" the name _Acacia_ to apply to Australian species (previously
+    _Racosperma_), stripping it from the roughly 200 African and American
+    species that had borne the name for over 250 years. This decision —
+    confirmed at the Melbourne Congress in 2011 — means the Carboncillo's genus
+    was officially changed from _Acacia_ to _Vachellia_. Many local and regional
+    references still use the traditional _Acacia pennatula_ name, creating
+    ongoing confusion. This guide uses _Acacia_ in the common name for
+    familiarity while noting _Vachellia_ as the accepted scientific
+    classification.
+  </AccordionItem>
+  <AccordionItem title="Subfamily Placement">
+    Like other mimosoid legumes, the Carboncillo was traditionally placed in the
+    subfamily Mimosoideae. The LPWG (Legume Phylogeny Working Group) 2017
+    reclassification merged Mimosoideae into a broadly defined Caesalpinioideae,
+    placing _Vachellia_ in the mimosoid clade within Caesalpinioideae on the
+    basis of molecular phylogenetic evidence. The species remains a classic
+    mimosoid in morphology — with globular flower heads, bipinnate leaves, and
+    stipular spines — regardless of its formal subfamily assignment.
+  </AccordionItem>
+</Accordion>
+
+### Etymology
+
+- **Acacia / Vachellia**: _Acacia_ from Greek _akantha_ (thorn); _Vachellia_ honors George Harvey Vachell (1799-1839), a British clergyman and plant collector in China
+- **pennatula**: Latin for "little feather" — describing the delicate, finely divided compound leaves
+- **Carboncillo**: Spanish diminutive of _carbón_ (charcoal) — "little charcoal tree," reflecting its premier use as fuel
+
 ---
 
-## Physical Description
+## Physical Description and Botany
 
 ### Overall Form
 
-Carboncillo is a small to medium-sized deciduous tree with an often crooked trunk and spreading, sometimes umbrella-shaped crown. The branches are armed with paired thorns at the base of leaves—a characteristic of many acacias. During the dry season, it loses its leaves, revealing the angular branch structure.
+Carboncillo is a **small to medium deciduous tree** reaching **8-15 meters** in height with a trunk diameter of **20-40 cm** at breast height. The trunk is often crooked or leaning, and the crown is **irregularly spreading, sometimes umbrella-shaped** — a silhouette immediately recognizable in Guanacaste's open pastures. The branches are armed with **paired stipular spines** at the base of each leaf — a defensive adaptation shared with many other _Vachellia_ species.
 
 <StatsGroup>
   <StatBar label="Mature Height" value={12} max={15} unit="meters" />
   <StatBar label="Trunk Diameter" value={30} max={40} unit="cm" />
   <StatBar label="Crown Spread" value={8} max={10} unit="meters" />
-  <StatBar label="Thorn Length" value={2} max={4} unit="cm" />
+  <StatBar label="Spine Length" value={2} max={4} unit="cm" />
 </StatsGroup>
 
-### Distinctive Features
+### Bark and Wood
 
-<TwoColumn>
-<Column>
+**Bark**: Dark gray to brown, becoming **rough and deeply fissured** with age. Contains moderate levels of tannins that contribute to pest resistance.
 
-#### Leaves
+**Wood**: Remarkably **dense and hard** for such a small tree — specific gravity 0.65-0.80 — which is precisely what makes it exceptional for charcoal. The high density results from slow growth in nutrient-poor, dry-season conditions and produces wood with superior calorific value (approximately 7,000-7,500 kcal/kg as charcoal). The heartwood is dark brown, fine-grained, and naturally resistant to decay.
 
-- **Type**: Bipinnate (twice-compound)
-- **Pinnae**: 8-25 pairs
-- **Leaflets**: Tiny, numerous (20-50 pairs)
-- **Appearance**: Feathery, delicate
-- **Size**: 10-20 cm long overall
-- **Timing**: Deciduous in dry season
+### Leaves
 
-#### Bark & Thorns
+<PropertiesGrid>
+  <PropertyCard icon="🍃" label="Type" value="Bipinnate (twice-compound)" />
+  <PropertyCard icon="📏" label="Length" value="10-20 cm overall" />
+  <PropertyCard icon="🔢" label="Pinnae" value="8-25 pairs" />
+  <PropertyCard icon="🌿" label="Leaflets" value="20-50 pairs per pinna" />
+</PropertiesGrid>
 
-- **Bark Color**: Dark gray to brown
-- **Texture**: Rough, fissured
-- **Thorns**: Paired, at leaf bases
-- **Thorn Length**: 1-4 cm
-- **Wood**: Dense, hard
-- **Good for**: Excellent charcoal
+The leaves are among the most **finely divided** of any Costa Rican tree — the "feather" of _pennatula_. Each bipinnate leaf carries 8-25 pairs of pinnae, with each pinna bearing 20-50 pairs of tiny leaflets (3-6 mm long). This extremely fine division creates a **delicate, lace-like appearance** that contrasts dramatically with the tree's fierce spines. The leaves are deciduous, falling during the dry season (December-April) and re-emerging rapidly with the first rains.
 
-</Column>
-<Column>
+### Flowers
 
-#### Flowers
+<PropertiesGrid>
+  <PropertyCard icon="🌸" label="Color" value="Creamy white to pale yellow" />
+  <PropertyCard icon="📏" label="Size" value="Globular heads, 1-1.5 cm" />
+  <PropertyCard icon="📅" label="Season" value="December-March (dry season)" />
+  <PropertyCard
+    icon="🐝"
+    label="Pollinators"
+    value="Bees, beetles, butterflies"
+  />
+</PropertiesGrid>
 
-- **Type**: Globular heads (mimosoid)
-- **Color**: Creamy white to pale yellow
-- **Size**: 1-1.5 cm diameter
-- **Arrangement**: Clusters from branches
-- **Fragrance**: Sweet, attracts bees
-- **Timing**: Late dry season
+The flowers are small individually but aggregate into **dense globular heads** (1-1.5 cm diameter) typical of the mimosoid clade. Numerous protruding stamens give each head a soft, fuzzy "powder puff" appearance. The sweet, honey-like fragrance attracts a wide range of pollinators including native stingless bees (_Trigona_, _Tetragonisca_), honeybees, beetles, and small butterflies. Flowering occurs during the dry season (December-March), often on leafless branches.
 
-#### Fruits (Pods)
+### Fruit and Seeds
 
-- **Type**: Legume pod
-- **Size**: 10-15 cm long
-- **Color**: Brown when mature
-- **Seeds**: Several per pod
-- **Value**: Excellent cattle fodder
-- **Timing**: End of dry season
+**Pods**: Legume pods, **10-15 cm long** and 1.5-2 cm wide, straight to slightly curved, becoming **dark brown and leathery** when ripe. Pods are indehiscent (do not split open naturally), requiring animal digestion or physical breakage to release seeds.
 
-</Column>
-</TwoColumn>
+**Seeds**: 6-12 per pod, **hard-coated and oval**, dark brown. Seeds are orthodox (can be stored dry) and require scarification for reliable germination. The pods are notably **protein-rich** (12-18% crude protein), making them excellent livestock fodder.
+
+**Dispersal**: The primary dispersal agent is **cattle** — livestock consume the nutritious pods and pass the hard-coated seeds intact through their digestive tract, depositing them in fertile dung piles across the landscape. This cattle-mediated dispersal explains why Carboncillo is so abundant in active pastures — the tree and the ranching system co-evolved a mutually beneficial relationship.
 
 ---
 
-## The Perfect Charcoal Tree
+## Geographic Distribution
 
-### Traditional Fuel Production
+<DistributionMap
+  distributions={["guanacaste", "puntarenas", "alajuela", "san-jose"]}
+/>
+
+<PropertiesGrid>
+  <PropertyCard icon="🌎" label="Range" value="Mexico to Costa Rica" />
+  <PropertyCard icon="🇨🇷" label="Costa Rica" value="Pacific dry forest zone" />
+  <PropertyCard icon="⛰️" label="Elevation" value="0-1,200 m" />
+  <PropertyCard icon="🌡️" label="Climate" value="Tropical dry to semi-dry" />
+</PropertiesGrid>
+
+<FeatureBox title="A Tree Shaped by Ranching" icon="🐄">
+  Carboncillo's distribution in Costa Rica tells the story of 500 years of
+  cattle ranching. Unlike most native trees that declined with deforestation,
+  the Carboncillo actually _expanded_ its range as forests were cleared for
+  pasture. Cattle eat the protein-rich pods and disperse the hard seeds in their
+  dung, effectively planting Carboncillo wherever they graze. Today, Carboncillo
+  is more abundant in agricultural Guanacaste than it was in pre-Columbian
+  intact dry forest — one of the few native trees that thrived alongside, rather
+  than despite, the livestock industry.
+</FeatureBox>
+
+### Distribution in Costa Rica
+
+<DataTable
+  headers={["Location", "Province", "Setting", "Abundance"]}
+  data={[
+    ["Guanacaste lowlands", "Guanacaste", "Pastures, forest edges", "Common"],
+    ["Nicoya Peninsula", "Guanacaste", "Dry hillsides", "Common"],
+    ["Tempisque basin", "Guanacaste", "Agricultural areas", "Abundant"],
+    ["Northern Puntarenas", "Puntarenas", "Dry zones", "Moderate"],
+    [
+      "Central Valley (dry)",
+      "Alajuela/San José",
+      "Western slopes",
+      "Occasional",
+    ],
+  ]}
+/>
+
+The species is native from southern Mexico (Guerrero, Oaxaca, Chiapas) through Guatemala, El Salvador, Honduras, and Nicaragua to Costa Rica, reaching its southernmost limit in the Pacific lowlands.
+
+### Where to See Carboncillo
+
+- **Tempisque River basin** — Abundant in cattle pastures; look for the distinctive thorny silhouette against the sky
+- **Parque Nacional Palo Verde** — Forest edges and transitions between wetland and dry forest
+- **Santa Cruz-Nicoya corridor** — Along fence lines and in silvopastoral landscapes
+- **Parque Nacional Santa Rosa** — Secondary dry forest and restored pasture areas
+- **Route 1 (Interamericana through Guanacaste)** — Visible from the highway in roadside pastures
+
+---
+
+## Charcoal Production
 
 <Callout type="success" title="Premium Charcoal">
-  Carboncillo has been prized for centuries for its exceptional charcoal. The
-  dense, hard wood burns hot and long, producing charcoal that was historically
-  preferred for blacksmithing, cooking, and even gunpowder production. While
-  less common today, some rural communities still produce "carbón de
-  carboncillo" using traditional earth-pit methods.
+  Carboncillo wood produces charcoal of **exceptional quality** — dense,
+  long-burning, and low-smoke. For centuries it was the preferred fuel for
+  blacksmithing, cooking, and even gunpowder production throughout Mesoamerica.
+  The traditional earth-pit kiln method, still practiced in some rural
+  communities, represents living cultural heritage.
 </Callout>
 
-<TwoColumn>
-<Column>
+### Why Carboncillo Makes Superior Charcoal
 
-#### Charcoal Properties
+<DataTable
+  headers={[
+    "Property",
+    "Carboncillo Charcoal",
+    "Typical Tropical Wood Charcoal",
+  ]}
+  data={[
+    ["Calorific value", "~7,000-7,500 kcal/kg", "~5,500-6,500 kcal/kg"],
+    ["Burn duration", "Very long (4-6 hours)", "Moderate (2-3 hours)"],
+    ["Smoke production", "Very low", "Moderate to high"],
+    ["Fixed carbon", "~75-85%", "~60-75%"],
+    ["Density", "Dense, heavy pieces", "Light to moderate"],
+    ["Spark/pop", "Minimal", "Variable"],
+  ]}
+/>
 
-- Very high heat output
-- Long burning time
-- Low smoke production
-- Dense, heavy charcoal
-- Excellent for metalwork
-- Traditional cooking fuel
+The superior quality stems from the wood's **high density** (specific gravity 0.65-0.80) and **low moisture content** at harvest time (the tree is deciduous, and wood is typically harvested during the dry season). Traditional carbonization uses earth-pit kilns (_hornos de tierra_) where stacked wood is covered with earth and slowly charred at 400-500°C over 2-3 days. The controlled, slow pyrolysis produces charcoal with high fixed carbon content and minimal volatile compounds — hence the clean, low-smoke burn.
 
-</Column>
-<Column>
+### Traditional vs. Modern Production
 
-#### Modern Considerations
-
-- Sustainable harvesting needed
-- Coppicing regeneration
-- Alternative fuels available
-- Cultural heritage value
-- Small-scale production continues
-- Traditional knowledge preservation
-
-</Column>
-</TwoColumn>
+<Accordion title="Charcoal Production Methods">
+  <AccordionItem title="Earth-Pit Kiln (Traditional)">
+    The traditional method used for centuries: a pit is dug in dry ground,
+    filled with stacked Carboncillo wood, and covered with a layer of green
+    branches and earth, leaving small air holes for controlled combustion. The
+    fire is lit from one end, and the carbonization proceeds slowly over 2-3
+    days. When smoke changes from white (steam) to blue (combustible gases), the
+    air holes are sealed to complete charring without burning. The resulting
+    charcoal is dense, uniform, and of excellent quality. This method converts
+    approximately 20-25% of wood weight to charcoal.
+  </AccordionItem>
+  <AccordionItem title="Modern Considerations">
+    While modern cooking fuels (LP gas, electricity) have largely replaced
+    charcoal in urban Costa Rica, artisanal charcoal production persists in
+    rural Guanacaste. Some communities produce _carbón de carboncillo_ for local
+    markets and restaurants that prefer the flavor profile of wood-grilled
+    cooking. Sustainable charcoal production from Carboncillo is feasible
+    because the tree **coppices vigorously** — cut stumps resprout multiple
+    stems that can be harvested again in 5-8 years, creating a renewable fuel
+    cycle without killing the root system.
+  </AccordionItem>
+</Accordion>
 
 ---
 
 ## Silvopastoral Value
 
-### Cattle and Landscape Management
-
-<Callout type="info" title="Rancher's Ally">
-  In Guanacaste's extensive cattle ranching, Carboncillo is valued for multiple
-  reasons. Its protein-rich pods and leaves provide crucial fodder during the
-  harsh dry season when grasses fail. As a legume, it fixes atmospheric nitrogen
-  into the soil, improving pasture productivity. And its thorny branches make
-  effective living fences.
-</Callout>
+<FeatureBox title="The Rancher's Ally" icon="🌾">
+  In Guanacaste's extensive cattle ranching system, few trees are as useful as
+  the Carboncillo. It fixes nitrogen to improve pasture soil, drops protein-rich
+  pods that sustain cattle through drought, provides thorny living fences, and
+  yields firewood and charcoal. Ranchers have deliberately protected and
+  promoted this tree in their pastures for generations — one of the earliest
+  forms of agroforestry in the Neotropics.
+</FeatureBox>
 
 ### Multiple Uses in Pastoral Systems
 
 <DataTable
   headers={["Use", "Part Used", "Benefit"]}
-  rows={[
-    ["Cattle fodder", "Pods, leaves", "Protein-rich dry season feed"],
-    ["Living fence", "Whole tree", "Thorny barrier, fence posts"],
-    ["Nitrogen fixation", "Root nodules", "Soil fertility improvement"],
-    ["Shade", "Crown", "Reduces heat stress for cattle"],
-    ["Firewood", "Branches", "Excellent fuel wood"],
-    ["Charcoal", "Trunk wood", "High-quality cooking fuel"],
+  data={[
+    [
+      "Cattle fodder",
+      "Pods and fallen leaves",
+      "12-18% crude protein; critical dry-season feed",
+    ],
+    [
+      "Living fence",
+      "Whole tree/cuttings",
+      "Thorny barrier; saves wire and wood",
+    ],
+    [
+      "Nitrogen fixation",
+      "Root nodules",
+      "20-50 kg N/ha/year; free soil fertilizer",
+    ],
+    ["Shade", "Crown", "Reduces heat stress; improves cattle weight gain"],
+    [
+      "Firewood",
+      "Branches, prunings",
+      "High-caloric wood; available from pruning",
+    ],
+    ["Charcoal", "Trunk wood", "Premium quality; income diversification"],
+    ["Erosion control", "Root system", "Stabilizes slopes in hilly pastures"],
   ]}
 />
 
+### Drought Insurance
+
+Ranchers in Guanacaste call Carboncillo _"seguro de sequía"_ — drought insurance. During the 5-6 month dry season when all grasses wither, cattle can survive on fallen Carboncillo pods. The pods' high protein content (12-18% crude protein) and carbohydrates make them a nutritionally adequate emergency feed. Trees are deliberately left in pastures for this purpose — a form of traditional ecological knowledge, proven over centuries, that modern livestock scientists now recognize as an effective silvopastoral strategy.
+
 ---
 
-## Distribution in Costa Rica
+## Habitat and Ecology
 
-<Callout type="info" title="Where to Find It">
-  Carboncillo is characteristic of Costa Rica's Pacific dry forest region,
-  particularly Guanacaste province. Look for it in pastures, along fences, in
-  secondary dry forest, and on hillsides. It's especially common in the
-  agricultural landscapes between remaining forest patches, where it's often
-  deliberately left by ranchers.
+<PropertiesGrid>
+  <PropertyCard icon="🌡️" label="Temperature" value="22-35°C" />
+  <PropertyCard icon="💧" label="Rainfall" value="800-1,800 mm/year" />
+  <PropertyCard icon="☀️" label="Dry Season" value="5-6 months" />
+  <PropertyCard icon="🪨" label="Soil" value="Well-drained, any fertility" />
+</PropertiesGrid>
+
+### Ecological Roles
+
+<Accordion title="Ecosystem Functions">
+  <AccordionItem title="Biological Nitrogen Fixation">
+    Carboncillo forms symbiotic associations with nitrogen-fixing bacteria
+    (primarily _Rhizobium_ and _Bradyrhizobium_ species) housed in specialized
+    root nodules. These bacteria convert atmospheric N₂ into plant-available
+    ammonium (NH₄⁺), enriching the surrounding soil at estimated rates of
+    **20-50 kg N/ha/year** — equivalent to a light application of commercial
+    fertilizer. In nutrient-depleted pastures, this nitrogen input visibly
+    improves grass growth in a "halo" around the tree's root zone, a phenomenon
+    that Guanacaste ranchers have recognized and exploited for generations.
+  </AccordionItem>
+  <AccordionItem title="Pioneer Species and Succession">
+    Carboncillo is a classic pioneer that rapidly colonizes disturbed sites —
+    abandoned pastures, roadsides, burn scars, and eroded slopes. Its tolerance
+    of poor soils, high light requirements, and nitrogen-fixing capacity allow
+    it to establish where few other trees can. Over time, its nitrogen inputs
+    and shade modification create conditions favorable for more demanding
+    species, facilitating forest succession. In restoration ecology, Carboncillo
+    is used as a "nurse tree" to prepare degraded sites for reforestation.
+  </AccordionItem>
+  <AccordionItem title="Fire Ecology">
+    Carboncillo is well-adapted to fire — a defining feature of tropical dry
+    forests. Mature trees survive moderate ground fires through their thick
+    bark, and cut or burnt stumps resprout vigorously from the root crown
+    (coppicing). Seeds in the soil bank also respond to fire: heat scarifies the
+    hard seed coat, triggering mass germination in post-fire environments. This
+    fire adaptation explains why Carboncillo persists in landscapes subject to
+    annual dry-season burning for pasture management.
+  </AccordionItem>
+  <AccordionItem title="Wildlife Support">
+    Despite its small size, Carboncillo supports diverse wildlife. Sweet,
+    honey-scented flowers attract native stingless bees (_Trigona_,
+    _Tetragonisca_), honeybees, beetles, and butterflies during the dry season
+    when few other trees bloom. The thorny branches provide protected nesting
+    sites for birds including the Turquoise-browed Motmot (_Eumomota
+    superciliosa_), flycatchers, and wrens. White-tailed deer (_Odocoileus
+    virginianus_) browse the foliage, and seed-eating rodents cache and disperse
+    seeds. The tree's association with cattle also creates microhabitats —
+    cattle dung piles enriched with Carboncillo seeds attract dung beetles,
+    which further enhance soil health.
+  </AccordionItem>
+</Accordion>
+
+### Forest Associations
+
+Carboncillo grows in association with characteristic Mesoamerican dry forest species:
+
+- **Guanacaste tree** (_Enterolobium cyclocarpum_) — The national tree; co-dominant canopy species
+- **Quebracho** (_Lysiloma divaricatum_) — Another nitrogen-fixing legume of dry forests
+- **Indio desnudo** (_Bursera simaruba_) — Red-barked pioneer; shared habitat
+- **Cornizuelo** (_Acacia collinsii_) — Ant-acacia; often confused with Carboncillo
+- **Jícaro** (_Crescentia alata_) — Pasture tree with gourd-like fruits
+
+---
+
+## Conservation Status
+
+<Callout type="success" title="Least Concern (LC)">
+  _Acacia pennatula_ (Vachellia pennatula) is assessed as **Least Concern** by
+  the IUCN Red List. The species has a wide range across Mesoamerica, stable to
+  increasing populations, and excellent adaptation to human-modified landscapes.
+  Unlike most native trees, Carboncillo has _benefited_ from deforestation and
+  cattle ranching through its cattle-dispersal seed strategy.
 </Callout>
 
-### Regional Distribution
+### Conservation Paradox
+
+Carboncillo presents a conservation paradox: while its dry forest habitat is among the most threatened on Earth (less than 2% of original Mesoamerican dry forest remains), the tree itself has expanded its range through association with cattle. However, this apparent success masks genetic concerns — pasture populations may represent a narrow genetic subset adapted to disturbed conditions, lacking the genetic diversity found in intact forest populations. Conservation of remnant dry forest fragments remains critically important for maintaining the full genetic heritage of this and other dry forest species.
+
+### Conservation Priorities
 
 <DataTable
-  headers={["Location", "Province", "Setting", "Abundance"]}
-  rows={[
-    ["Guanacaste lowlands", "Guanacaste", "Pastures, forest edges", "Common"],
-    ["Nicoya Peninsula", "Guanacaste", "Dry hillsides", "Common"],
-    ["Tempisque basin", "Guanacaste", "Agricultural areas", "Abundant"],
-    ["Northern Puntarenas", "Puntarenas", "Dry zones", "Moderate"],
-    ["Central Valley (dry)", "Alajuela", "Western slopes", "Occasional"],
+  headers={["Priority", "Action", "Benefit"]}
+  data={[
+    [
+      "High",
+      "Protect remnant dry forest fragments",
+      "Preserves genetic diversity of intact forest populations",
+    ],
+    [
+      "High",
+      "Promote silvopastoral systems",
+      "Integrates Carboncillo in productive landscapes",
+    ],
+    [
+      "Medium",
+      "Sustainable charcoal management",
+      "Maintains traditional use without overharvesting",
+    ],
+    [
+      "Medium",
+      "Fire management in pastures",
+      "Reduces damage to regenerating forest",
+    ],
+    [
+      "Medium",
+      "Biological corridor connectivity",
+      "Connects isolated populations across pasture matrix",
+    ],
   ]}
 />
 
 ---
 
-## Ecological Role
+## Cultural Significance
 
-### Dry Forest Ecosystem
+### The Blacksmith's Tree
 
-<TwoColumn>
-<Column>
+Before modern fuels, Carboncillo charcoal was the **premier fuel for blacksmithing** throughout Central America. Spanish colonizers arriving in Guanacaste in the 16th century quickly recognized its value — the dense, hot-burning charcoal was ideal for forging iron tools, horseshoes, and weapons. Charcoal production (_carbonería_) became an important colonial industry, and the skills were passed down through generations of rural families. Even today, some Guanacaste families identify as _carboneros_ — charcoal makers — maintaining expertise in the traditional earth-pit kiln method as cultural heritage.
 
-#### Ecosystem Functions
+### Sabanero Landscape
 
-- Nitrogen fixation
-- Soil improvement
-- Erosion control
-- Wildlife shelter
-- Pollinator support
-- Seed bank contributor
+For Guanacaste's _sabaneros_ (cowboys), the Carboncillo is as iconic as the horse and the lasso. Its thorny silhouette against a dry-season sunset is the quintessential image of the Guanacaste pastoral landscape. Ranchers have a deep pragmatic appreciation for this tree — providing fencing, fuel, fodder, and shade from a single species. The traditional practice of selectively retaining Carboncillo in pastures represents one of the oldest forms of agroforestry in the Neotropics, predating formal scientific descriptions by centuries.
 
-</Column>
-<Column>
+### Phenological Calendar
 
-#### Wildlife Interactions
-
-- Bees attracted to flowers
-- Cattle disperse seeds
-- Birds nest in branches
-- Small mammals use cover
-- Deer browse leaves
-- Insects in bark
-
-</Column>
-</TwoColumn>
-
-### Pioneer and Recovery
-
-<Callout type="success" title="Restoration Potential">
-  Carboncillo readily colonizes disturbed areas in the dry forest zone. Its
-  ability to fix nitrogen makes it valuable for restoring degraded pastures and
-  preparing soil for other species. When managing secondary dry forest, allowing
-  Carboncillo to grow can accelerate succession.
-</Callout>
+Rural communities use Carboncillo's seasonal rhythms as a natural calendar. Flowering in December-January signals the deepening of the dry season and the need to reserve water. Pod drop in March-April provides emergency cattle feed during the harshest drought weeks. The first flush of green leaves with early May rains signals the time to prepare fields for planting — a phenological knowledge system that connects farming to the rhythms of the natural world.
 
 ---
 
-## Growing Information
+## Growing Carboncillo
 
-### Cultivation
+<Callout type="warning" title="Climate Requirements">
+  Carboncillo requires a **tropical dry climate** with a pronounced dry season.
+  It is **not suitable** for humid Caribbean conditions or high-elevation cloud
+  forests. It performs best in Guanacaste and the Pacific lowlands below 1,000
+  m. **Note**: paired thorns make this tree unsuitable for areas with heavy foot
+  traffic or play areas for children.
+</Callout>
+
+### Propagation
+
+<Accordion title="Propagation Methods">
+  <AccordionItem title="By Seed (Recommended)">
+    Collect brown, mature pods from tree or ground (February-May). Extract seeds
+    and store dry — seeds are orthodox and remain viable for months. **Seed
+    scarification is essential**: pour boiling water over seeds and soak for
+    12-24 hours, or mechanically nick the seed coat with a file. Without
+    scarification, germination rates are below 20%; with treatment, rates reach
+    **60-85%**. Plant 1-2 cm deep in well-drained nursery soil. Germination
+    occurs in **7-14 days**. Seedlings grow moderately fast, reaching 30-50 cm
+    in the first year. Transplant to field at the start of the rainy season
+    (May-June) when seedlings are 30-60 cm tall.
+  </AccordionItem>
+  <AccordionItem title="By Coppice and Stump Sprouts">
+    Carboncillo coppices vigorously — cut stumps produce multiple new stems
+    within weeks during the rainy season. This trait makes it excellent for
+    sustainable firewood and charcoal production: trees can be harvested on a
+    5-8 year rotation cycle without killing the root system. For living fences,
+    large stakes (50-80 cm long, 3-5 cm diameter) can be planted directly in
+    moist soil at the start of the rains, though success rates are lower than
+    for seed propagation (30-50%).
+  </AccordionItem>
+  <AccordionItem title="Natural Regeneration via Cattle">
+    The most cost-effective "propagation" method is simply cattle-mediated
+    dispersal. When cattle consume pods and deposit scarified seeds in dung
+    piles, germination rates are naturally high and seedlings benefit from the
+    nutrient- rich microsite. Protecting young seedlings from overgrazing (using
+    temporary exclusion cages or reducing stocking density) allows natural
+    regeneration to establish dense Carboncillo stands in pastures at zero cost.
+  </AccordionItem>
+</Accordion>
+
+### Cultivation Requirements
 
 <DataTable
   headers={["Factor", "Requirement", "Notes"]}
-  rows={[
-    ["Climate", "Tropical dry", "Needs distinct dry season"],
-    ["Temperature", "22-35°C (72-95°F)", "Heat tolerant"],
-    ["Rainfall", "800-1800mm annually", "Drought tolerant"],
-    ["Soil", "Various, well-drained", "Tolerates poor soils"],
-    ["Light", "Full sun", "Needs open conditions"],
-    ["Propagation", "Seeds", "Scarify for best germination"],
+  data={[
+    [
+      "Sunlight",
+      "Full sun essential",
+      "Shade intolerant; do not plant under canopy",
+    ],
+    [
+      "Water",
+      "Low once established",
+      "Adapted to 5-6 month drought; no irrigation needed",
+    ],
+    [
+      "Soil",
+      "Well-drained, any fertility",
+      "Tolerates poor, rocky, degraded substrates",
+    ],
+    [
+      "Growth rate",
+      "Moderate (0.5-1.5 m/yr)",
+      "Faster in good soil; slower on degraded sites",
+    ],
+    [
+      "Spacing",
+      "5-8 m (forestry); 2-3 m (fences)",
+      "Thorny habit requires cautious spacing",
+    ],
+    [
+      "Pruning",
+      "Tolerates heavy pruning",
+      "Coppices vigorously; prune for fence maintenance",
+    ],
+    ["USDA zones", "10-12 (tropical)", "Not frost tolerant"],
   ]}
 />
 
-<TwoColumn>
-<Column>
+### Landscaping Uses
 
-#### Planting Uses
+**Excellent for**: Silvopastoral systems, living fences and property boundaries, dry forest restoration on degraded pastures, firewood/charcoal plantations on marginal land, erosion control on slopes, pollinator and wildlife habitat.
 
-- Living fences
-- Silvopastoral systems
-- Dry forest restoration
-- Firewood plantations
-- Soil improvement
-- Erosion control
-
-</Column>
-<Column>
-
-#### Management Notes
-
-- Coppices well
-- Can become thorny thicket
-- Control if invasive concerns
-- Prune for fence maintenance
-- Protect from overgrazing
-- Allow pod development
-
-</Column>
-</TwoColumn>
+**Considerations**: Paired thorns make this tree unsuitable near playgrounds, walkways, or high-traffic areas. Deciduous habit means bare branches during the dry season. Can form dense thickets if not managed — regular pruning maintains desired form. Pod drop attracts cattle, which may damage fencing or garden areas.
 
 ---
 
-## Interesting Facts
-
-<Accordion>
-<AccordionItem title="🔥 The Blacksmith's Choice">
-
-Before modern fuels, Carboncillo charcoal was prized by blacksmiths throughout
-Central America. Its high heat and long burn time made it ideal for forging
-iron and steel. The Spanish colonizers quickly recognized its value, and
-charcoal production became an important colonial industry in Guanacaste.
-
-</AccordionItem>
-<AccordionItem title="🐄 Drought Insurance">
-
-Ranchers in Guanacaste call Carboncillo "seguro de sequía" (drought
-insurance). When the long dry season withers all grasses, cattle can survive
-on fallen Carboncillo pods and leaves. Trees are deliberately left in
-pastures precisely for this emergency food supply—traditional ecological
-knowledge proven over centuries.
-
-</AccordionItem>
-<AccordionItem title="🦠 Underground Partners">
-
-Like other legumes, Carboncillo partners with Rhizobium bacteria in root
-nodules to convert atmospheric nitrogen into plant-usable form. A single tree
-can add 20-50 kg of nitrogen to the soil annually—free fertilizer that
-benefits surrounding grasses and other plants.
-
-</AccordionItem>
-<AccordionItem title="🌳 Acacia Confusion">
-
-The genus Acacia has been split by taxonomists, with New World species often
-moved to Vachellia or Senegalia. You may see this tree listed as Vachellia
-pennatula in recent references. However, many local sources still use the
-traditional Acacia name, creating some confusion in identification.
-
-</AccordionItem>
-</Accordion>
-
----
-
-## Related Species
+## Similar Species
 
 <DataTable
-  headers={["Species", "Common Name", "Difference"]}
-  rows={[
-    ["Acacia collinsii", "Cornizuelo", "Hollow thorns with ants"],
-    ["Acacia farnesiana", "Aromo", "More fragrant flowers"],
-    ["Senna atomaria", "Vainillo", "Different flowers, no thorns"],
-    ["Enterolobium cyclocarpum", "Guanacaste", "Much larger, ear-shaped pods"],
+  headers={[
+    "Feature",
+    "V. pennatula (Carboncillo)",
+    "A. collinsii (Cornizuelo)",
+    "A. farnesiana (Aromo)",
+    "Leucaena leucocephala",
+  ]}
+  data={[
+    ["Height", "8-15 m", "4-10 m", "3-8 m", "5-15 m"],
+    [
+      "Spines",
+      "Paired, straight, 1-4 cm",
+      "Hollow, swollen, with ants",
+      "Paired, straight, 1-3 cm",
+      "None or small",
+    ],
+    [
+      "Leaflets",
+      "Tiny, 20-50 pairs/pinna",
+      "Small, 10-20 pairs/pinna",
+      "Small, 10-25 pairs/pinna",
+      "Moderate, 10-20 pairs/pinna",
+    ],
+    [
+      "Flowers",
+      "Globular, cream-white",
+      "Globular, yellow",
+      "Globular, golden yellow",
+      "Globular, white",
+    ],
+    [
+      "Pods",
+      "Flat, 10-15 cm, brown",
+      "Cylindrical, 5-8 cm",
+      "Round, 3-7 cm, black",
+      "Flat, 10-18 cm",
+    ],
+    ["Ant symbiosis", "No", "Yes (Pseudomyrmex)", "No", "No"],
+    ["Native status", "Native", "Native", "Native", "Introduced (invasive)"],
   ]}
 />
 
 ---
 
-## References and Resources
+## External Resources
 
-<DataTable
-  headers={["Resource", "Type", "Link"]}
-  rows={[
-    [
-      "iNaturalist",
-      "Observations",
-      "https://www.inaturalist.org/taxa/564932-Acacia-pennatula",
-    ],
-    ["GBIF", "Distribution Data", "https://www.gbif.org/species/2978509"],
-    [
-      "Tropicos",
-      "Botanical Database",
-      "https://www.tropicos.org/name/13048074",
-    ],
-  ]}
-/>
+<ExternalLinksGrid>
+  <ExternalLink
+    title="iNaturalist — Vachellia pennatula"
+    url="https://www.inaturalist.org/taxa/349260-Vachellia-pennatula"
+    description="Community observations and photos from Costa Rica and Mesoamerica"
+  />
+  <ExternalLink
+    title="GBIF — Distribution Data"
+    url="https://www.gbif.org/species/2978509"
+    description="Global distribution records and specimen data"
+  />
+  <ExternalLink
+    title="Tropicos — Missouri Botanical Garden"
+    url="https://www.tropicos.org/name/13048074"
+    description="Nomenclatural records and synonymy"
+  />
+  <ExternalLink
+    title="Plants of the World Online — Kew"
+    url="https://powo.science.kew.org/"
+    description="Accepted name, synonyms, and distribution data"
+  />
+  <ExternalLink
+    title="Área de Conservación Guanacaste"
+    url="https://www.acguanacaste.ac.cr/"
+    description="Dry forest restoration programs using native species"
+  />
+  <ExternalLink
+    title="IUCN Red List"
+    url="https://www.iucnredlist.org/"
+    description="Conservation status assessment"
+  />
+</ExternalLinksGrid>
+
+---
+
+## References
+
+1. Janzen, D.H. (1988). Tropical dry forests: the most endangered major tropical ecosystem. In E.O. Wilson (ed.), _Biodiversity_, pp. 130-137. National Academy Press, Washington, DC.
+
+2. LPWG (Legume Phylogeny Working Group). (2017). A new subfamily classification of the Leguminosae based on a taxonomically comprehensive phylogeny. _Taxon_ 66(1): 44-77.
+
+3. Maslin, B.R. (2008). Generic and subgeneric names in Acacia following retypification of the genus. _Muelleria_ 26(1): 7-9.
+
+4. Smith, G.F. & Figueiredo, E. (2011). Conserving _Acacia_ Mill. with a conserved type: What happened in Melbourne? _Taxon_ 60(5): 1504-1506.
+
+5. Jiménez, Q. (1999). _Árboles maderables de Costa Rica: ecología y silvicultura_. Instituto Nacional de Biodiversidad (INBio), Santo Domingo de Heredia, Costa Rica.
+
+6. Pezo, D. & Ibrahim, M. (1999). _Sistemas silvopastoriles_. CATIE, Turrialba, Costa Rica.
+
+7. Sprent, J.I. (2009). _Legume Nodulation: A Global Perspective_. Wiley-Blackwell, Oxford.
+
+8. Standley, P.C. & Steyermark, J.A. (1946). Flora of Guatemala. _Fieldiana: Botany_ 24(4).
+
+9. Hammel, B.E., Grayum, M.H., Herrera, C., & Zamora, N. (eds.) (2003-2015). _Manual de Plantas de Costa Rica_ (Volumes I-VIII). Missouri Botanical Garden Press.

--- a/content/trees/es/carboncillo.mdx
+++ b/content/trees/es/carboncillo.mdx
@@ -39,7 +39,7 @@ fruitingSeason:
   - "may"
 featuredImage: "/images/trees/carboncillo.jpg"
 publishedAt: "2024-12-20"
-updatedAt: "2026-01-11"
+updatedAt: "2026-01-14"
 # Información de Seguridad
 toxicityLevel: "low"
 toxicParts:
@@ -56,15 +56,16 @@ skinContactDetails: "Las espinas pueden causar heridas punzantes. Manejar con cu
 safetyNotes: "ESPINAS AFILADAS en las ramas—precaución al manipular o cerca de niños. Ampliamente utilizado como forraje para ganado con buen registro de seguridad. Las semillas de leguminosas en la familia Fabaceae a menudo contienen alcaloides leves—evitar consumir semillas crudas. Precauciones estándar de aserrín. Por lo demás, árbol nativo seguro para reforestación y agroforestería."
 ---
 
-# Carboncillo (Acacia de Hojas Plumosas)
+# Carboncillo
 
-<Callout type="success" title="El Árbol del Carbón">
-  El **Carboncillo** (_Acacia pennatula_) obtiene su nombre de "carbón"—este
-  pequeño árbol produce uno de los mejores carbones de América Central. Más allá
-  del combustible, es un caballo de batalla de los sistemas silvopastoriles del
-  bosque seco de Guanacaste: fijando nitrógeno, alimentando ganado durante la
-  sequía, proporcionando cercas vivas, y definiendo la silueta espinosa del
-  "Oeste Salvaje" de Costa Rica.
+<Callout type="success" title="El Árbol del Carbón de Guanacaste">
+  El **Carboncillo** (_Acacia pennatula_) toma su nombre de "carbón" — este
+  árbol pequeño pero resistente produce uno de los mejores carbones de América
+  Central. Más allá del combustible, es un caballo de batalla de los sistemas
+  silvopastoriles del bosque seco de Guanacaste: fijando nitrógeno atmosférico,
+  alimentando ganado durante sequías brutales, proporcionando cercas vivas
+  espinosas, y definiendo la silueta espinosa de las tierras bajas pastoriles de
+  Costa Rica. Donde los pastos fallan, el Carboncillo perdura.
 </Callout>
 
 <TwoColumn>
@@ -78,7 +79,9 @@ safetyNotes: "ESPINAS AFILADAS en las ramas—precaución al manipular o cerca d
     { label: "Altura Máxima", value: "8-15 m" },
     { label: "Extensión de Copa", value: "6-10 m" },
     { label: "Conservación", value: "Preocupación Menor" },
-    { label: "Conocido Por", value: "Carbón, forraje" },
+    { label: "Floración", value: "Diciembre-Marzo" },
+    { label: "Fructificación", value: "Febrero-Mayo" },
+    { label: "Rasgos clave", value: "Fija N₂, espinas, carbón" },
   ]}
 />
 
@@ -101,40 +104,40 @@ safetyNotes: "ESPINAS AFILADAS en las ramas—precaución al manipular o cerca d
 <ImageGallery>
   <ImageCard
     src="https://inaturalist-open-data.s3.amazonaws.com/photos/153983689/medium.jpg"
-    alt="Acacia pennatula - Whole tree"
-    title="Whole tree"
+    alt="Acacia pennatula - Árbol completo en potrero seco"
+    title="Árbol completo"
     credit="(c) Sune Holt, some rights reserved (CC BY-NC)"
     license="CC BY-NC"
     sourceUrl="https://www.inaturalist.org/taxa/349260-Vachellia-pennatula/browse_photos"
   />
   <ImageCard
     src="https://inaturalist-open-data.s3.amazonaws.com/photos/153983682/medium.jpg"
-    alt="Acacia pennatula - Leaves"
-    title="Leaves"
+    alt="Acacia pennatula - Hojas bipinnadas plumosas"
+    title="Hojas plumosas"
     credit="(c) Sune Holt, some rights reserved (CC BY-NC)"
     license="CC BY-NC"
     sourceUrl="https://www.inaturalist.org/taxa/349260-Vachellia-pennatula/browse_photos"
   />
   <ImageCard
     src="https://inaturalist-open-data.s3.amazonaws.com/photos/153983676/medium.jpg"
-    alt="Acacia pennatula - Habitat"
-    title="Habitat"
+    alt="Acacia pennatula - Hábitat de bosque seco"
+    title="Hábitat de bosque seco"
     credit="no rights reserved"
     license="CC BY-NC"
     sourceUrl="https://www.inaturalist.org/taxa/349260-Vachellia-pennatula/browse_photos"
   />
   <ImageCard
     src="https://inaturalist-open-data.s3.amazonaws.com/photos/153983177/medium.jpg"
-    alt="Acacia pennatula - Whole tree"
-    title="Whole tree"
+    alt="Acacia pennatula - Silueta de árbol maduro"
+    title="Árbol maduro"
     credit="(c) María Eugenia Mendiola González, some rights reserved (CC BY-NC-SA)"
     license="CC BY-NC"
     sourceUrl="https://www.inaturalist.org/taxa/349260-Vachellia-pennatula/browse_photos"
   />
   <ImageCard
     src="https://inaturalist-open-data.s3.amazonaws.com/photos/133896070/medium.jpeg"
-    alt="Acacia pennatula - Leaves"
-    title="Leaves"
+    alt="Acacia pennatula - Detalle de hojas"
+    title="Detalle de hojas"
     credit="(c) Sune Holt, some rights reserved (CC BY-NC)"
     license="CC BY-NC"
     sourceUrl="https://www.inaturalist.org/taxa/349260-Vachellia-pennatula/browse_photos"
@@ -152,41 +155,79 @@ safetyNotes: "ESPINAS AFILADAS en las ramas—precaución al manipular o cerca d
 ## Taxonomía y Clasificación
 
 <PropertiesGrid>
-  <PropertyCard title="Reino" value="Plantae" />
-  <PropertyCard title="Clado" value="Angiospermas" />
-  <PropertyCard title="Clado" value="Eudicotiledóneas" />
-  <PropertyCard title="Orden" value="Fabales" />
-  <PropertyCard title="Familia" value="Fabaceae" />
-  <PropertyCard title="Género" value="Acacia" />
-  <PropertyCard title="Especie" value="A. pennatula" />
+  <PropertyCard icon="👑" label="Reino" value="Plantae" />
+  <PropertyCard
+    icon="🌸"
+    label="Clado"
+    value="Angiospermas / Eudicots / Rósidas"
+  />
+  <PropertyCard icon="🌿" label="Orden" value="Fabales" />
+  <PropertyCard icon="🪴" label="Familia" value="Fabaceae" />
+  <PropertyCard icon="🔬" label="Subfamilia" value="Caesalpinioideae" />
+  <PropertyCard icon="🌳" label="Género" value="Vachellia (antes Acacia)" />
+  <PropertyCard icon="📋" label="Especie" value="V. pennatula" />
+  <PropertyCard
+    icon="✍️"
+    label="Autoridad"
+    value="(Schltdl. & Cham.) Seigler & Ebinger"
+  />
 </PropertiesGrid>
-
-<Callout type="info" title="Origen de los Nombres">
-  - **Acacia**: Del griego "akantha" que significa espina - **pennatula**: Latín
-  que significa "pequeña pluma" - describe las delicadas hojas compuestas -
-  **Carboncillo**: Diminutivo español de "carbón" - Nota taxonómica: Puede ser
-  clasificada como Vachellia pennatula por algunas autoridades
-</Callout>
 
 ### Nombres Comunes
 
 <DataTable
   headers={["Idioma/Región", "Nombre(s) Común(es)", "Significado"]}
-  rows={[
+  data={[
     ["Inglés", "Feather-leaved Acacia", "Apariencia de las hojas"],
     ["Español (Costa Rica)", "Carboncillo, Carbonero", "Árbol del carbón"],
-    ["Español (México)", "Tepame, Huizache", "Nombres regionales"],
+    ["Español (México)", "Tepame, Huizache", "Nombres indígenas"],
     ["Español (Guatemala)", "Espino, Subin", "Árbol espinoso"],
+    ["Español (Honduras)", "Carbón, Carbonero", "Carbón"],
   ]}
 />
 
+### La Reclasificación de Acacia
+
+<Accordion title="Historia Taxonómica">
+  <AccordionItem title="Las 'Guerras de las Acacias'">
+    El género _Acacia_ fue una vez uno de los géneros de árboles más grandes del
+    mundo, con más de 1.300 especies en África, Australia y las Américas. En
+    2005, una decisión controvertida en el Congreso Internacional de Botánica en
+    Viena "retipificó" el nombre _Acacia_ para aplicarlo a las especies
+    australianas (antes _Racosperma_), quitándolo de las aproximadamente 200
+    especies africanas y americanas que habían llevado el nombre durante más de
+    250 años. Esta decisión — confirmada en el Congreso de Melbourne en 2011 —
+    significa que el género del Carboncillo fue oficialmente cambiado de
+    _Acacia_ a _Vachellia_. Muchas referencias locales y regionales aún usan el
+    nombre tradicional _Acacia pennatula_, creando confusión continua. Esta guía
+    usa _Acacia_ en el nombre común por familiaridad mientras nota _Vachellia_
+    como la clasificación científica aceptada.
+  </AccordionItem>
+  <AccordionItem title="Ubicación en Subfamilia">
+    Como otras leguminosas mimosoideas, el Carboncillo fue tradicionalmente
+    ubicado en la subfamilia Mimosoideae. La reclasificación del LPWG (Grupo de
+    Trabajo en Filogenia de Leguminosas) de 2017 fusionó Mimosoideae en una
+    Caesalpinioideae ampliamente definida, ubicando a _Vachellia_ en el clado
+    mimosoidea dentro de Caesalpinioideae con base en evidencia filogenética
+    molecular. La especie permanece como un mimosoidea clásico en morfología —
+    con cabezuelas florales globulares, hojas bipinnadas y espinas estipulares —
+    independientemente de su asignación formal de subfamilia.
+  </AccordionItem>
+</Accordion>
+
+### Etimología
+
+- **Acacia / Vachellia**: _Acacia_ del griego _akantha_ (espina); _Vachellia_ honra a George Harvey Vachell (1799-1839), clérigo y colector de plantas británico en China
+- **pennatula**: Latín para "pequeña pluma" — describiendo las hojas compuestas delicadas y finamente divididas
+- **Carboncillo**: Diminutivo español de _carbón_ — "arbolito del carbón," reflejando su uso principal como combustible
+
 ---
 
-## Descripción Física
+## Descripción Física y Botánica
 
 ### Forma General
 
-El Carboncillo es un árbol pequeño a mediano deciduo con un tronco a menudo torcido y copa extendida, a veces en forma de sombrilla. Las ramas están armadas con espinas pareadas en la base de las hojas—una característica de muchas acacias. Durante la estación seca, pierde sus hojas, revelando la estructura angular de las ramas.
+El Carboncillo es un **árbol pequeño a mediano deciduo** que alcanza **8-15 metros** de altura con un diámetro de tronco de **20-40 cm** a la altura del pecho. El tronco es a menudo torcido o inclinado, y la copa es **irregularmente extendida, a veces en forma de sombrilla** — una silueta inmediatamente reconocible en los potreros abiertos de Guanacaste. Las ramas están armadas con **espinas estipulares pareadas** en la base de cada hoja — una adaptación defensiva compartida con muchas otras especies de _Vachellia_.
 
 <StatsGroup>
   <StatBar label="Altura Madura" value={12} max={15} unit="metros" />
@@ -195,147 +236,98 @@ El Carboncillo es un árbol pequeño a mediano deciduo con un tronco a menudo to
   <StatBar label="Largo de Espinas" value={2} max={4} unit="cm" />
 </StatsGroup>
 
-### Características Distintivas
+### Corteza y Madera
 
-<TwoColumn>
-<Column>
+**Corteza**: Gris oscuro a marrón, volviéndose **rugosa y profundamente fisurada** con la edad. Contiene niveles moderados de taninos que contribuyen a la resistencia contra plagas.
 
-#### Hojas
+**Madera**: Notablemente **densa y dura** para un árbol tan pequeño — gravedad específica 0,65-0,80 — que es precisamente lo que la hace excepcional para carbón. La alta densidad resulta del crecimiento lento en condiciones de suelos pobres y estación seca, y produce madera con valor calorífico superior (aproximadamente 7.000-7.500 kcal/kg como carbón). El duramen es marrón oscuro, de grano fino y naturalmente resistente a la descomposición.
 
-- **Tipo**: Bipinnadas (dos veces compuestas)
-- **Pinnas**: 8-25 pares
-- **Folíolos**: Diminutos, numerosos (20-50 pares)
-- **Apariencia**: Plumosa, delicada
-- **Tamaño**: 10-20 cm de largo total
-- **Época**: Caducifolia en estación seca
+### Hojas
 
-#### Corteza y Espinas
+<PropertiesGrid>
+  <PropertyCard
+    icon="🍃"
+    label="Tipo"
+    value="Bipinnadas (dos veces compuestas)"
+  />
+  <PropertyCard icon="📏" label="Longitud" value="10-20 cm total" />
+  <PropertyCard icon="🔢" label="Pinnas" value="8-25 pares" />
+  <PropertyCard icon="🌿" label="Folíolos" value="20-50 pares por pinna" />
+</PropertiesGrid>
 
-- **Color de Corteza**: Gris oscuro a marrón
-- **Textura**: Rugosa, fisurada
-- **Espinas**: Pareadas, en bases de hojas
-- **Largo de Espinas**: 1-4 cm
-- **Madera**: Densa, dura
-- **Buena para**: Excelente carbón
+Las hojas están entre las más **finamente divididas** de cualquier árbol costarricense — la "pluma" de _pennatula_. Cada hoja bipinnada porta 8-25 pares de pinnas, con cada pinna llevando 20-50 pares de folíolos diminutos (3-6 mm de largo). Esta división extremadamente fina crea una **apariencia delicada, como de encaje** que contrasta dramáticamente con las feroces espinas del árbol. Las hojas son deciduas, cayendo durante la estación seca (diciembre-abril) y re-emergiendo rápidamente con las primeras lluvias.
 
-</Column>
-<Column>
+### Flores
 
-#### Flores
+<PropertiesGrid>
+  <PropertyCard
+    icon="🌸"
+    label="Color"
+    value="Blanco cremoso a amarillo pálido"
+  />
+  <PropertyCard
+    icon="📏"
+    label="Tamaño"
+    value="Cabezuelas globulares, 1-1,5 cm"
+  />
+  <PropertyCard
+    icon="📅"
+    label="Temporada"
+    value="Diciembre-Marzo (estación seca)"
+  />
+  <PropertyCard
+    icon="🐝"
+    label="Polinizadores"
+    value="Abejas, escarabajos, mariposas"
+  />
+</PropertiesGrid>
 
-- **Tipo**: Cabezuelas globulares (mimosoide)
-- **Color**: Blanco cremoso a amarillo pálido
-- **Tamaño**: 1-1.5 cm de diámetro
-- **Disposición**: Racimos desde las ramas
-- **Fragancia**: Dulce, atrae abejas
-- **Época**: Final de estación seca
+Las flores son pequeñas individualmente pero se agregan en **cabezuelas globulares densas** (1-1,5 cm de diámetro) típicas del clado mimosoidea. Los numerosos estambres sobresalientes dan a cada cabezuela una apariencia suave de "borla". La fragancia dulce, como de miel, atrae un amplio rango de polinizadores incluyendo abejas nativas sin aguijón (_Trigona_, _Tetragonisca_), abejas melíferas, escarabajos y mariposas pequeñas. La floración ocurre durante la estación seca (diciembre-marzo), frecuentemente en ramas sin hojas.
 
-#### Frutos (Vainas)
+### Fruto y Semillas
 
-- **Tipo**: Vaina de leguminosa
-- **Tamaño**: 10-15 cm de largo
-- **Color**: Marrón cuando madura
-- **Semillas**: Varias por vaina
-- **Valor**: Excelente forraje para ganado
-- **Época**: Final de estación seca
+**Vainas**: Legumbres de **10-15 cm de largo** y 1,5-2 cm de ancho, rectas a ligeramente curvadas, volviéndose **marrón oscuro y correosas** al madurar. Las vainas son indehiscentes (no se abren naturalmente), requiriendo digestión animal o quiebre físico para liberar las semillas.
 
-</Column>
-</TwoColumn>
+**Semillas**: 6-12 por vaina, **de cubierta dura y ovaladas**, marrón oscuro. Las semillas son ortodoxas (pueden almacenarse secas) y requieren escarificación para germinación confiable. Las vainas son notablemente **ricas en proteína** (12-18% de proteína cruda), haciéndolas excelente forraje para ganado.
 
----
-
-## El Árbol Perfecto para Carbón
-
-### Producción Tradicional de Combustible
-
-<Callout type="success" title="Carbón Premium">
-  El Carboncillo ha sido apreciado durante siglos por su excepcional carbón. La
-  madera densa y dura arde caliente y por largo tiempo, produciendo carbón que
-  fue históricamente preferido para herrería, cocina, e incluso producción de
-  pólvora. Aunque menos común hoy, algunas comunidades rurales aún producen
-  "carbón de carboncillo" usando métodos tradicionales de fosa en tierra.
-</Callout>
-
-<TwoColumn>
-<Column>
-
-#### Propiedades del Carbón
-
-- Muy alto rendimiento de calor
-- Largo tiempo de combustión
-- Baja producción de humo
-- Carbón denso, pesado
-- Excelente para trabajo de metal
-- Combustible tradicional para cocinar
-
-</Column>
-<Column>
-
-#### Consideraciones Modernas
-
-- Se necesita cosecha sostenible
-- Regeneración por rebrote
-- Combustibles alternativos disponibles
-- Valor de patrimonio cultural
-- Producción a pequeña escala continúa
-- Preservación de conocimiento tradicional
-
-</Column>
-</TwoColumn>
+**Dispersión**: El principal agente dispersor es el **ganado** — el ganado consume las vainas nutritivas y pasa las semillas de cubierta dura intactas a través de su tracto digestivo, depositándolas en montones fértiles de estiércol a través del paisaje. Esta dispersión mediada por ganado explica por qué el Carboncillo es tan abundante en potreros activos — el árbol y el sistema ganadero co-evolucionaron una relación mutuamente beneficiosa.
 
 ---
 
-## Valor Silvopastoril
+## Distribución Geográfica
 
-### Manejo de Ganado y Paisaje
-
-<Callout type="info" title="Aliado del Ganadero">
-  En la ganadería extensiva de Guanacaste, el Carboncillo es valorado por
-  múltiples razones. Sus vainas y hojas ricas en proteína proporcionan forraje
-  crucial durante la dura estación seca cuando los pastos fallan. Como
-  leguminosa, fija nitrógeno atmosférico en el suelo, mejorando la productividad
-  del potrero. Y sus ramas espinosas hacen cercas vivas efectivas.
-</Callout>
-
-### Múltiples Usos en Sistemas Pastoriles
-
-<DataTable
-  headers={["Uso", "Parte Usada", "Beneficio"]}
-  rows={[
-    [
-      "Forraje para ganado",
-      "Vainas, hojas",
-      "Alimento rico en proteína para estación seca",
-    ],
-    ["Cerca viva", "Árbol completo", "Barrera espinosa, postes de cerca"],
-    [
-      "Fijación de nitrógeno",
-      "Nódulos de raíz",
-      "Mejora de fertilidad del suelo",
-    ],
-    ["Sombra", "Copa", "Reduce estrés por calor en ganado"],
-    ["Leña", "Ramas", "Excelente madera combustible"],
-    ["Carbón", "Madera del tronco", "Combustible de alta calidad para cocinar"],
-  ]}
+<DistributionMap
+  distributions={["guanacaste", "puntarenas", "alajuela", "san-jose"]}
 />
 
----
+<PropertiesGrid>
+  <PropertyCard icon="🌎" label="Rango" value="México a Costa Rica" />
+  <PropertyCard
+    icon="🇨🇷"
+    label="Costa Rica"
+    value="Zona de bosque seco del Pacífico"
+  />
+  <PropertyCard icon="⛰️" label="Elevación" value="0-1.200 m" />
+  <PropertyCard icon="🌡️" label="Clima" value="Tropical seco a semi-seco" />
+</PropertiesGrid>
 
-## Distribución en Costa Rica
+<FeatureBox title="Un Árbol Moldeado por la Ganadería" icon="🐄">
+  La distribución del Carboncillo en Costa Rica cuenta la historia de 500 años
+  de ganadería. A diferencia de la mayoría de los árboles nativos que declinaron
+  con la deforestación, el Carboncillo en realidad _expandió_ su rango cuando
+  los bosques fueron talados para pasturas. El ganado come las vainas ricas en
+  proteína y dispersa las semillas duras en su estiércol, efectivamente
+  plantando Carboncillo donde sea que pastoreen. Hoy, el Carboncillo es más
+  abundante en el Guanacaste agrícola de lo que fue en el bosque seco intacto
+  precolombino — uno de los pocos árboles nativos que prosperó junto a, más que
+  a pesar de, la industria ganadera.
+</FeatureBox>
 
-<Callout type="info" title="Dónde Encontrarlo">
-  El Carboncillo es característico de la región del bosque seco del Pacífico de
-  Costa Rica, particularmente la provincia de Guanacaste. Búsquelo en potreros,
-  a lo largo de cercas, en bosque seco secundario y en laderas. Es especialmente
-  común en los paisajes agrícolas entre parches de bosque remanente, donde a
-  menudo es deliberadamente dejado por los ganaderos.
-</Callout>
-
-### Distribución Regional
+### Distribución en Costa Rica
 
 <DataTable
   headers={["Ubicación", "Provincia", "Entorno", "Abundancia"]}
-  rows={[
+  data={[
     [
       "Tierras bajas de Guanacaste",
       "Guanacaste",
@@ -345,175 +337,481 @@ El Carboncillo es un árbol pequeño a mediano deciduo con un tronco a menudo to
     ["Península de Nicoya", "Guanacaste", "Laderas secas", "Común"],
     ["Cuenca del Tempisque", "Guanacaste", "Áreas agrícolas", "Abundante"],
     ["Norte de Puntarenas", "Puntarenas", "Zonas secas", "Moderado"],
-    ["Valle Central (seco)", "Alajuela", "Laderas occidentales", "Ocasional"],
+    [
+      "Valle Central (seco)",
+      "Alajuela/San José",
+      "Laderas occidentales",
+      "Ocasional",
+    ],
   ]}
 />
 
+La especie es nativa desde el sur de México (Guerrero, Oaxaca, Chiapas) a través de Guatemala, El Salvador, Honduras y Nicaragua hasta Costa Rica, alcanzando su límite sur en las tierras bajas del Pacífico.
+
+### Dónde Ver el Carboncillo
+
+- **Cuenca del río Tempisque** — Abundante en potreros de ganado; buscar la silueta espinosa contra el cielo
+- **Parque Nacional Palo Verde** — Bordes de bosque y transiciones entre humedales y bosque seco
+- **Corredor Santa Cruz-Nicoya** — A lo largo de cercas y en paisajes silvopastoriles
+- **Parque Nacional Santa Rosa** — Bosque seco secundario y áreas de potreros restaurados
+- **Ruta 1 (Interamericana por Guanacaste)** — Visible desde la carretera en potreros al borde del camino
+
 ---
 
-## Rol Ecológico
+## Producción de Carbón
 
-### Ecosistema del Bosque Seco
-
-<TwoColumn>
-<Column>
-
-#### Funciones Ecosistémicas
-
-- Fijación de nitrógeno
-- Mejora del suelo
-- Control de erosión
-- Refugio para fauna
-- Apoyo a polinizadores
-- Contribuidor al banco de semillas
-
-</Column>
-<Column>
-
-#### Interacciones con Fauna
-
-- Abejas atraídas a las flores
-- Ganado dispersa semillas
-- Aves anidan en ramas
-- Pequeños mamíferos usan cobertura
-- Venados ramonean hojas
-- Insectos en corteza
-
-</Column>
-</TwoColumn>
-
-### Pionera y Recuperación
-
-<Callout type="success" title="Potencial de Restauración">
-  El Carboncillo coloniza fácilmente áreas perturbadas en la zona del bosque
-  seco. Su capacidad de fijar nitrógeno lo hace valioso para restaurar potreros
-  degradados y preparar el suelo para otras especies. Al manejar bosque seco
-  secundario, permitir que el Carboncillo crezca puede acelerar la sucesión.
+<Callout type="success" title="Carbón Premium">
+  La madera de Carboncillo produce carbón de **calidad excepcional** — denso, de
+  combustión prolongada y bajo humo. Durante siglos fue el combustible preferido
+  para herrería, cocina e incluso producción de pólvora en toda Mesoamérica. El
+  método tradicional de horno de fosa en tierra, aún practicado en algunas
+  comunidades rurales, representa patrimonio cultural vivo.
 </Callout>
 
----
-
-## Información de Cultivo
-
-### Cultivo
+### Por Qué el Carboncillo Hace Carbón Superior
 
 <DataTable
-  headers={["Factor", "Requisito", "Notas"]}
-  rows={[
-    ["Clima", "Tropical seco", "Necesita estación seca marcada"],
-    ["Temperatura", "22-35°C", "Tolerante al calor"],
-    ["Precipitación", "800-1800mm anuales", "Tolerante a sequía"],
-    ["Suelo", "Varios, bien drenado", "Tolera suelos pobres"],
-    ["Luz", "Sol pleno", "Necesita condiciones abiertas"],
-    ["Propagación", "Semillas", "Escarificar para mejor germinación"],
+  headers={[
+    "Propiedad",
+    "Carbón de Carboncillo",
+    "Carbón Típico de Madera Tropical",
+  ]}
+  data={[
+    ["Valor calorífico", "~7.000-7.500 kcal/kg", "~5.500-6.500 kcal/kg"],
+    ["Duración de combustión", "Muy larga (4-6 horas)", "Moderada (2-3 horas)"],
+    ["Producción de humo", "Muy baja", "Moderada a alta"],
+    ["Carbono fijo", "~75-85%", "~60-75%"],
+    ["Densidad", "Piezas densas y pesadas", "Ligera a moderada"],
+    ["Chispas/chasquidos", "Mínimos", "Variable"],
   ]}
 />
 
-<TwoColumn>
-<Column>
+La calidad superior proviene de la **alta densidad** de la madera (gravedad específica 0,65-0,80) y **bajo contenido de humedad** al momento de la cosecha (el árbol es deciduo, y la madera se cosecha típicamente durante la estación seca). La carbonización tradicional usa hornos de fosa en tierra (_hornos de tierra_) donde la madera apilada se cubre con tierra y se carboniza lentamente a 400-500°C durante 2-3 días. La pirólisis controlada y lenta produce carbón con alto contenido de carbono fijo y mínimos compuestos volátiles — de ahí la combustión limpia y de bajo humo.
 
-#### Usos de Plantación
+### Producción Tradicional vs. Moderna
 
-- Cercas vivas
-- Sistemas silvopastoriles
-- Restauración de bosque seco
-- Plantaciones de leña
-- Mejora del suelo
-- Control de erosión
-
-</Column>
-<Column>
-
-#### Notas de Manejo
-
-- Rebrota bien
-- Puede formar matorral espinoso
-- Controlar si hay preocupaciones de invasividad
-- Podar para mantenimiento de cerca
-- Proteger del sobrepastoreo
-- Permitir desarrollo de vainas
-
-</Column>
-</TwoColumn>
-
----
-
-## Datos Interesantes
-
-<Accordion>
-<AccordionItem title="🔥 La Elección del Herrero">
-
-Antes de los combustibles modernos, el carbón de Carboncillo era apreciado por
-herreros en toda América Central. Su alto calor y largo tiempo de combustión
-lo hacían ideal para forjar hierro y acero. Los colonizadores españoles
-reconocieron rápidamente su valor, y la producción de carbón se convirtió en
-una importante industria colonial en Guanacaste.
-
-</AccordionItem>
-<AccordionItem title="🐄 Seguro de Sequía">
-
-Los ganaderos en Guanacaste llaman al Carboncillo "seguro de sequía". Cuando
-la larga estación seca marchita todos los pastos, el ganado puede sobrevivir
-con vainas y hojas caídas de Carboncillo. Los árboles se dejan deliberadamente
-en los potreros precisamente para este suministro de alimento de
-emergencia—conocimiento ecológico tradicional probado por siglos.
-
-</AccordionItem>
-<AccordionItem title="🦠 Socios Subterráneos">
-
-Como otras leguminosas, el Carboncillo se asocia con bacterias Rhizobium en
-nódulos de raíz para convertir nitrógeno atmosférico en forma utilizable por
-plantas. Un solo árbol puede agregar 20-50 kg de nitrógeno al suelo
-anualmente—fertilizante gratis que beneficia pastos circundantes y otras
-plantas.
-
-</AccordionItem>
-<AccordionItem title="🌳 Confusión de Acacia">
-
-El género Acacia ha sido dividido por taxonomistas, con especies del Nuevo
-Mundo a menudo movidas a Vachellia o Senegalia. Puede ver este árbol listado
-como Vachellia pennatula en referencias recientes. Sin embargo, muchas fuentes
-locales aún usan el nombre tradicional Acacia, creando algo de confusión en la
-identificación.
-
-</AccordionItem>
+<Accordion title="Métodos de Producción de Carbón">
+  <AccordionItem title="Horno de Fosa en Tierra (Tradicional)">
+    El método tradicional usado por siglos: se cava una fosa en suelo seco, se
+    llena con madera de Carboncillo apilada, y se cubre con una capa de ramas
+    verdes y tierra, dejando pequeños agujeros de aire para combustión
+    controlada. Se enciende el fuego desde un extremo y la carbonización procede
+    lentamente durante 2-3 días. Cuando el humo cambia de blanco (vapor) a azul
+    (gases combustibles), se sellan los agujeros de aire para completar la
+    carbonización sin quemar. El carbón resultante es denso, uniforme y de
+    excelente calidad. Este método convierte aproximadamente 20-25% del peso de
+    la madera en carbón.
+  </AccordionItem>
+  <AccordionItem title="Consideraciones Modernas">
+    Mientras los combustibles modernos de cocina (gas LP, electricidad) han
+    reemplazado en gran parte al carbón en la Costa Rica urbana, la producción
+    artesanal de carbón persiste en el Guanacaste rural. Algunas comunidades
+    producen _carbón de carboncillo_ para mercados locales y restaurantes que
+    prefieren el perfil de sabor de la cocina a las brasas. La producción
+    sostenible de carbón de Carboncillo es factible porque el árbol **rebrota
+    vigorosamente** — los tocones cortados producen múltiples tallos nuevos que
+    pueden cosecharse de nuevo en 5-8 años, creando un ciclo de combustible
+    renovable sin matar el sistema radicular.
+  </AccordionItem>
 </Accordion>
 
 ---
 
-## Especies Relacionadas
+## Valor Silvopastoril
+
+<FeatureBox title="El Aliado del Ganadero" icon="🌾">
+  En el sistema de ganadería extensiva de Guanacaste, pocos árboles son tan
+  útiles como el Carboncillo. Fija nitrógeno para mejorar el suelo del potrero,
+  deja caer vainas ricas en proteína que sostienen al ganado durante la sequía,
+  proporciona cercas vivas espinosas y produce leña y carbón. Los ganaderos han
+  protegido y promovido deliberadamente este árbol en sus potreros por
+  generaciones — una de las formas más antiguas de agroforestería en el
+  Neotrópico.
+</FeatureBox>
+
+### Múltiples Usos en Sistemas Pastoriles
 
 <DataTable
-  headers={["Especie", "Nombre Común", "Diferencia"]}
-  rows={[
-    ["Acacia collinsii", "Cornizuelo", "Espinas huecas con hormigas"],
-    ["Acacia farnesiana", "Aromo", "Flores más fragantes"],
-    ["Senna atomaria", "Vainillo", "Flores diferentes, sin espinas"],
+  headers={["Uso", "Parte Usada", "Beneficio"]}
+  data={[
     [
-      "Enterolobium cyclocarpum",
-      "Guanacaste",
-      "Mucho más grande, vainas en forma de oreja",
+      "Forraje para ganado",
+      "Vainas y hojas caídas",
+      "12-18% proteína cruda; alimento crítico en sequía",
+    ],
+    [
+      "Cerca viva",
+      "Árbol completo/esquejes",
+      "Barrera espinosa; ahorra alambre y madera",
+    ],
+    [
+      "Fijación de nitrógeno",
+      "Nódulos radiculares",
+      "20-50 kg N/ha/año; fertilizante gratis",
+    ],
+    ["Sombra", "Copa", "Reduce estrés por calor; mejora ganancia de peso"],
+    [
+      "Leña",
+      "Ramas, podas",
+      "Madera de alto poder calorífico; disponible de podas",
+    ],
+    [
+      "Carbón",
+      "Madera del tronco",
+      "Calidad premium; diversificación de ingresos",
+    ],
+    [
+      "Control de erosión",
+      "Sistema radicular",
+      "Estabiliza laderas en potreros ondulados",
+    ],
+  ]}
+/>
+
+### Seguro de Sequía
+
+Los ganaderos de Guanacaste llaman al Carboncillo _"seguro de sequía"_. Durante la estación seca de 5-6 meses cuando todos los pastos se marchitan, el ganado puede sobrevivir con vainas caídas de Carboncillo. El alto contenido de proteína de las vainas (12-18% de proteína cruda) y sus carbohidratos los convierten en un alimento de emergencia nutricionalmente adecuado. Los árboles se dejan deliberadamente en los potreros para este propósito — una forma de conocimiento ecológico tradicional, probado por siglos, que los científicos de ganadería moderna ahora reconocen como una estrategia silvopastoril efectiva.
+
+---
+
+## Hábitat y Ecología
+
+<PropertiesGrid>
+  <PropertyCard icon="🌡️" label="Temperatura" value="22-35°C" />
+  <PropertyCard icon="💧" label="Precipitación" value="800-1.800 mm/año" />
+  <PropertyCard icon="☀️" label="Estación Seca" value="5-6 meses" />
+  <PropertyCard
+    icon="🪨"
+    label="Suelo"
+    value="Bien drenado, cualquier fertilidad"
+  />
+</PropertiesGrid>
+
+### Roles Ecológicos
+
+<Accordion title="Funciones Ecosistémicas">
+  <AccordionItem title="Fijación Biológica de Nitrógeno">
+    El Carboncillo forma asociaciones simbióticas con bacterias fijadoras de
+    nitrógeno (principalmente especies de _Rhizobium_ y _Bradyrhizobium_)
+    alojadas en nódulos radiculares especializados. Estas bacterias convierten
+    el N₂ atmosférico en amonio (NH₄⁺) disponible para plantas, enriqueciendo el
+    suelo circundante a tasas estimadas de **20-50 kg N/ha/año** — equivalente a
+    una aplicación ligera de fertilizante comercial. En potreros agotados de
+    nutrientes, este aporte de nitrógeno mejora visiblemente el crecimiento del
+    pasto en un "halo" alrededor de la zona radicular del árbol, un fenómeno que
+    los ganaderos de Guanacaste han reconocido y explotado por generaciones.
+  </AccordionItem>
+  <AccordionItem title="Especie Pionera y Sucesión">
+    El Carboncillo es un pionero clásico que coloniza rápidamente sitios
+    perturbados — potreros abandonados, bordes de caminos, cicatrices de quema y
+    laderas erosionadas. Su tolerancia a suelos pobres, altos requerimientos de
+    luz y capacidad de fijación de nitrógeno le permiten establecerse donde
+    pocos otros árboles pueden. Con el tiempo, sus aportes de nitrógeno y
+    modificación de sombra crean condiciones favorables para especies más
+    exigentes, facilitando la sucesión forestal. En ecología de restauración, el
+    Carboncillo se usa como "árbol nodriza" para preparar sitios degradados para
+    la reforestación.
+  </AccordionItem>
+  <AccordionItem title="Ecología del Fuego">
+    El Carboncillo está bien adaptado al fuego — una característica definitoria
+    de los bosques secos tropicales. Los árboles maduros sobreviven fuegos
+    superficiales moderados gracias a su corteza gruesa, y los tocones cortados
+    o quemados rebrotan vigorosamente desde la corona de la raíz (rebrote). Las
+    semillas en el banco del suelo también responden al fuego: el calor
+    escarifica la cubierta dura de la semilla, desencadenando germinación masiva
+    en ambientes post-fuego. Esta adaptación al fuego explica por qué el
+    Carboncillo persiste en paisajes sujetos a quemas anuales de estación seca
+    para manejo de potreros.
+  </AccordionItem>
+  <AccordionItem title="Apoyo a Vida Silvestre">
+    A pesar de su pequeño tamaño, el Carboncillo sustenta vida silvestre
+    diversa. Las flores dulces con aroma a miel atraen abejas nativas sin
+    aguijón (_Trigona_, _Tetragonisca_), abejas melíferas, escarabajos y
+    mariposas durante la estación seca cuando pocos otros árboles florecen. Las
+    ramas espinosas proveen sitios de anidación protegidos para aves incluyendo
+    el Momoto Cejiturquesa (_Eumomota superciliosa_), mosqueros y soterreyes. El
+    venado cola blanca (_Odocoileus virginianus_) ramonea el follaje, y roedores
+    granívoros almacenan y dispersan semillas. La asociación del árbol con el
+    ganado también crea microhábitats — los montones de estiércol enriquecidos
+    con semillas de Carboncillo atraen escarabajos coprófagos, que mejoran aún
+    más la salud del suelo.
+  </AccordionItem>
+</Accordion>
+
+### Asociaciones Forestales
+
+El Carboncillo crece en asociación con especies características del bosque seco mesoamericano:
+
+- **Árbol de Guanacaste** (_Enterolobium cyclocarpum_) — El árbol nacional; especie co-dominante del dosel
+- **Quebracho** (_Lysiloma divaricatum_) — Otra leguminosa fijadora de nitrógeno de bosques secos
+- **Indio desnudo** (_Bursera simaruba_) — Pionero de corteza roja; hábitat compartido
+- **Cornizuelo** (_Acacia collinsii_) — Acacia de hormigas; frecuentemente confundido con Carboncillo
+- **Jícaro** (_Crescentia alata_) — Árbol de potrero con frutos como calabazas
+
+---
+
+## Estado de Conservación
+
+<Callout type="success" title="Preocupación Menor (LC)">
+  _Acacia pennatula_ (Vachellia pennatula) está evaluada como **Preocupación
+  Menor** por la Lista Roja de la UICN. La especie tiene un rango amplio en
+  Mesoamérica, poblaciones estables a crecientes, y excelente adaptación a
+  paisajes modificados por humanos. A diferencia de la mayoría de los árboles
+  nativos, el Carboncillo se ha _beneficiado_ de la deforestación y la ganadería
+  a través de su estrategia de dispersión de semillas por ganado.
+</Callout>
+
+### Paradoja de Conservación
+
+El Carboncillo presenta una paradoja de conservación: mientras su hábitat de bosque seco está entre los más amenazados de la Tierra (menos del 2% del bosque seco mesoamericano original permanece), el árbol mismo ha expandido su rango a través de su asociación con el ganado. Sin embargo, este aparente éxito enmascara preocupaciones genéticas — las poblaciones de potreros pueden representar un subconjunto genético estrecho adaptado a condiciones perturbadas, careciendo de la diversidad genética encontrada en poblaciones de bosque intacto. La conservación de fragmentos remanentes de bosque seco sigue siendo críticamente importante para mantener la herencia genética completa de esta y otras especies de bosque seco.
+
+### Prioridades de Conservación
+
+<DataTable
+  headers={["Prioridad", "Acción", "Beneficio"]}
+  data={[
+    [
+      "Alta",
+      "Proteger fragmentos remanentes de bosque seco",
+      "Preserva diversidad genética de poblaciones de bosque intacto",
+    ],
+    [
+      "Alta",
+      "Promover sistemas silvopastoriles",
+      "Integra Carboncillo en paisajes productivos",
+    ],
+    [
+      "Media",
+      "Manejo sostenible de carbón",
+      "Mantiene uso tradicional sin sobreexplotación",
+    ],
+    [
+      "Media",
+      "Manejo del fuego en potreros",
+      "Reduce daño a bosque en regeneración",
+    ],
+    [
+      "Media",
+      "Conectividad de corredores biológicos",
+      "Conecta poblaciones aisladas a través de la matriz de potreros",
     ],
   ]}
 />
 
 ---
 
-## Referencias y Recursos
+## Importancia Cultural
+
+### El Árbol del Herrero
+
+Antes de los combustibles modernos, el carbón de Carboncillo era el **combustible principal para herrería** en toda América Central. Los colonizadores españoles que llegaron a Guanacaste en el siglo XVI reconocieron rápidamente su valor — el carbón denso y de combustión caliente era ideal para forjar herramientas de hierro, herraduras y armas. La producción de carbón (_carbonería_) se convirtió en una importante industria colonial, y las habilidades fueron transmitidas de generación en generación de familias rurales. Incluso hoy, algunas familias guanacastecas se identifican como _carboneros_ — productores de carbón — manteniendo la experiencia en el método tradicional de horno de fosa como patrimonio cultural.
+
+### Paisaje Sabanero
+
+Para los _sabaneros_ (vaqueros) de Guanacaste, el Carboncillo es tan icónico como el caballo y el lazo. Su silueta espinosa contra un atardecer de estación seca es la imagen por excelencia del paisaje pastoril guanacasteco. Los ganaderos tienen una profunda apreciación pragmática por este árbol — proporcionando cercado, combustible, forraje y sombra de una sola especie. La práctica tradicional de retener selectivamente Carboncillo en los potreros representa una de las formas más antiguas de agroforestería en el Neotrópico, predatando las descripciones científicas formales por siglos.
+
+### Calendario Fenológico
+
+Las comunidades rurales usan los ritmos estacionales del Carboncillo como calendario natural. La floración en diciembre-enero señala la profundización de la estación seca y la necesidad de reservar agua. La caída de vainas en marzo-abril proporciona forraje de emergencia para el ganado durante las semanas más duras de sequía. El primer brote de hojas verdes con las lluvias tempranas de mayo señala el momento de preparar los campos para siembra — un sistema de conocimiento fenológico que conecta la agricultura con los ritmos del mundo natural.
+
+---
+
+## Cultivar Carboncillo
+
+<Callout type="warning" title="Requerimientos Climáticos">
+  El Carboncillo requiere un **clima tropical seco** con una estación seca
+  pronunciada. **No es adecuado** para condiciones del Caribe húmedo o bosques
+  nubosos de alta elevación. Rinde mejor en Guanacaste y las tierras bajas del
+  Pacífico por debajo de 1.000 m. **Nota**: las espinas pareadas hacen este
+  árbol inadecuado para áreas de mucho tráfico peatonal o áreas de juego para
+  niños.
+</Callout>
+
+### Propagación
+
+<Accordion title="Métodos de Propagación">
+  <AccordionItem title="Por Semilla (Recomendado)">
+    Recolectar vainas maduras marrones del árbol o el suelo (febrero-mayo).
+    Extraer semillas y almacenar secas — las semillas son ortodoxas y mantienen
+    viabilidad por meses. **La escarificación de semillas es esencial**: verter
+    agua hirviendo sobre las semillas y remojar por 12-24 horas, o raspar
+    mecánicamente la cubierta de la semilla con una lima. Sin escarificación,
+    las tasas de germinación son inferiores al 20%; con tratamiento, las tasas
+    alcanzan **60-85%**. Plantar a 1-2 cm de profundidad en suelo de vivero bien
+    drenado. La germinación ocurre en **7-14 días**. Las plántulas crecen
+    moderadamente rápido, alcanzando 30-50 cm en el primer año. Transplantar al
+    campo al inicio de la temporada de lluvias (mayo-junio) cuando las plántulas
+    tengan 30-60 cm.
+  </AccordionItem>
+  <AccordionItem title="Por Rebrote y Brotes de Tocón">
+    El Carboncillo rebrota vigorosamente — los tocones cortados producen
+    múltiples tallos nuevos en semanas durante la temporada de lluvias. Este
+    rasgo lo hace excelente para producción sostenible de leña y carbón: los
+    árboles pueden cosecharse en un ciclo de rotación de 5-8 años sin matar el
+    sistema radicular. Para cercas vivas, estacas grandes (50-80 cm de largo,
+    3-5 cm de diámetro) pueden plantarse directamente en suelo húmedo al inicio
+    de las lluvias, aunque las tasas de éxito son menores que para propagación
+    por semilla (30-50%).
+  </AccordionItem>
+  <AccordionItem title="Regeneración Natural vía Ganado">
+    El método de "propagación" más costo-efectivo es simplemente la dispersión
+    mediada por ganado. Cuando el ganado consume vainas y deposita semillas
+    escarificadas en montones de estiércol, las tasas de germinación son
+    naturalmente altas y las plántulas se benefician del micrositio rico en
+    nutrientes. Proteger las plántulas jóvenes del sobrepastoreo (usando jaulas
+    de exclusión temporales o reduciendo la carga animal) permite que la
+    regeneración natural establezca rodales densos de Carboncillo en potreros a
+    costo cero.
+  </AccordionItem>
+</Accordion>
+
+### Requerimientos de Cultivo
 
 <DataTable
-  headers={["Recurso", "Tipo", "Enlace"]}
-  rows={[
+  headers={["Factor", "Requisito", "Notas"]}
+  data={[
     [
-      "iNaturalist",
-      "Observaciones",
-      "https://www.inaturalist.org/taxa/564932-Acacia-pennatula",
+      "Luz solar",
+      "Sol pleno esencial",
+      "Intolerante a sombra; no plantar bajo dosel",
     ],
-    ["GBIF", "Datos de Distribución", "https://www.gbif.org/species/2978509"],
     [
-      "Tropicos",
-      "Base de Datos Botánica",
-      "https://www.tropicos.org/name/13048074",
+      "Agua",
+      "Baja una vez establecido",
+      "Adaptado a sequía de 5-6 meses; sin riego necesario",
     ],
+    [
+      "Suelo",
+      "Bien drenado, cualquier fertilidad",
+      "Tolera sustratos pobres, rocosos, degradados",
+    ],
+    [
+      "Tasa de crecimiento",
+      "Moderada (0,5-1,5 m/año)",
+      "Más rápido en buen suelo; más lento en sitios degradados",
+    ],
+    [
+      "Espaciamiento",
+      "5-8 m (silvicultura); 2-3 m (cercas)",
+      "Hábito espinoso requiere espaciamiento cauteloso",
+    ],
+    [
+      "Poda",
+      "Tolera poda fuerte",
+      "Rebrota vigorosamente; podar para mantenimiento de cerca",
+    ],
+    ["Zonas USDA", "10-12 (tropical)", "No tolera heladas"],
   ]}
 />
+
+### Usos Paisajísticos
+
+**Excelente para**: Sistemas silvopastoriles, cercas vivas y límites de propiedad, restauración de bosque seco en potreros degradados, plantaciones de leña/carbón en terrenos marginales, control de erosión en laderas, hábitat para polinizadores y vida silvestre.
+
+**Consideraciones**: Las espinas pareadas hacen este árbol inadecuado cerca de juegos infantiles, senderos o áreas de alto tráfico. El hábito deciduo significa ramas desnudas durante la estación seca. Puede formar matorrales densos si no se maneja — la poda regular mantiene la forma deseada. La caída de vainas atrae ganado, que puede dañar cercas o áreas de jardín.
+
+---
+
+## Especies Similares
+
+<DataTable
+  headers={[
+    "Característica",
+    "V. pennatula (Carboncillo)",
+    "A. collinsii (Cornizuelo)",
+    "A. farnesiana (Aromo)",
+    "Leucaena leucocephala",
+  ]}
+  data={[
+    ["Altura", "8-15 m", "4-10 m", "3-8 m", "5-15 m"],
+    [
+      "Espinas",
+      "Pareadas, rectas, 1-4 cm",
+      "Huecas, hinchadas, con hormigas",
+      "Pareadas, rectas, 1-3 cm",
+      "Ninguna o pequeñas",
+    ],
+    [
+      "Folíolos",
+      "Diminutos, 20-50 pares/pinna",
+      "Pequeños, 10-20 pares/pinna",
+      "Pequeños, 10-25 pares/pinna",
+      "Moderados, 10-20 pares/pinna",
+    ],
+    [
+      "Flores",
+      "Globulares, blanco-crema",
+      "Globulares, amarillas",
+      "Globulares, amarillo dorado",
+      "Globulares, blancas",
+    ],
+    [
+      "Vainas",
+      "Planas, 10-15 cm, marrones",
+      "Cilíndricas, 5-8 cm",
+      "Redondas, 3-7 cm, negras",
+      "Planas, 10-18 cm",
+    ],
+    ["Simbiosis hormiga", "No", "Sí (Pseudomyrmex)", "No", "No"],
+    ["Estado nativo", "Nativo", "Nativo", "Nativo", "Introducido (invasor)"],
+  ]}
+/>
+
+---
+
+## Recursos Externos
+
+<ExternalLinksGrid>
+  <ExternalLink
+    title="iNaturalist — Vachellia pennatula"
+    url="https://www.inaturalist.org/taxa/349260-Vachellia-pennatula"
+    description="Observaciones comunitarias y fotos de Costa Rica y Mesoamérica"
+  />
+  <ExternalLink
+    title="GBIF — Datos de Distribución"
+    url="https://www.gbif.org/species/2978509"
+    description="Registros de distribución global y datos de especímenes"
+  />
+  <ExternalLink
+    title="Tropicos — Missouri Botanical Garden"
+    url="https://www.tropicos.org/name/13048074"
+    description="Registros nomenclaturales y sinonimia"
+  />
+  <ExternalLink
+    title="Plants of the World Online — Kew"
+    url="https://powo.science.kew.org/"
+    description="Nombre aceptado, sinónimos y datos de distribución"
+  />
+  <ExternalLink
+    title="Área de Conservación Guanacaste"
+    url="https://www.acguanacaste.ac.cr/"
+    description="Programas de restauración de bosque seco con especies nativas"
+  />
+  <ExternalLink
+    title="Lista Roja de la UICN"
+    url="https://www.iucnredlist.org/"
+    description="Evaluación de estado de conservación"
+  />
+</ExternalLinksGrid>
+
+---
+
+## Referencias
+
+1. Janzen, D.H. (1988). Tropical dry forests: the most endangered major tropical ecosystem. En E.O. Wilson (ed.), _Biodiversity_, pp. 130-137. National Academy Press, Washington, DC.
+
+2. LPWG (Legume Phylogeny Working Group). (2017). A new subfamily classification of the Leguminosae based on a taxonomically comprehensive phylogeny. _Taxon_ 66(1): 44-77.
+
+3. Maslin, B.R. (2008). Generic and subgeneric names in Acacia following retypification of the genus. _Muelleria_ 26(1): 7-9.
+
+4. Smith, G.F. & Figueiredo, E. (2011). Conserving _Acacia_ Mill. with a conserved type: What happened in Melbourne? _Taxon_ 60(5): 1504-1506.
+
+5. Jiménez, Q. (1999). _Árboles maderables de Costa Rica: ecología y silvicultura_. Instituto Nacional de Biodiversidad (INBio), Santo Domingo de Heredia, Costa Rica.
+
+6. Pezo, D. & Ibrahim, M. (1999). _Sistemas silvopastoriles_. CATIE, Turrialba, Costa Rica.
+
+7. Sprent, J.I. (2009). _Legume Nodulation: A Global Perspective_. Wiley-Blackwell, Oxford.
+
+8. Standley, P.C. & Steyermark, J.A. (1946). Flora of Guatemala. _Fieldiana: Botany_ 24(4).
+
+9. Hammel, B.E., Grayum, M.H., Herrera, C., & Zamora, N. (eds.) (2003-2015). _Manual de Plantas de Costa Rica_ (Tomos I-VIII). Missouri Botanical Garden Press.

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -9,12 +9,14 @@
 **Last Auto-Updated:** 2026-02-07
 
 ### Content Coverage
+
 - **Species**: 133/175 (76%) - Target: 175+ documented species
 - **Comparison Guides**: 20/20 (100%) - Target: 20 guides
 - **Glossary Terms**: 100/150 (67%) - Target: 150+ terms
 - **Care Guidance**: 60/128 (47%) - Target: 100/128 (78%)
 
 ### Implementation Progress
+
 - **Overall**: 0/0 tasks (0%)
 - **Priority 0 (Blockers)**: 0/0 (0%)
 - **Priority 1 (Content)**: 0/0 (0%)
@@ -22,6 +24,7 @@
 - **Priority 3 (Quick Wins)**: 0/0 (0%)
 
 ### Technical Health
+
 - **Lighthouse Score**: 48/100 → Target: 90/100
 - **LCP (Largest Contentful Paint)**: 6.0s → Target: <2.5s
 - **TBT (Total Blocking Time)**: 440ms → Target: <200ms
@@ -30,6 +33,7 @@
 - **Image Status**: 109/128 optimized (85%), 66 galleries need refresh
 
 ### Priority Status Legend
+
 - ✅ **Complete** - All tasks done, validated
 - 🟡 **In Progress** - Active work ongoing
 - 📋 **Ready** - No blockers, can start anytime
@@ -129,7 +133,7 @@ This document is the **executable implementation roadmap** for the Costa Rica Tr
 4. ~~ciprecillo (445 lines)~~ → **885 lines** ✅ Enhanced with conservation, taxonomy, ecology, cultivation
 5. ~~quizarra (482 lines)~~ → **771 lines** ✅ Enhanced with comprehensive cloud forest ecology content
 6. quebracho (492 lines)
-7. carboncillo (498 lines)
+7. ~~carboncillo (498 lines)~~ → **761 lines** ✅ Enhanced with Acacia reclassification, charcoal science, silvopastoral ecology
 8. targua (513 lines)
 9. cana-india (516 lines)
 10. palmera-real (519 lines)
@@ -930,7 +934,7 @@ Each species should include:
 - [x] Enhance ciprecillo (445→885 lines EN, 915 lines ES) → 600+ ✅ @content
 - [ ] Enhance quizarra (482 lines) → 600+ [4h] @content
 - [ ] Enhance quebracho (492 lines) → 600+ [4h] @content
-- [ ] Enhance carboncillo (498 lines) → 600+ [4h] @content
+- [x] Enhance carboncillo (498→761 lines EN, 668 lines ES) → 600+ ✅ @content
 - [ ] Enhance targua (513 lines) → 600+ [4h] @content
 - [ ] Enhance cana-india (516 lines) → 600+ [4h] @content
 - [ ] Enhance palmera-real (519 lines) → 600+ [4h] @content


### PR DESCRIPTION
## Summary

Comprehensive enhancement of the Carboncillo (*Acacia pennatula* / *Vachellia pennatula*) species page (EN + ES), expanding content from 499→761 lines (EN) and 520→668 lines (ES).

## Changes

### Component Fixes
- **Standardized `PropertyCard`** from `title` prop to `icon`+`label`+`value` format
- **Standardized `DataTable`** from `rows` prop to `data` prop
- **Replaced References DataTable** with proper `ExternalLinksGrid`/`ExternalLink` components
- **Added `DistributionMap`** for Guanacaste/Puntarenas/Alajuela/San José
- **Added `FeatureBox`** — "A Tree Shaped by Ranching" (cattle-mediated dispersal ecology)

### New Content
- **Acacia → Vachellia reclassification** — The "Acacia Wars" (Vienna 2005, Melbourne 2011 botanical congress decisions), with context on why local sources still use *Acacia*
- **LPWG 2017 subfamily reclassification** — Mimosoideae → mimosoid clade within Caesalpinioideae
- **Charcoal science** — Calorific values (7,000-7,500 kcal/kg), pyrolysis temperatures, fixed carbon content, comparison table with typical tropical wood charcoal
- **Traditional earth-pit kiln** — Detailed description of the *horno de tierra* method
- **Cattle-mediated seed dispersal** — Ecological explanation of why Carboncillo expanded with deforestation
- **Fire ecology** — Coppicing, seed bank response to fire, adaptation to annual burns
- **Conservation paradox** — Species thriving despite habitat loss, genetic diversity concerns
- **Cultural sections** — Blacksmith heritage, sabanero landscape, phenological calendar
- **Expanded propagation** — Seed scarification, coppice rotations, natural regeneration via cattle
- **Species comparison table** — vs Cornizuelo, Aromo, and Leucaena
- **9 numbered scientific references** including LPWG 2017, Maslin 2008, Pezo & Ibrahim 1999

### Implementation Plan
- Updated audit section and Week 2-3 checklist

## Verification
- ✅ Contentlayer2 build passes (506/506 documents)
- ✅ Pre-commit hooks pass (MDX validation, lint-staged)
- ✅ Both EN and ES versions provided

## Summary by Sourcery

Enhance the Carboncillo species pages in English and Spanish with expanded scientific, ecological, and cultural content while standardizing UI components and updating implementation progress documentation.

New Features:
- Add detailed sections on Acacia-to-Vachellia taxonomic reclassification and legume subfamily placement for Carboncillo.
- Introduce comprehensive charcoal production and fuel-quality content, including traditional earth-pit kilns and comparative charcoal properties tables.
- Expand habitat, distribution, and silvopastoral ecology coverage with new maps, feature boxes, and species comparison tables for Carboncillo.
- Add external resource link grids and numbered scientific references to support the Carboncillo content in both languages.

Enhancements:
- Refine introductory callouts, image metadata, phenology stats, and structural headings for clearer, richer Carboncillo descriptions in English and Spanish.
- Standardize usage of PropertyCard and DataTable components to the newer icon/label/value and data-based APIs on the Carboncillo pages.
- Update the implementation plan to mark Carboncillo as enhanced and record new line counts for tracking content progress.

Documentation:
- Significantly deepen user-facing documentation for the Carboncillo species, covering taxonomy, charcoal science, fire ecology, conservation context, propagation, and cultural significance in both English and Spanish.