### PR TITLE
docs: add persistent next-agent handoff guide

### DIFF
--- a/docs/NEXT_AGENT_HANDOFF.md
+++ b/docs/NEXT_AGENT_HANDOFF.md
@@ -4,7 +4,7 @@ Last updated: 2026-02-12
 
 ## Current Repository State
 
-- Repository path: `/Users/christopherennis/Websites/Costa-Rica-Tree-Atlas`
+- Repository path: `<REPO_ROOT>` (resolve via `git rev-parse --show-toplevel`)
 - Canonical base branch: `main`
 - Main commit at handoff creation: `66c51d5`
 - Most recent merged PRs:
@@ -13,7 +13,7 @@ Last updated: 2026-02-12
 
 ## Highest-Priority Remaining Work
 
-From `/Users/christopherennis/Websites/Costa-Rica-Tree-Atlas/docs/IMPLEMENTATION_PLAN.md`:
+From `<REPO_ROOT>/docs/IMPLEMENTATION_PLAN.md`:
 
 - Priority 1.3 remains active.
 - Week 2 progress: `15/30`.
@@ -32,8 +32,10 @@ From `/Users/christopherennis/Websites/Costa-Rica-Tree-Atlas/docs/IMPLEMENTATION
 You are working in an existing repo with strict agent instructions.
 
 Repository
-- Path: /Users/christopherennis/Websites/Costa-Rica-Tree-Atlas
-- Start by reading: /Users/christopherennis/Websites/Costa-Rica-Tree-Atlas/docs/NEXT_AGENT_HANDOFF.md
+- Resolve repo root first:
+  - REPO_ROOT=$(git rev-parse --show-toplevel)
+- Path: $REPO_ROOT
+- Start by reading: $REPO_ROOT/docs/NEXT_AGENT_HANDOFF.md
 - Treat repository docs as authoritative, especially IMPLEMENTATION_PLAN.md and AGENTS.md
 
 Mission
@@ -43,10 +45,10 @@ Mission
 
 Required workflow
 1. Read and follow:
-   - /Users/christopherennis/Websites/Costa-Rica-Tree-Atlas/AGENTS.md
-   - /Users/christopherennis/Websites/Costa-Rica-Tree-Atlas/.github/instructions/*.md
-   - /Users/christopherennis/Websites/Costa-Rica-Tree-Atlas/docs/IMPLEMENTATION_PLAN.md
-   - /Users/christopherennis/Websites/Costa-Rica-Tree-Atlas/docs/NEXT_AGENT_HANDOFF.md
+   - $REPO_ROOT/AGENTS.md
+   - $REPO_ROOT/.github/instructions/*.md
+   - $REPO_ROOT/docs/IMPLEMENTATION_PLAN.md
+   - $REPO_ROOT/docs/NEXT_AGENT_HANDOFF.md
 2. Sync main:
    - git fetch origin
    - git checkout main
@@ -72,7 +74,7 @@ MANDATORY END-OF-RUN DIRECTIVES
    - If PR merged, clean associated branches (remote and local) when safe.
    - Ensure local main can be fast-forwarded cleanly.
 2. Handoff:
-   - Update /Users/christopherennis/Websites/Costa-Rica-Tree-Atlas/docs/NEXT_AGENT_HANDOFF.md with latest state (commit, merged PR, remaining top task).
+   - Update $REPO_ROOT/docs/NEXT_AGENT_HANDOFF.md with latest state (commit, merged PR, remaining top task).
    - Write a fresh next-agent prompt that explicitly references this handoff file.
 ```
 

