### PR TITLE
refactor(about): move DataSourceCard to server boundary

### DIFF
--- a/context/context.md
+++ b/context/context.md
@@ -3,7 +3,7 @@
 ## Project Summary
 
 - Costa Rica Tree Atlas is a bilingual (EN/ES) Next.js 16 application using Contentlayer MDX content and next-intl routing.
-- This task focused on the highest-priority open engineering work in `docs/IMPLEMENTATION_PLAN.md` Phase 3 performance: migrating additional homepage UI sections from client to server components to reduce hydration cost.
+- This task focused on the highest-priority open engineering work in `docs/IMPLEMENTATION_PLAN.md` Phase 3 performance: migrating additional UI components from client to server components to reduce hydration cost.
 
 ## Dependency Graph (High Level)
 
@@ -22,11 +22,8 @@
 
 ## Key Paths by Feature
 
-- Homepage route and composition: `src/app/[locale]/page.tsx`
-- Homepage sections converted to server components:
-  - `src/components/home/AboutSection.tsx`
-  - `src/components/home/StatsSection.tsx`
-  - `src/components/home/NowBloomingSection.tsx`
+- About route and composition: `src/app/[locale]/about/page.tsx`
+- About data source card component: `src/components/DataSourceCard.tsx`
 - Translation source files: `messages/en.json`, `messages/es.json`
 - Planning tracker: `docs/IMPLEMENTATION_PLAN.md`
 
@@ -34,4 +31,4 @@
 
 - EN/ES translation parity is required for any UI string changes.
 - Components under `src/components/**` should avoid `"use client"` unless hooks/browser APIs are needed.
-- The homepage retains dynamic/lazy loading for heavier below-the-fold components while moving purely render-only sections to server components.
+- Components in `src/components/**` should avoid client boundaries unless hooks or browser APIs are required.

