### PR TITLE
feat(image-review): generate image proposals in weekly workflow (no auto-apply)

### DIFF
--- a/.github/workflows/weekly-image-quality.yml
+++ b/.github/workflows/weekly-image-quality.yml
@@ -18,6 +18,7 @@ on:
           - download-force
           - refresh
           - refresh-gallery
+          - propose
           - optimize
           - optimize-force
           - full
@@ -124,7 +125,7 @@ jobs:
 
           TOTAL_ISSUES=$((${{ steps.audit.outputs.broken_count || 0 }} + ${{ steps.audit.outputs.placeholder_count || 0 }} + ${{ steps.audit.outputs.too_small_count || 0 }}))
           if [ $TOTAL_ISSUES -gt 0 ]; then
-            echo "**Status:** ⚠️ Issues detected - automated fixes will be applied" >> audit-report.md
+            echo "**Status:** ⚠️ Issues detected - proposals will be generated for admin review" >> audit-report.md
           elif [ $PENDING_IMAGES -gt 0 ]; then
             echo "**Status:** ⚠️ $PENDING_IMAGES images need optimization" >> audit-report.md
           else
@@ -132,7 +133,7 @@ jobs:
           fi
 
       - name: Download missing/broken images
-        if: steps.mode.outputs.mode == 'download' || steps.mode.outputs.mode == 'full' || (steps.mode.outputs.mode == 'auto' && steps.audit.outputs.audit_failed == 'true')
+        if: steps.mode.outputs.mode == 'download'
         run: |
           echo "" >> audit-report.md
           echo "### Automated Fixes Applied" >> audit-report.md
@@ -145,20 +146,36 @@ jobs:
         run: npm run images:download:force
 
       - name: Check for better featured images
-        if: steps.mode.outputs.mode == 'refresh' || steps.mode.outputs.mode == 'full' || steps.mode.outputs.mode == 'auto'
+        if: steps.mode.outputs.mode == 'refresh'
         run: |
           echo "" >> audit-report.md
           echo "#### Refreshed Featured Images" >> audit-report.md
           npm run images:refresh >> audit-report.md 2>&1
 
       - name: Refresh gallery images
-        if: steps.mode.outputs.mode == 'refresh-gallery' || (steps.mode.outputs.mode == 'auto' && steps.audit_gallery.outputs.gallery_audit_failed == 'true') || steps.mode.outputs.mode == 'full'
+        if: steps.mode.outputs.mode == 'refresh-gallery'
         run: |
           echo "" >> audit-report.md
           echo "#### Refreshed Gallery Images" >> audit-report.md
           npm run images:refresh:gallery >> audit-report.md 2>&1
 
       # NEW: Image Optimization Steps
+
+      - name: Generate image review proposals
+        if: steps.mode.outputs.mode == 'propose' || steps.mode.outputs.mode == 'auto' || steps.mode.outputs.mode == 'full'
+        env:
+          API_BASE_URL: ${{ secrets.IMAGE_PROPOSALS_API_BASE_URL }}
+          WORKFLOW_TOKEN: Bearer workflow-${{ github.run_id }}
+        run: |
+          echo "" >> audit-report.md
+          echo "### Image Proposal Generation" >> audit-report.md
+          if [ -z "$API_BASE_URL" ]; then
+            echo "⚠️ Skipped: IMAGE_PROPOSALS_API_BASE_URL secret is not configured." >> audit-report.md
+            echo "Set it to your deployed endpoint, e.g. https://example.com/api/admin/images/proposals" >> audit-report.md
+          else
+            npm run images:propose -- --verbose >> audit-report.md 2>&1
+          fi
+
       - name: Optimize tree images
         if: steps.mode.outputs.mode == 'optimize' || steps.mode.outputs.mode == 'full' || steps.mode.outputs.mode == 'auto'
         run: |
@@ -190,7 +207,7 @@ jobs:
           npm run images:optimize:hero >> audit-report.md 2>&1
 
       - name: Run legacy cleanup
-        if: steps.mode.outputs.mode == 'auto' || steps.mode.outputs.mode == 'full'
+        if: steps.mode.outputs.mode == 'full'
         run: |
           echo "" >> audit-report.md
           echo "#### Updated iNaturalist Links" >> audit-report.md

--- a/.github/workflows/weekly-image-quality.yml
+++ b/.github/workflows/weekly-image-quality.yml
@@ -165,7 +165,7 @@ jobs:
         if: steps.mode.outputs.mode == 'propose' || steps.mode.outputs.mode == 'auto' || steps.mode.outputs.mode == 'full'
         env:
           API_BASE_URL: ${{ secrets.IMAGE_PROPOSALS_API_BASE_URL }}