--- a/docs/NEXT_AGENT_HANDOFF.md
+++ b/docs/NEXT_AGENT_HANDOFF.md
@@ -1,0 +1,86 @@
+# Next Agent Handoff
+
+Last updated: 2026-02-12
+
+## Current Repository State
+
+- Repository path: `/Users/christopherennis/Websites/Costa-Rica-Tree-Atlas`
+- Canonical base branch: `main`
+- Main commit at handoff creation: `66c51d5`
+- Most recent merged PRs:
+  - #362 `[ImgBot] Optimize images`
+  - #361 `feat: expand care guidance for 4 medium-priority palm species`
+
+## Highest-Priority Remaining Work
+
+From `/Users/christopherennis/Websites/Costa-Rica-Tree-Atlas/docs/IMPLEMENTATION_PLAN.md`:
+
+- Priority 1.3 remains active.
+- Week 2 progress: `15/30`.
+- Open task: `Add care guidance to 15 additional mid-priority species`.
+
+## Operator Preferences (Persistent)
+
+1. Batch depth: go as far as practical in each run, with slight safety margin to reduce regression risk.
+2. Warning policy: be lenient with pre-existing lint warnings; avoid warning churn unless directly related to touched changes.
+3. Handoff policy: always update this file at end of run and ensure the next prompt references this file.
+4. Branch hygiene: after PR merge, clean up associated branches (remote and local) when safe.
+
+## Next-Agent Prompt (Copy/Paste)
+
+```text
+You are working in an existing repo with strict agent instructions.
+
+Repository
+- Path: /Users/christopherennis/Websites/Costa-Rica-Tree-Atlas
+- Start by reading: /Users/christopherennis/Websites/Costa-Rica-Tree-Atlas/docs/NEXT_AGENT_HANDOFF.md
+- Treat repository docs as authoritative, especially IMPLEMENTATION_PLAN.md and AGENTS.md
+
+Mission
+- Execute the highest-priority unchecked item in docs/IMPLEMENTATION_PLAN.md.
+- If multiple tightly coupled changes affect the same feature/files, implement them together.
+- Do not ask questions if answer exists in repo docs.
+
+Required workflow
+1. Read and follow:
+   - /Users/christopherennis/Websites/Costa-Rica-Tree-Atlas/AGENTS.md
+   - /Users/christopherennis/Websites/Costa-Rica-Tree-Atlas/.github/instructions/*.md
+   - /Users/christopherennis/Websites/Costa-Rica-Tree-Atlas/docs/IMPLEMENTATION_PLAN.md
+   - /Users/christopherennis/Websites/Costa-Rica-Tree-Atlas/docs/NEXT_AGENT_HANDOFF.md
+2. Sync main:
+   - git fetch origin
+   - git checkout main
+   - git pull --ff-only origin main
+3. Create a branch using conventions: feature/*, fix/*, content/*, docs/*.
+4. Implement selected item end-to-end.
+5. Update docs/counters/checklists affected by your change.
+6. Verify:
+   - npm run lint
+   - npm run build
+7. Commit with conventional commit type, push, and open PR to main.
+
+Output format
+- Chosen task and why it was highest priority
+- Exact files changed
+- Verification results (lint/build)
+- PR link
+- Blockers or follow-up recommendations
+
+MANDATORY END-OF-RUN DIRECTIVES
+1. Cleanup:
+   - Ensure worktree is clean or explain exactly why not.
+   - If PR merged, clean associated branches (remote and local) when safe.
+   - Ensure local main can be fast-forwarded cleanly.
+2. Handoff:
+   - Update /Users/christopherennis/Websites/Costa-Rica-Tree-Atlas/docs/NEXT_AGENT_HANDOFF.md with latest state (commit, merged PR, remaining top task).
+   - Write a fresh next-agent prompt that explicitly references this handoff file.
+```
+
+## End-of-Run Checklist
+
+- [ ] `main` synced to `origin/main`
+- [ ] Feature/fix/content/docs branch used for changes
+- [ ] PR opened (and merged if applicable)
+- [ ] Associated merged branches cleaned up (remote + local)
+- [ ] `docs/NEXT_AGENT_HANDOFF.md` updated
+- [ ] Next-agent prompt generated and references `docs/NEXT_AGENT_HANDOFF.md`


### PR DESCRIPTION
## Summary
- add docs/NEXT_AGENT_HANDOFF.md as the canonical handoff document
- include persistent operator preferences for task depth, warning leniency, handoff updates, and branch cleanup
- include a copy/paste next-agent prompt that explicitly references the handoff file
- include mandatory end-of-run directives requiring cleanup + regeneration of the next handoff prompt

## Verification
- npm run lint (passes with existing repo warnings; no new errors)
- npm run build (passes)