### PR TITLE
docs(planning): sync medium-priority species completion status

### DIFF
--- a/context/context.md
+++ b/context/context.md
@@ -2,33 +2,34 @@
 
 ## Project Summary
 
-- Costa Rica Tree Atlas is a bilingual (EN/ES) Next.js 16 app with App Router, Contentlayer-backed MDX content, and next-intl locale routing.
-- The highest-priority unaddressed implementation item selected from `docs/IMPLEMENTATION_PLAN.md` was Priority 2 / Phase 3: migrating more components to Server Components.
-- This change converts `Footer` from a client component to an async server component to reduce hydration work and align with the performance roadmap.
+- Costa Rica Tree Atlas is a bilingual (EN/ES) Next.js 16 application using Contentlayer MDX content and next-intl routing.
+- For this task, the highest-priority unaddressed item in `docs/IMPLEMENTATION_PLAN.md` was Priority 1.1: "Add remaining medium priority species."
+- Repository content verification showed those medium-priority species already exist in both locales, so this change synchronizes planning docs with implementation reality.
 
 ## Dependency Graph (High Level)
 
-- **Framework/runtime**: `next`, `react`, `react-dom`
-- **Localization**: `next-intl` (server APIs for translations in server components)
-- **Content**: `contentlayer2`, `next-contentlayer2`
-- **State/client-only logic**: Zustand store in `src/lib/store`
+- **App framework**: `next`, `react`, `react-dom`
+- **Content pipeline**: `contentlayer2`, `next-contentlayer2`
+- **Localization**: `next-intl`
+- **State**: `zustand`
+- **Validation/testing**: `eslint`, `vitest`, TypeScript strict mode
 
 ## Commands Map
 
-- Development: `npm run dev`
-- Lint: `npm run lint`
-- Type checks: `npm run type-check`
+- Dev server: `npm run dev`
 - Build: `npm run build`
+- Lint: `npm run lint`
+- Type check: `npm run type-check`
 
 ## Key Paths by Feature
 
-- Implementation tracking: `docs/IMPLEMENTATION_PLAN.md`
-- Performance strategy: `docs/PERFORMANCE_OPTIMIZATION.md`
-- Locale layout (server component shell): `src/app/[locale]/layout.tsx`
-- Footer component: `src/components/Footer.tsx`
+- Master implementation tracker: `docs/IMPLEMENTATION_PLAN.md`
+- Missing-species source of truth: `docs/MISSING_SPECIES_LIST.md`
+- Species content (EN): `content/trees/en/*.mdx`
+- Species content (ES): `content/trees/es/*.mdx`
 
 ## Known Constraints & Feature Flags
 
-- Footer localization now uses server-side `getTranslations({ locale, namespace })` and requires explicit `locale` prop passing from layout.
-- No dependency additions or lockfile changes were required.
-- Scope intentionally limited to a single reversible server-component migration plus documentation updates.
+- Species additions require EN+ES parity and frontmatter/schema compatibility.
+- Documentation should track real implementation status to prevent duplicated content work.
+- No runtime code changes or dependency updates were necessary for this docs-alignment task.

--- a/context/links.md
+++ b/context/links.md
@@ -1,14 +1,16 @@
 # Related Issue / PR History
 
-No GitHub issue/PR metadata is available from this local clone (no configured remote).
+GitHub issue/PR metadata is not available from this local environment (no remote issue tracker context available in-repo).
 
-## Local history checks performed
+## Local discovery commands used
 
-- `git log --oneline -- docs/IMPLEMENTATION_PLAN.md docs/PERFORMANCE_OPTIMIZATION.md src/components/Footer.tsx src/app/[locale]/layout.tsx`
-- `rg -n "Phase 3|Server Components|Footer" docs/IMPLEMENTATION_PLAN.md docs/PERFORMANCE_OPTIMIZATION.md src/components/Footer.tsx src/app/[locale]/layout.tsx`
+- `rg -n "\[ \]" docs/IMPLEMENTATION_PLAN.md`
+- `rg --files content/trees/en content/trees/es | rg -i 'camibar|cortez-blanco|sardinillo|flor-de-itabo|corozo|papayillo|tirra|lengua-de-vaca|chirraca|palma-de-escoba|palma-yolillo|palma-suita|palma-cacho-de-venado'`
+- `find content/trees/en -name '*.mdx' | wc -l`
+- `find content/trees/es -name '*.mdx' | wc -l`
 
 ## Summary
 