-          WORKFLOW_TOKEN: Bearer workflow-${{ github.run_id }}
+          WORKFLOW_TOKEN: ${{ secrets.IMAGE_PROPOSALS_WORKFLOW_TOKEN }}
         run: |
           echo "" >> audit-report.md
           echo "### Image Proposal Generation" >> audit-report.md

--- a/context/context.md
+++ b/context/context.md
@@ -4,41 +4,36 @@
 
 - Costa Rica Tree Atlas is a bilingual (EN/ES) Next.js 16 app for Costa Rican tree profiles, built with TypeScript, Tailwind CSS, MDX via Contentlayer2, and next-intl routing.
 - Tree content lives in MDX files under `content/trees/{en,es}` and is rendered with custom MDX components.
-- Image maintenance is handled by Node.js scripts in `scripts/`, including audits, downloads, and gallery refreshes.
+- Image maintenance and review automation is handled by scripts and a weekly GitHub Actions workflow.
 
 ## Dependency Graph (High Level)
 
 - App framework: Next.js (`next`), React (`react`, `react-dom`).
 - Content pipeline: `contentlayer2`, `next-contentlayer2`, MDX loaders.
 - i18n: `next-intl` with locale routing.
-- UI/state/utilities: Tailwind CSS 4, Zustand.
-- Scripts/tooling: Node.js scripts in `scripts/` for image management.
+- Data and auth: Prisma + Postgres + NextAuth.
+- Scripts/tooling: Node.js scripts in `scripts/` for image audits, optimization, and proposal generation.
 
 ## Commands Map
 
 - Dev server: `npm run dev`
 - Build: `npm run build`
 - Lint: `npm run lint`
-- Format: `npm run format`
-- Image audit: `npm run images:audit`, `npm run images:audit:gallery`
-- Image repair: `npm run images:download`, `npm run images:refresh`, `npm run images:refresh:gallery`, `npm run images:cleanup`
+- Type check: `npm run type-check`
+- Tests: `npm run test:run`
+- Image review proposal generation: `npm run images:propose`, `npm run images:propose:dry`
+- Image audits/optimization: `npm run images:audit`, `npm run images:audit:gallery`, `npm run images:optimize`
 
 ## Key Paths by Feature
 
-- Tree content (MDX): `content/trees/en/*.mdx`, `content/trees/es/*.mdx`
-- Image storage & attributions: `public/images/trees/`, `public/images/trees/attributions.json`
-- Image maintenance scripts: `scripts/manage-tree-images.mjs`, `scripts/cleanup-tree-images.mjs`
-- Weekly maintenance workflow: `.github/workflows/weekly-image-quality.yml`
-- MDX components: `src/components/mdx/`
-- Tree detail page: `src/app/[locale]/trees/[slug]/page.tsx`
-
-## Code Search Notes
-
-- Gallery rendering: `src/components/mdx/index.tsx` (`ImageCard`, `ImageGallery`).
-- Featured image maintenance: `scripts/manage-tree-images.mjs` (`downloadImages`, `refreshImages`, `scoreFeaturedCandidate`).
-- Weekly image workflow: `.github/workflows/weekly-image-quality.yml` (modes `audit`, `audit-gallery`, `download`, `download-force`, `refresh`, `refresh-gallery`, `full`).
+- Weekly image workflow: `.github/workflows/weekly-image-quality.yml`
+- Proposal generation script: `scripts/propose-image-changes.mjs`
+- Admin proposals API: `src/app/api/admin/images/proposals/**`
+- Admin review UI: `src/app/[locale]/admin/images/proposals/**`
+- Validation docs: `docs/IMAGE_REVIEW_SYSTEM.md`, `docs/IMPLEMENTATION_PLAN.md`
 
 ## Known Constraints & Feature Flags
 
-- Optional analytics and APIs are configured via `.env.example`.
-- Some integrations disabled by default (e.g., Google Cloud Vision API, Maps API).
+- Proposal creation requires deployed API + DB migration for `image_proposals` tables.
+- Weekly workflow proposal step depends on `IMAGE_PROPOSALS_API_BASE_URL` GitHub secret.
+- If that secret is unset, workflow now logs a warning and skips proposal generation safely.

--- a/context/links.md
+++ b/context/links.md
@@ -1,0 +1,8 @@
+# Related Issue / PR History
+
+No repository issue/PR references were discovered locally for this implementation task.
+
+## Search basis
+
+- Keywords: `image proposals`, `weekly image quality`, `propose-image-changes`, `validation gate`, `admin/images/proposals`
+- Scope searched: repository code/docs/workflows (local clone)

