### PR TITLE
feat: expose admin link on homepage

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -30,6 +30,7 @@
     "subtitle": "Discover the magnificent trees of Costa Rica",
     "description": "Explore the rich botanical heritage of this tropical paradise—from the iconic Guanacaste to the towering Ceiba. A free, open-source guide in English and Spanish.",
     "exploreButton": "Explore Trees",
+    "adminButton": "Admin Portal",
     "featuredTrees": "Featured Trees",
     "viewAll": "View All Trees",
     "nowBlooming": "What's Blooming Now",

--- a/messages/es.json
+++ b/messages/es.json
@@ -30,6 +30,7 @@
     "subtitle": "Descubre los magníficos árboles de Costa Rica",
     "description": "Explora la rica herencia botánica de este paraíso tropical—desde el icónico Guanacaste hasta la imponente Ceiba. Una guía gratuita y de código abierto en español e inglés.",
     "exploreButton": "Explorar Árboles",
+    "adminButton": "Portal de Admin",
     "featuredTrees": "Árboles Destacados",
     "viewAll": "Ver Todos los Árboles",
     "nowBlooming": "Floreciendo Ahora",

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -280,7 +280,7 @@ const HeroContent = memo(function HeroContent({
           </svg>
         </Link>
         <Link
-          href="/admin"
+          href="/admin/login"
           className="inline-flex items-center gap-2 border border-white/70 bg-white/10 text-white font-semibold py-3.5 px-6 rounded-lg transition-all duration-200 hover:bg-white/20"
         >
           {adminButton}

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -169,6 +169,7 @@ export default async function HomePage({ params }: Props) {
               title={t("title")}
               description={t("description")}
               exploreButton={t("exploreButton")}
+              adminButton={t("adminButton")}
             />
           </div>
         </section>
@@ -244,10 +245,12 @@ const HeroContent = memo(function HeroContent({
   title,
   description,
   exploreButton,
+  adminButton,
 }: {
   title: string;
   description: string;
   exploreButton: string;
+  adminButton: string;
 }) {
   return (
     <>
@@ -257,24 +260,32 @@ const HeroContent = memo(function HeroContent({
       <p className="text-lg md:text-xl text-white mb-10 max-w-2xl mx-auto leading-relaxed drop-shadow-[0_2px_4px_rgba(0,0,0,0.8)]">
         {description}
       </p>
-      <Link
-        href="/trees"
-        className="inline-flex items-center gap-2 bg-accent hover:bg-accent-light text-primary-dark font-semibold py-3.5 px-8 rounded-lg transition-all duration-200 shadow-2xl hover:shadow-xl hover:scale-[1.02]"
-      >
-        {exploreButton}
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          className="h-5 w-5"
-          viewBox="0 0 20 20"
-          fill="currentColor"
+      <div className="flex flex-wrap justify-center gap-3">
+        <Link
+          href="/trees"
+          className="inline-flex items-center gap-2 bg-accent hover:bg-accent-light text-primary-dark font-semibold py-3.5 px-8 rounded-lg transition-all duration-200 shadow-2xl hover:shadow-xl hover:scale-[1.02]"
         >
-          <path
-            fillRule="evenodd"
-            d="M10.293 3.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
-            clipRule="evenodd"
-          />
-        </svg>
-      </Link>
+          {exploreButton}
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            className="h-5 w-5"
+            viewBox="0 0 20 20"
+            fill="currentColor"
+          >
+            <path
+              fillRule="evenodd"
+              d="M10.293 3.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
+              clipRule="evenodd"
+            />
+          </svg>
+        </Link>
+        <Link
+          href="/admin"
+          className="inline-flex items-center gap-2 border border-white/70 bg-white/10 text-white font-semibold py-3.5 px-6 rounded-lg transition-all duration-200 hover:bg-white/20"
+        >
+          {adminButton}
+        </Link>
+      </div>
     </>
   );
 });


### PR DESCRIPTION
## 📋 Description

- Expose a new admin portal link in the homepage hero
- Add bilingual labels for the admin CTA

## 🎯 Related Issue

Fixes #

## 🔄 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [ ] 🌳 Content: New tree profile
- [ ] 🌐 Content: Translation improvement
- [ ] 🎨 Style/UI change
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvement

## 📸 Screenshots

| Before | After |
| ------ | ----- |
|        |       |

## ✅ Checklist

### General

- [ ] I have read the [Contributing Guidelines](CONTRIBUTING.md)
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [x] The build (`npm run build`) succeeds

### For Code Changes

- [x] I have run `npm run lint` and fixed any issues
- [ ] I have run `npm run format` to format my code
- [ ] I have tested my changes in both English (`/en`) and Spanish (`/es`) routes
- [ ] I have tested on mobile viewport sizes
- [ ] I have tested in both light and dark modes

### For Content Changes

- [ ] I have added/updated both English AND Spanish versions
- [ ] Both language files have the same slug/filename
- [ ] Frontmatter is complete and accurate
- [ ] Scientific information is accurate and sourced
- [ ] Images are properly licensed (noted in PR description)

## 🧪 How Has This Been Tested?

- [x] Chrome (Desktop)
- [ ] Firefox (Desktop)
- [ ] Safari (Desktop)
- [ ] Mobile browser: **___**

## 📝 Additional Notes

- ESLint reports existing warnings in the repository; no new lint errors were introduced.

## Summary by Sourcery

Expose an admin portal call-to-action on the homepage hero section.

New Features:
- Add an admin portal button alongside the existing explore button in the homepage hero.
- Provide localized label text for the new admin button in both English and Spanish message files.