-- Priority 2 / Phase 3 still listed server-component migration work as open.
-- Footer was a low-risk target because it only needed locale-aware text and no client interactivity.
-- This commit captures one incremental migration and documents progress in both implementation and performance tracking docs.
+- The checklist item "Add remaining medium priority species" was stale relative to current content files.
+- All medium-priority species listed in plan/missing-list are present in both English and Spanish content trees.
+- Documentation was updated to mark medium-priority groups complete and set next focus to low-priority/special-case species.

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -7,7 +7,7 @@
 
 ### Content Coverage
 
-- **Species**: 151/175 (86%) - Target: 175+ documented species
+- **Species**: 153/175 (87%) - Target: 175+ documented species
 - **Comparison Guides**: 20/20 (100%) ✅ Complete
 - **Glossary Terms**: 100/150 (67%) - Target: 150+ terms
 - **Care Guidance**: 60/128 (47%) - Target: 100/128 (78%)
@@ -168,7 +168,7 @@
 - [x] Tamarindo Dulce (Tamarindus indica var. dulcis) — added 2026-02-09
 - [x] Marañón de Jardín (Anacardium occidentale var.) — already existed
 
-#### Medium Priority (20 species) — 16/20 complete ✅ Fruit Trees Done
+#### Medium Priority (20 species) — 20/20 complete ✅
 
 - [x] Cortez Blanco (Roseodendron donnell-smithii) — added 2026-02-09
 - [x] Sardinillo (Tecoma stans) — added 2026-02-09
@@ -186,7 +186,7 @@
 - [x] Guaba Machete (Inga spectabilis) — added 2026-01-22
 - [x] Anona Colorada (Annona purpurea) — added 2026-01-22
 - [x] Guanábana Cimarrona (Annona montana) — added 2026-01-22
-- [ ] Add remaining medium priority species (See MISSING_SPECIES_LIST.md)
+- [x] Add remaining medium priority species (completed 2026-02-10; see docs/MISSING_SPECIES_LIST.md)
 
 #### Low Priority (7 species)
 

--- a/docs/MISSING_SPECIES_LIST.md
+++ b/docs/MISSING_SPECIES_LIST.md
@@ -64,7 +64,7 @@ The following 12 species from the original missing list were successfully docume
 
 ## Priority Categories
 
-### HIGH PRIORITY - Native Forest Trees (1 species remaining)
+### HIGH PRIORITY - Native Forest Trees (0 species remaining) ✅ COMPLETE
 
 Important rainforest and montane species still needed:
 
@@ -76,50 +76,50 @@ Important rainforest and montane species still needed:
 - ~~**Surá de Montaña** - _Terminalia oblonga_~~ ✅ DUPLICATE: Same as **Surá** already documented
 - ~~**Comenegro** - _Simarouba glauca_ - Paradise tree~~ ✅ ADDED 2026-01-15
 - ~~**Mayo** - _Vochysia hondurensis_ - Important timber species~~ ✅ ADDED 2026-01-15
-- **Camíbar** - _Copaifera aromatica_ - Copaiba, medicinal resin
+- ~~**Camíbar** - _Copaifera aromatica_ - Copaiba, medicinal resin~~ ✅ ALREADY DOCUMENTED (`content/trees/{en,es}/camibar.mdx`)
 
 **Rationale:** These are ecologically significant native species commonly encountered in Costa Rican forests.
 
-### MEDIUM PRIORITY - Flowering/Ornamental (4 species)
+### MEDIUM PRIORITY - Flowering/Ornamental (4 species) ✅ COMPLETE
 
 Showy flowering species for urban landscaping and conservation:
 
-- **Cortez Blanco** - _Tabebuia donnell-smithii_ - White trumpet tree
+- ~~**Cortez Blanco** - _Tabebuia donnell-smithii_ - White trumpet tree~~ ✅ ADDED 2026-02-09
 - ~~**Llama del Bosque** - _Spathodea campanulata_ - African tulip tree (introduced but widespread)~~ ✅ ADDED 2026-01-14
-- **Sardinillo** - _Tecoma stans_ - Yellow bells
+- ~~**Sardinillo** - _Tecoma stans_ - Yellow bells~~ ✅ ADDED 2026-02-09
 - ~~**Cañafístula Rosada** - _Cassia grandis_~~ ✅ DUPLICATE: Same as **Carao** already documented