--- a/docs/IMAGE_REVIEW_SYSTEM.md
+++ b/docs/IMAGE_REVIEW_SYSTEM.md
@@ -525,3 +525,25 @@ export const QUALITY_CONFIG = {
 - [ ] Should user votes be public or anonymous?
 - [ ] Do we want email notifications for new proposals?
 - [ ] Should we have categories of users (admin, moderator, contributor)?
+
+## Validation Gate Runbook
+
+Use this checklist after database deployment to complete Priority 0.3 validation:
+
+1. Configure `IMAGE_PROPOSALS_API_BASE_URL` in GitHub Actions secrets to point to your deployed endpoint (`https://<domain>/api/admin/images/proposals`).
+2. Trigger **Weekly Image Quality & Optimization** with mode `propose` or wait for the scheduled run.
+3. Confirm the workflow report includes proposal generation output and does not auto-apply images.
+4. Review at least 10 proposals in `/admin/images/proposals` and open at least one detail page to verify side-by-side comparison.
+5. Approve and apply one proposal, then verify an `ImageAudit` row is created with action `APPLIED_PROPOSAL`.
+
+### Validation Commands
+
+```bash
+# Local dry run (no proposal creation)
+npm run images:propose:dry
+
+# Local proposal generation against a deployed API
+API_BASE_URL="https://<domain>/api/admin/images/proposals" \
+WORKFLOW_TOKEN="Bearer workflow-local" \
+npm run images:propose -- --verbose
+```

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -126,7 +126,7 @@
   - [ ] Test 10 proposals end-to-end
   - [ ] Verify side-by-side comparison works
   - [ ] Confirm audit log tracks changes
-  - [ ] Ensure weekly workflow generates proposals (not auto-applies)
+  - [x] Ensure weekly workflow generates proposals (not auto-applies) — automated mode now runs `npm run images:propose` (2026-02-10)
 
 **🚦 Completion Gate:** Auth fixed ✅, Safety live ✅, Image Review code complete ✅ (validation pending DB deployment) → Unblocks Priority 4
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
     "images:refresh": "node scripts/manage-tree-images.mjs refresh",
     "images:refresh:gallery": "node scripts/manage-tree-images.mjs refresh-gallery",
     "images:refresh:gallery:force": "node scripts/manage-tree-images.mjs refresh-gallery --force",
+    "images:propose": "node scripts/propose-image-changes.mjs",
+    "images:propose:dry": "node scripts/propose-image-changes.mjs --dry-run",
     "images:check": "node scripts/cleanup-tree-images.mjs",
     "images:cleanup": "node scripts/cleanup-tree-images.mjs --write",
     "images:cleanup:force": "node scripts/cleanup-tree-images.mjs --write --force",


### PR DESCRIPTION
### Motivation
- Ensure the weekly image maintenance workflow proposes candidate image changes for human review instead of automatically applying replacements to prevent accidental overwrites and enable the validation gate. 
- Provide a safe, deploy-time validation path and local dry-run commands so the image-review system can be validated after DB deployment and secret configuration.

### Description
- Added npm scripts `images:propose` and `images:propose:dry` to run the proposal generator (`scripts/propose-image-changes.mjs`).
- Updated `.github/workflows/weekly-image-quality.yml` to add a `propose` dispatch mode and a `Generate image review proposals` step that runs in `propose`, `auto`, and `full` modes and uses the `IMAGE_PROPOSALS_API_BASE_URL` secret and `WORKFLOW_TOKEN` for workflow-authenticated requests.
- Scoped scheduled `auto` mode to generate proposals (not auto-apply fixes) by removing auto-download/refresh apply conditions from `auto` and requiring explicit `download`/`refresh` modes for automatic fixes.
- Added a `Validation Gate Runbook` to `docs/IMAGE_REVIEW_SYSTEM.md` with concrete commands for local dry runs and deployed-run validation, and updated `docs/IMPLEMENTATION_PLAN.md` to mark the weekly-proposals check as completed.
- Added/updated project context artifacts (`context/context.md`, `context/links.md`) documenting the change and constraints (workflow depends on `IMAGE_PROPOSALS_API_BASE_URL` + DB migration). 

### Testing
- Ran lint: `npm run lint` which completed (repo contains pre-existing warnings; no new ESLint errors introduced). ✅
- Ran type checks: `npm run type-check` completed successfully (no type errors). ✅
- Attempted full build: `npm run build` failed in this environment due to Turbopack attempting to fetch Google Fonts over TLS (external fetch/TLS error), unrelated to the workflow changes. ⚠️
- Executed the proposal dry-run: `npm run images:propose:dry -- --tree=guanacaste` which completed successfully and reported zero proposals for that tree in dry mode. ✅
- Performed a secrets scan on changed files (regex check) and found no exposed secrets. ✅

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b00d4c2288323a7760283372b4890)