### PR TITLE
refactor(performance): migrate Footer to server component

### DIFF
--- a/context/context.md
+++ b/context/context.md
@@ -2,16 +2,16 @@
 
 ## Project Summary
 
-- Costa Rica Tree Atlas is a bilingual (EN/ES) Next.js 16 app documenting Costa Rican tree species with MDX content, locale routing, and strict TypeScript.
-- The highest-priority unchecked implementation item was Priority 0.3 validation-gate completion for the image proposal workflow.
-- This work focused on validating proposal lifecycle behavior (creation, listing, detail comparison payload, and audit logging on review status changes).
+- Costa Rica Tree Atlas is a bilingual (EN/ES) Next.js 16 app with App Router, Contentlayer-backed MDX content, and next-intl locale routing.
+- The highest-priority unaddressed implementation item selected from `docs/IMPLEMENTATION_PLAN.md` was Priority 2 / Phase 3: migrating more components to Server Components.
+- This change converts `Footer` from a client component to an async server component to reduce hydration work and align with the performance roadmap.
 
 ## Dependency Graph (High Level)
 
 - **Framework/runtime**: `next`, `react`, `react-dom`
-- **Content**: `contentlayer2`, `next-contentlayer2`, MDX tooling
-- **Auth/data**: `next-auth`, `@prisma/client`, Prisma SQL access through `@/lib/prisma`
-- **Testing**: `vitest`, `jsdom`, Next.js route handlers with mocked auth/DB
+- **Localization**: `next-intl` (server APIs for translations in server components)
+- **Content**: `contentlayer2`, `next-contentlayer2`
+- **State/client-only logic**: Zustand store in `src/lib/store`
 
 ## Commands Map
 
@@ -19,18 +19,16 @@
 - Lint: `npm run lint`
 - Type checks: `npm run type-check`
 - Build: `npm run build`
-- Targeted validation gate test: `npm run test:run -- tests/image-review/validation-gate.test.ts`
 
 ## Key Paths by Feature
 
 - Implementation tracking: `docs/IMPLEMENTATION_PLAN.md`
-- Image review architecture/runbook: `docs/IMAGE_REVIEW_SYSTEM.md`
-- Proposal list/create API: `src/app/api/admin/images/proposals/route.ts`
-- Proposal detail/update API: `src/app/api/admin/images/proposals/[id]/route.ts`
-- New validation test: `tests/image-review/validation-gate.test.ts`
+- Performance strategy: `docs/PERFORMANCE_OPTIMIZATION.md`
+- Locale layout (server component shell): `src/app/[locale]/layout.tsx`
+- Footer component: `src/components/Footer.tsx`
 
 ## Known Constraints & Feature Flags
 
-- Proposal APIs depend on migrated `image_proposals`, `image_votes`, and `image_audits` tables.
-- Tests in this PR mock auth (`getServerSession`) and DB raw SQL calls to provide deterministic validation coverage independent of external DB state.
-- Workflow proposal automation remains dependent on deployed API endpoint and `IMAGE_PROPOSALS_API_BASE_URL` secret.
+- Footer localization now uses server-side `getTranslations({ locale, namespace })` and requires explicit `locale` prop passing from layout.
+- No dependency additions or lockfile changes were required.
+- Scope intentionally limited to a single reversible server-component migration plus documentation updates.