-- **Flor de Itabo** - _Yucca guatemalensis_ - Izote, national flower of El Salvador
+- ~~**Flor de Itabo** - _Yucca guatemalensis_ - Izote, national flower of El Salvador~~ ✅ ADDED 2026-02-09
 - ~~**Lirio de Agua** - _Crinum erubescens_~~ ❌ REMOVED: Not a tree (herbaceous aquatic plant)
 
 **Rationale:** Popular ornamental species, some with cultural significance.
 
-### MEDIUM PRIORITY - Palms (5 species)
+### MEDIUM PRIORITY - Palms (5 species) ✅ COMPLETE
 
 Additional palm diversity for tropical ecosystems:
 
-- **Corozo** - _Elaeis oleifera_ - American oil palm, wild relative
-- **Palma de Escoba** - _Cryosophila albida_ - Broom palm
-- **Palma Yolillo** - _Raphia taedigera_ - Raffia palm, largest leaves
-- **Palma Suita** - _Geonoma congesta_ - Understory palm
-- **Palma Cacho de Venado** - _Oenocarpus bataua_ - Milpesos palm, edible oil
+- ~~**Corozo** - _Elaeis oleifera_ - American oil palm, wild relative~~ ✅ ADDED 2026-02-09
+- ~~**Palma de Escoba** - _Cryosophila albida_ - Broom palm~~ ✅ ADDED 2026-02-09
+- ~~**Palma Yolillo** - _Raphia taedigera_ - Raffia palm, largest leaves~~ ✅ ADDED 2026-02-09
+- ~~**Palma Suita** - _Geonoma congesta_ - Understory palm~~ ✅ ADDED 2026-02-09
+- ~~**Palma Cacho de Venado** - _Oenocarpus bataua_ - Milpesos palm, edible oil~~ ✅ ADDED 2026-02-09
 
 **Rationale:** Costa Rica has exceptional palm diversity. Current atlas may be missing important species.
 
-### MEDIUM PRIORITY - Cloud Forest/Highland (3 species remaining)
+### MEDIUM PRIORITY - Cloud Forest/Highland (0 species remaining) ✅ COMPLETE
 
 High-elevation specialists still needed:
 
-- **Papayillo** - _Vasconcellea cauliflora_ - Mountain papaya
-- **Tirrá** - _Ulmus mexicana_ - Mexican elm
-- **Lengua de Vaca** - _Miconia argentea_ - Silvery miconia
+- ~~**Papayillo** - _Vasconcellea cauliflora_ - Mountain papaya~~ ✅ ADDED 2026-02-09
+- ~~**Tirrá** - _Ulmus mexicana_ - Mexican elm~~ ✅ ADDED 2026-02-09
+- ~~**Lengua de Vaca** - _Miconia argentea_ - Silvery miconia~~ ✅ ADDED 2026-02-09
 
 **Rationale:** Cloud forest ecosystems are biodiversity hotspots and currently underrepresented.
 
-### MEDIUM PRIORITY - Dry Forest Species (1 species remaining)
+### MEDIUM PRIORITY - Dry Forest Species (0 species remaining) ✅ COMPLETE
 
 Important for Guanacaste dry forest ecosystem:
 
-- **Chirraca** - _Lonchocarpus minimiflorus_ - Dry forest nitrogen-fixer
+- ~~**Chirraca** - _Lonchocarpus minimiflorus_ - Dry forest nitrogen-fixer~~ ✅ ADDED 2026-02-09
 
 **Rationale:** Dry forest is threatened ecosystem in Costa Rica, needs better representation.
 
@@ -241,11 +241,11 @@ The following were listed as "missing" but are already documented under differen
 
 All 5 mangrove species have been successfully documented.
 
-### Phase 2: High-Value Natives (17 species remaining)
+### Phase 2: High-Value Natives (0 species remaining) ✅ COMPLETE
 
-1. Native forest trees (verified unique species) - 9 remaining
-2. Cloud forest specialists - 3 remaining
-3. Dry forest indicators - 1 remaining
+1. Native forest trees (verified unique species) - complete
+2. Cloud forest specialists - complete
+3. Dry forest indicators - complete
 4. Focus on filling ecosystem gaps
 
 ### Phase 3: Cultivation & Ornamental (10 species)
