### PR TITLE
fix(auth): always generate Prisma Client at build + update admin setup docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,7 +121,7 @@ If you have questions about licensing, please ask in [GitHub Discussions](https:
 
 ### Admin Access
 
-The project includes admin routes (e.g., `/en/admin/images` for reviewing tree images) that require **NextAuth + database-backed authentication**.
+The project includes admin routes (e.g., `/{locale}/admin/images` such as `/en/admin/images` or `/es/admin/images` for reviewing tree images) that require **NextAuth + database-backed authentication**.
 
 To enable admin access during development:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,7 +121,7 @@ If you have questions about licensing, please ask in [GitHub Discussions](https:
 
 ### Admin Access
 
-The project includes admin routes (e.g., `/en/admin/images` for reviewing tree images) that require authentication.
+The project includes admin routes (e.g., `/en/admin/images` for reviewing tree images) that require **NextAuth + database-backed authentication**.
 
 To enable admin access during development:
 
@@ -131,20 +131,32 @@ To enable admin access during development:
    cp .env.example .env.local
    ```
 
-2. **Set the `ADMIN_PASSWORD` environment variable**
+2. **Configure required auth/database environment variables**
 
    ```bash
    # In .env.local
-   ADMIN_PASSWORD=your-secure-password
+   DATABASE_URL=postgresql://USER:PASSWORD@HOST:5432/DB_NAME
+   NEXTAUTH_SECRET=your-generated-secret
+   NEXTAUTH_URL=http://localhost:3000
+   MFA_ENCRYPTION_KEY=your-64-char-hex-key
    ```
 
-3. **Access admin routes**
+3. **Generate Prisma Client and run migrations**
 
-   When you visit an admin route (e.g., `http://localhost:3000/en/admin/images`), your browser will prompt for credentials:
-   - **Username**: `admin`
-   - **Password**: The value you set in `ADMIN_PASSWORD`
+   ```bash
+   npm run prisma:generate:optional
+   npx prisma migrate dev
+   ```
 
-**Security Note**: Without `ADMIN_PASSWORD` configured, admin routes will return a 503 error. Never commit `.env.local` or share your admin password publicly.
+4. **Create at least one admin user record**
+
+   Use the app's auth/admin bootstrap flow or a seed script for your environment so a valid user exists in the `users` table.
+
+5. **Access admin routes**
+
+   Visit `http://localhost:3000/en/admin/login` and sign in with your database-backed credentials.
+
+**Security Note**: Never commit `.env.local` or share secrets/passwords publicly.
 
 ## Development Workflow
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,7 +154,7 @@ To enable admin access during development:
 
 5. **Access admin routes**
 
-   Visit `http://localhost:3000/en/admin/login` and sign in with your database-backed credentials.
+   Visit `http://localhost:3000/{locale}/admin/login` (for example, `/en/admin/login` or `/es/admin/login`) and sign in with your database-backed credentials.
 
 **Security Note**: Never commit `.env.local` or share secrets/passwords publicly.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,10 +148,12 @@ To enable admin access during development:
    npx prisma migrate dev
    ```
 
-4. **Create at least one admin user record**
+4. **Create the first admin user**
 
-   Use the app's auth/admin bootstrap flow or a seed script for your environment so a valid user exists in the `users` table.
+   With your dev server running, call the one-time setup endpoint to create the initial admin user:
 
+   ```bash
+   curl -X POST http://localhost:3000/api/admin/setup
 5. **Access admin routes**
 
    Visit `http://localhost:3000/{locale}/admin/login` (for example, `/en/admin/login` or `/es/admin/login`) and sign in with your database-backed credentials.

--- a/context/context.md
+++ b/context/context.md
@@ -43,3 +43,13 @@
 - Continued Phase 3 performance work by converting `src/components/FeaturedTreesSection.tsx` from a client component to a server component.
 - Removed `useMemo`/client boundary and extracted deterministic featured-tree selection into a pure server-side helper within the component file.
 - Updated performance tracking docs in `docs/IMPLEMENTATION_PLAN.md` and `docs/PERFORMANCE_OPTIMIZATION.md`.
+
+## Latest Update (2026-02-11, Prisma build env fallback)
+
+- Fixed admin login deployment regression where Prisma Client could be unavailable at runtime because `prisma generate` was skipped when `DATABASE_URL` was not present at build time.
+- Updated the npm `prisma:generate:optional` script to always run `prisma generate` using a placeholder PostgreSQL URL when `DATABASE_URL` is unset.
+
+## Latest Update (2026-02-11, Admin auth docs alignment)
+
+- Updated `CONTRIBUTING.md` Admin Access section to reflect current NextAuth + Prisma workflow (database-backed login), replacing outdated legacy `ADMIN_PASSWORD` basic-auth instructions.
+- Added explicit setup steps for required env vars, Prisma generation/migrations, and login path.

--- a/context/links.md
+++ b/context/links.md
@@ -32,3 +32,14 @@ GitHub issue/PR metadata is not available from this local environment (no remote
 - `rg -n 'FeaturedTreesSection' -g '*.tsx' src`
 - `sed -n '1,290p' src/app/[locale]/page.tsx`
 - `rg -n 'Phase 3|Server Components|Footer|AboutSection|CurrentYear|FeaturedTreesSection' docs/PERFORMANCE_OPTIMIZATION.md docs/IMPLEMENTATION_PLAN.md`
+
+## Additional discovery commands used for Prisma admin auth issue
+
+- `rg -n "Prisma Client is not available|DATABASE_URL was not set during build|Authentication failed" src`
+- `sed -n '1,220p' src/lib/prisma.ts`
+- `sed -n '1,220p' package.json`
+
+## Additional discovery commands used for admin docs cleanup
+
+- `nl -ba CONTRIBUTING.md | sed -n '110,180p'`
+- `rg -n "Admin Access|ADMIN_PASSWORD|DATABASE_URL|NextAuth" CONTRIBUTING.md src/app/api/auth/[...nextauth]/route.ts package.json`

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "npm run prisma:generate:optional && contentlayer2 build && next build",
-    "prisma:generate:optional": "DATABASE_URL=${DATABASE_URL:-postgresql://placeholder:placeholder@localhost:5432/placeholder} prisma generate",
+    "prisma:generate:optional": "DATABASE_URL=\"${DATABASE_URL:-postgresql://placeholder:placeholder@localhost:5432/placeholder}\" prisma generate",
     "start": "next start",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "npm run prisma:generate:optional && contentlayer2 build && next build",
-    "prisma:generate:optional": "if [ -n \"$DATABASE_URL\" ]; then prisma generate; else echo 'Skipping Prisma generation (DATABASE_URL not set)'; fi",
+    "prisma:generate:optional": "DATABASE_URL=${DATABASE_URL:-postgresql://placeholder:placeholder@localhost:5432/placeholder} prisma generate",
     "start": "next start",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",


### PR DESCRIPTION
### Motivation
- Fix a runtime admin login failure caused by the Prisma Client not being generated when `DATABASE_URL` was unset at build time.
- Make contributor docs accurate by reflecting the current NextAuth + Prisma database-backed auth flow so local setup and troubleshooting match runtime requirements.

### Description
- Change `package.json` `prisma:generate:optional` to run `prisma generate` with a placeholder `DATABASE_URL` fallback so generation always runs at build time.
- Replace legacy basic-auth `ADMIN_PASSWORD` instructions with explicit NextAuth/Prisma setup steps in `CONTRIBUTING.md`, including required env vars, `prisma` generation/migrations, and the admin login path (`/en/admin/login`).
- Update `context/context.md` and `context/links.md` with notes about the Prisma build-env fallback and the discovery commands used during the change.

### Testing
- Ran `npm run prisma:generate:optional` and it completed successfully, producing a generated Prisma client.
- Ran `npm run lint` and it completed with existing repository warnings (no new lint errors introduced).
- Ran `npm run build` which failed due to external Google Fonts TLS fetch errors unrelated to the Prisma/auth changes, indicating the fix addresses the original Prisma-client build issue but a separate environment TLS issue remains.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ce7bd5a088323a082ccefbc56b35c)