--- a/context/links.md
+++ b/context/links.md
@@ -4,10 +4,11 @@ No GitHub issue/PR metadata is available from this local clone (no configured re
 
 ## Local history checks performed
 
-- `git log --oneline -- docs/IMPLEMENTATION_PLAN.md docs/IMAGE_REVIEW_SYSTEM.md`
-- `rg -n "Validation gate|image proposals|PROPOSAL_APPROVED|/api/admin/images/proposals" docs src tests`
+- `git log --oneline -- docs/IMPLEMENTATION_PLAN.md docs/PERFORMANCE_OPTIMIZATION.md src/components/Footer.tsx src/app/[locale]/layout.tsx`
+- `rg -n "Phase 3|Server Components|Footer" docs/IMPLEMENTATION_PLAN.md docs/PERFORMANCE_OPTIMIZATION.md src/components/Footer.tsx src/app/[locale]/layout.tsx`
 
 ## Summary
 
-- Validation gate tasks were still unchecked in `docs/IMPLEMENTATION_PLAN.md` before this change.
-- Existing docs already contained a manual validation runbook in `docs/IMAGE_REVIEW_SYSTEM.md`; this update adds automated test coverage and documents it.
+- Priority 2 / Phase 3 still listed server-component migration work as open.
+- Footer was a low-risk target because it only needed locale-aware text and no client interactivity.
+- This commit captures one incremental migration and documents progress in both implementation and performance tracking docs.

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -441,6 +441,7 @@ See `audit-content-report.md` for complete list of 26 species.
 ### Phase 3: Long-term
 
 - [ ] Migrate more components to Server Components
+  - [x] Convert `Footer` to server component to reduce client hydration (2026-02-10)
 - [ ] Implement partial hydration
 - [ ] Add progressive enhancement strategies
 - [ ] Optimize database queries (when admin active)

--- a/docs/PERFORMANCE_OPTIMIZATION.md
+++ b/docs/PERFORMANCE_OPTIMIZATION.md
@@ -266,6 +266,7 @@ import { useVirtualizer } from "@tanstack/react-virtual";
 ### Phase 3: Long-term Improvements
 
 - [ ] Migrate more components to Server Components
+  - [x] Convert `Footer` from client component to async server component (2026-02-10)
 - [ ] Implement partial hydration
 - [ ] Add progressive enhancement
 - [ ] Optimize database queries

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -229,7 +229,7 @@ export default async function LocaleLayout({ children, params }: Props) {
                 <main id="main-content" className="flex-grow">
                   {children}
                 </main>
-                <Footer />
+                <Footer locale={locale} />
                 <ScrollToTop />
                 <KeyboardShortcuts />
                 <PWARegister />

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,11 +1,12 @@
-"use client";
-
-import { useTranslations, useLocale } from "next-intl";
+import { getTranslations } from "next-intl/server";
 import Image from "next/image";
 
-export function Footer() {
-  const t = useTranslations("footer");
-  const locale = useLocale();
+interface FooterProps {
+  locale: string;
+}
+
+export async function Footer({ locale }: FooterProps) {
+  const t = await getTranslations({ locale, namespace: "footer" });
   const currentYear = new Date().getFullYear();
 
   return (


### PR DESCRIPTION
### Motivation
- Reduce client-side hydration and main-thread work by moving a non-interactive presentational component to the server, aligning with the Phase 3 performance goal to migrate more components to Server Components.

### Description
- Converted `Footer` from a client component to an async server component by removing the `"use client"` directive and using `getTranslations` from `next-intl/server` with an explicit `locale` prop. 
- Updated the locale layout to pass `locale` into `<Footer locale={locale} />` so translations are rendered server-side. 
- Recorded this incremental migration in `docs/PERFORMANCE_OPTIMIZATION.md` and `docs/IMPLEMENTATION_PLAN.md`, and added context notes in `context/context.md` and `context/links.md` to document rationale and impacted files. 

### Testing
- Ran lint with `npm run lint` which completed (repository-wide warnings present but no new errors introduced by this change). 
- Ran type checks with `npm run type-check` which failed due to existing repository-wide `contentlayer/generated` typing issues unrelated to the Footer migration. 
- Attempted production build with `npm run build`; initial build failed in this environment due to TLS/font fetch issues and a later prerender failure caused by an external-network `ENETUNREACH` error when fetching remote content (retriable in CI/networked environment). 
- Performed a lightweight secret scan with `rg` for common key patterns which returned no matches.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b8f1333208323bd75bf892aebc848)