@@ -267,16 +267,16 @@ All 5 mangrove species have been successfully documented.
 
 ### Implementation Notes
 
-**Progress Update (2026-01-19):**
+**Progress Update (2026-02-10):**
 
 - **18 species successfully added** since last major update (2026-01-12)
 - **7 duplicates identified and removed** from missing list through scientific name verification
 - Recent additions: Sigua, Comenegro, Mayo, Lechoso Montañero, Guanábana
 - All mangrove species now documented (critical coastal ecosystem coverage complete)
 - High-priority native forest, cloud forest, and dry forest species added
-- **Current total: 129 species documented** (up from 110)
-- **Actual missing species: ~40 unique species** (down from original 57 after removing duplicates)
-- Phase 2 progress: Only 1 high-priority native forest species remaining (Camíbar)
+- **Current total: 153 species documented** (up from 110)
+- **Actual missing species: prioritized low-priority and special-case species remain**
+- Phase 2 progress: completed — Camíbar and all medium-priority ecosystem species are now documented
 
 ### Content Requirements per Species
 
@@ -297,7 +297,7 @@ Each new species should include:
 - **Per species:** 4-6 hours (research + writing + translation + images)
 - **Phase 1 (5 mangrove species):** ✅ COMPLETE (20-30 hours invested)
 - **Recent additions (19 species total):** ✅ COMPLETE (76-114 hours invested)
-- **Phase 2 (1 high-priority species remaining):** 4-6 hours
+- **Phase 2:** ✅ COMPLETE
 - **Complete remaining list (~40 unique species):** 160-240 hours
 
 **Achievement Rate:** 19 species added in 6 days (2026-01-12 to 2026-01-19), demonstrating excellent progress.
@@ -321,12 +321,12 @@ Each new species should include:
 
 **Note:** This list was compiled from community input and represents species commonly encountered in Costa Rica that would enhance the comprehensiveness of the atlas. Verification against existing content and scientific name accuracy should be performed before beginning content creation.
 
-**Status Update (2026-01-19):**
+**Status Update (2026-02-10):**
 
 - ✅ **Phase 1 Complete!** All 5 mangrove species documented
 - ✅ **19 total species** added since 2026-01-12 (including Guanábana)
 - ✅ **Verification complete:** 9 duplicates identified and removed from list
-- 📊 **129 species** now in atlas (up from 110)
+- 📊 **153 species** now in atlas (up from 110)
 - 🎯 **Actual remaining:** ~40 unique species (down from 57 after duplicate removal)
-- 🎯 **Next Priority:** Complete Phase 2 native forest trees (1 high-priority: Camíbar)
+- 🎯 **Next Priority:** Complete low-priority medicinal, timber, and introduced-context species
 - 💡 **Key Learning:** Always verify scientific names to prevent duplicate documentation


### PR DESCRIPTION
### Motivation
- The implementation tracker and missing-species roadmap were out of sync with the actual content: a tranche of medium-priority species already existed in `content/trees/{en,es}` but remained unchecked in planning docs. 
- Keep contributor work focused and avoid duplicated effort by reconciling docs with repository state and pointing next work at remaining low-priority/special-case species. 

### Description
- Updated `docs/IMPLEMENTATION_PLAN.md` to bump species coverage to `153/175 (87%)`, mark the Medium Priority group as `20/20 complete`, and check off the stale "Add remaining medium priority species" item. 
- Updated `docs/MISSING_SPECIES_LIST.md` to mark `Camíbar` and the medium-priority subgroups (flowering, palms, cloud forest, dry forest) as documented and to refresh Phase/Progress messaging. 
- Added/updated verification artifacts in `context/context.md` and `context/links.md` capturing the discovery commands used and the rationale for the docs changes. 
- No runtime code, dependency, or content MDX changes were made; this is a docs-only alignment to reduce project drift. 

### Testing
- Ran `npm run lint` which completed with the repository's existing warnings and introduced no new ESLint errors. 
- Ran `npm run type-check` which completed successfully with no TypeScript errors. 
- Ran `npm run build` which failed in this environment due to Next.js/Turbopack failing to fetch Google Fonts (TLS/network issue) unrelated to these documentation-only changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b9fa91e108323b746cfe5bb198ff8)