### PR TITLE
fix: DistributionMap component crashes on sotacaballo and other pages

### DIFF
--- a/src/components/mdx/server-components.tsx
+++ b/src/components/mdx/server-components.tsx
@@ -351,14 +351,19 @@ export function Timeline({ items }: { items: TimelineItemProps[] }) {
 
 // Distribution Map Placeholder Component
 interface DistributionMapProps {
-  countries: string[];
+  distribution?: string[];
+  countries?: string[];
+  elevation?: string;
   locale?: string;
 }
 
 export function DistributionMap({
+  distribution,
   countries,
+  elevation,
   locale = "en",
 }: DistributionMapProps) {
+  const items = distribution || countries || [];
   return (
     <div className="bg-gradient-to-br from-primary/5 to-secondary/5 rounded-xl p-6 my-6 not-prose border border-border">
       <div className="text-center mb-4">
@@ -369,16 +374,23 @@ export function DistributionMap({
             : "Geographic Distribution"}
         </h4>
       </div>
-      <div className="flex flex-wrap justify-center gap-2">
-        {countries.map((country, index) => (
-          <span
-            key={index}
-            className="px-3 py-1 bg-primary/10 text-primary rounded-full text-sm font-medium"
-          >
-            📍 {country}
-          </span>
-        ))}
-      </div>
+      {items.length > 0 && (
+        <div className="flex flex-wrap justify-center gap-2">
+          {items.map((item, index) => (
+            <span
+              key={index}
+              className="px-3 py-1 bg-primary/10 text-primary rounded-full text-sm font-medium"
+            >
+              📍 {item}
+            </span>
+          ))}
+        </div>
+      )}
+      {elevation && (
+        <p className="text-center text-sm text-muted-foreground mt-3">
+          {locale === "es" ? "Elevación" : "Elevation"}: {elevation}
+        </p>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Fixes `TypeError: Cannot read properties of undefined (reading 'map')` on the sotacaballo page and any other tree page using `DistributionMap`.

## Problem

The `DistributionMap` server component in `src/components/mdx/server-components.tsx` required a `countries` prop, but all MDX tree files pass `distribution`. This caused `.map()` to be called on `undefined`, crashing the page.

## Fix

- Updated `DistributionMap` to accept both `distribution` and `countries` props (both optional)
- Added safe fallback to empty array so `.map()` never fails
- Added `elevation` prop support that MDX files also pass

## Summary by Sourcery

Handle flexible distribution data and elevation metadata in the DistributionMap MDX server component while preventing runtime crashes when distribution data is missing.

New Features:
- Allow DistributionMap to accept either distribution or countries arrays plus an optional elevation value for display.

Bug Fixes:
- Prevent DistributionMap from throwing when no countries data is provided by defaulting to an empty list before mapping.

Enhancements:
- Hide the distribution pill list when there are no items to display to avoid rendering empty UI.