--- a/context/links.md
+++ b/context/links.md
@@ -9,6 +9,12 @@ GitHub issue/PR metadata is not available from this local environment (no remote
 - `rg -n "^\"use client\"|^'use client'" src/components src/app`
 - `sed -n '1,260p' src/app/[locale]/page.tsx`
 
+## Additional discovery commands used for this change
+
+- `sed -n '1,260p' docs/IMPLEMENTATION_PLAN.md`
+- `rg -n "DataSourceCard|dataSources" src/app/[locale]/about/page.tsx`
+- `sed -n '220,340p' src/app/[locale]/about/page.tsx`
+
 ## Summary
 
 - Highest-priority open implementation item selected: Phase 3 performance task to migrate more components to server components.

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -443,6 +443,7 @@ See `audit-content-report.md` for complete list of 26 species.
 - [ ] Migrate more components to Server Components
   - [x] Convert `Footer` to server component to reduce client hydration (2026-02-10)
   - [x] Convert homepage `AboutSection`, `StatsSection`, and `NowBloomingSection` to server components (2026-02-10)
+  - [x] Convert `DataSourceCard` (about page) to server component by moving translations to parent and passing labels as props (2026-02-10)
 - [ ] Implement partial hydration
 - [ ] Add progressive enhancement strategies
 - [ ] Optimize database queries (when admin active)

--- a/src/app/[locale]/about/page.tsx
+++ b/src/app/[locale]/about/page.tsx
@@ -75,6 +75,10 @@ export default async function AboutPage({ params }: Props) {
 function AboutContent() {
   const t = useTranslations("about");
   const dataSourcesLabels = {
+    // Prefer these label-suffixed keys for clarity and easier prop spreading
+    whatWeUseLabel: t("dataSources.whatWeUseLabel"),
+    whyItMattersLabel: t("dataSources.whyItMattersLabel"),
+    // Backwards-compatible aliases for existing call sites
     whatWeUse: t("dataSources.whatWeUseLabel"),
     whyItMatters: t("dataSources.whyItMattersLabel"),
   };

--- a/src/app/[locale]/about/page.tsx
+++ b/src/app/[locale]/about/page.tsx
@@ -74,6 +74,10 @@ export default async function AboutPage({ params }: Props) {
 
 function AboutContent() {
   const t = useTranslations("about");
+  const dataSourcesLabels = {
+    whatWeUse: t("dataSources.whatWeUseLabel"),
+    whyItMatters: t("dataSources.whyItMattersLabel"),
+  };
 
   return (
     <article className="prose prose-lg dark:prose-invert mx-auto">
@@ -247,6 +251,8 @@ function AboutContent() {
             whyItMatters={t("dataSources.inaturalist.whyItMatters")}
             link="https://www.inaturalist.org"
             ctaText={t("dataSources.inaturalist.cta")}
+            whatWeUseLabel={dataSourcesLabels.whatWeUse}
+            whyItMattersLabel={dataSourcesLabels.whyItMatters}
           />
 
           <DataSourceCard
@@ -257,6 +263,8 @@ function AboutContent() {
             whyItMatters={t("dataSources.sinac.whyItMatters")}
             link="https://www.sinac.go.cr"
             ctaText={t("dataSources.sinac.cta")}
+            whatWeUseLabel={dataSourcesLabels.whatWeUse}
+            whyItMattersLabel={dataSourcesLabels.whyItMatters}
           />
 
           <DataSourceCard
@@ -267,6 +275,8 @@ function AboutContent() {
             whyItMatters={t("dataSources.museoNacional.whyItMatters")}
             link="https://www.museocostarica.go.cr/nuestro-trabajo/colecciones/historia-natural/herbario/"
             ctaText={t("dataSources.museoNacional.cta")}
+            whatWeUseLabel={dataSourcesLabels.whatWeUse}
+            whyItMattersLabel={dataSourcesLabels.whyItMatters}
           />
 
           <DataSourceCard
@@ -277,6 +287,8 @@ function AboutContent() {
             whyItMatters={t("dataSources.inbio.whyItMatters")}
             link="http://www.inbio.ac.cr"
             ctaText={t("dataSources.inbio.cta")}
+            whatWeUseLabel={dataSourcesLabels.whatWeUse}
+            whyItMattersLabel={dataSourcesLabels.whyItMatters}
           />
 
           <DataSourceCard
@@ -287,6 +299,8 @@ function AboutContent() {
             whyItMatters={t("dataSources.ots.whyItMatters")}
             link="https://tropicalstudies.org/portfolio/las-cruces-research-station/"
             ctaText={t("dataSources.ots.cta")}
+            whatWeUseLabel={dataSourcesLabels.whatWeUse}
+            whyItMattersLabel={dataSourcesLabels.whyItMatters}
           />
 
           <DataSourceCard
@@ -297,6 +311,8 @@ function AboutContent() {
             whyItMatters={t("dataSources.lankester.whyItMatters")}
             link="https://jbl.ucr.ac.cr"
             ctaText={t("dataSources.lankester.cta")}
+            whatWeUseLabel={dataSourcesLabels.whatWeUse}
+            whyItMattersLabel={dataSourcesLabels.whyItMatters}
           />
         </div>
 

--- a/src/components/DataSourceCard.tsx
+++ b/src/components/DataSourceCard.tsx
@@ -1,7 +1,3 @@
-"use client";
-
-import { useTranslations } from "next-intl";
-
 interface DataSourceCardProps {
   name: string;
   icon: string;
@@ -10,6 +6,8 @@ interface DataSourceCardProps {
   whyItMatters: string;
   link: string;
   ctaText: string;
+  whatWeUseLabel: string;
+  whyItMattersLabel: string;
 }
 
 export function DataSourceCard({
@@ -20,9 +18,9 @@ export function DataSourceCard({
   whyItMatters,
   link,
   ctaText,
+  whatWeUseLabel,
+  whyItMattersLabel,
 }: DataSourceCardProps) {
-  const t = useTranslations("about.dataSources");
-
   return (
     <div className="bg-card border border-border rounded-xl p-6 hover:border-primary/30 hover:shadow-lg transition-all">
       {/* Header */}
@@ -37,7 +35,7 @@ export function DataSourceCard({
       {/* What We Use */}
       <div className="mb-4">
         <h4 className="text-sm font-semibold text-primary-dark dark:text-primary-light mb-2">
-          {t("whatWeUseLabel")}
+          {whatWeUseLabel}
         </h4>
         <p className="text-sm text-foreground/80">{whatWeUse}</p>
       </div>
@@ -45,7 +43,7 @@ export function DataSourceCard({
       {/* Why It Matters */}
       <div className="mb-4">
         <h4 className="text-sm font-semibold text-primary-dark dark:text-primary-light mb-2">
-          {t("whyItMattersLabel")}
+          {whyItMattersLabel}
         </h4>
         <p className="text-sm text-foreground/80">{whyItMatters}</p>
       </div>


### PR DESCRIPTION
### Motivation
- Reduce unnecessary client-side hydration for a purely presentational About page component to improve performance (Phase 3 migration to Server Components).
- Avoid creating a client boundary solely to read translation strings and centralize i18n resolution at the parent to maintain parity and reduce duplicated work.

### Description
- Removed the `"use client"` directive and `useTranslations` usage from `src/components/DataSourceCard.tsx` and added `whatWeUseLabel` and `whyItMattersLabel` props so the component is purely presentational.
- Updated `src/app/[locale]/about/page.tsx` to resolve the shared `dataSources` labels once using `useTranslations("about")` and pass them into each `DataSourceCard` instance.
- Recorded the migration step in `docs/IMPLEMENTATION_PLAN.md` and updated `context/context.md` and `context/links.md` to reflect the change and discovery commands used.

### Testing
- Ran `npm run lint` which completed successfully (repository warnings remain but no new errors introduced).
- Ran `npm run type-check` which failed due to pre-existing repository-wide Contentlayer/type issues unrelated to this refactor.
- Ran `npm run build` which failed in this environment because Turbopack could not fetch Google Fonts (`Geist`, `Geist Mono`) due to a TLS/network fetch issue; this is environment-specific and not caused by the component change.
- Ran a lightweight secret scan (`rg ...`) which found only expected env references and no committed secrets.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698baaf91f888323b839430fc5d9ad00)