### PR TITLE
feat: expand care guidance for 5 mid-priority species

### DIFF
--- a/content/trees/en/corozo.mdx
+++ b/content/trees/en/corozo.mdx
@@ -40,7 +40,7 @@ fruitingSeason:
   - "december"
 featuredImage: "/images/trees/corozo.jpg"
 publishedAt: "2026-02-09"
-updatedAt: "2026-02-09"
+updatedAt: "2026-02-12"
 # Safety Information
 toxicityLevel: "none"
 toxicParts: []
@@ -364,6 +364,13 @@ Choose a low-lying site with consistently moist to wet soil and full sun. The Co
 - Apply balanced fertilizer (12-12-12) every 6 months for fruiting
 - Remove dead fronds by cutting cleanly at the trunk
 - Monitor for bud rot symptoms (wilting of spear leaf, brown discoloration)
+
+### Companion Planting for Wet-Site Restoration
+
+- **Upper canopy support**: Pair with floodplain trees such as _Higuerón_ and _Guácimo_ to create layered habitat and wind buffering around young Corozo palms.
+- **Wetland understory**: Use moisture-loving understory plants (for example native heliconias and shade-adapted ferns) to protect soil, retain humidity, and reduce weed pressure.
+- **Riparian corridors**: Integrate with other native wet-zone species in strips along quebradas and river margins to improve wildlife movement and reduce bank erosion.
+- **Avoid**: Dry-forest species and crops that require frequent soil drying; Corozo performs poorly in mixed plantings designed for drought-tolerant trees.
 
 ### Care Calendar
 

--- a/content/trees/en/cortez-blanco.mdx
+++ b/content/trees/en/cortez-blanco.mdx
@@ -39,7 +39,7 @@ fruitingSeason:
   - "june"
 featuredImage: "/images/trees/cortez-blanco.jpg"
 publishedAt: "2026-02-09"
-updatedAt: "2026-02-09"
+updatedAt: "2026-02-12"
 # Safety Information
 toxicityLevel: "none"
 toxicParts: []
@@ -341,6 +341,13 @@ Seeds are the primary method of propagation. Collect capsules when they begin to
 ### Planting
 
 Transplant seedlings at the beginning of the rainy season (May–June) for best establishment. Dig planting holes 50 × 50 × 50 cm and amend with compost if soil is poor. Water thoroughly after planting and provide weekly supplemental irrigation through the first dry season. Staking may be necessary in windy sites.
+
+### Companion Planting and Dry-Forest Integration
+
+- **Pollinator support layer**: Plant nectar-rich shrubs such as _Sardinillo_ nearby to maintain pollinator activity before and after Cortez Blanco flowering peaks.
+- **Nitrogen-fixing partners**: Include species such as _Madero Negro_ in mixed reforestation blocks to improve soil fertility and early shade moderation for young Primavera trees.
+- **Urban avenue pairing**: In parks and roadsides, combine with lower understory ornamentals that tolerate dry-season stress to reduce bare-soil heat around the root zone.
+- **Avoid**: Dense evergreen companions planted too close to the crown; heavy shade reduces flowering intensity and canopy architecture.
 
 ### Care Calendar
 

--- a/content/trees/en/flor-de-itabo.mdx
+++ b/content/trees/en/flor-de-itabo.mdx
@@ -42,7 +42,7 @@ fruitingSeason:
   - "july"
 featuredImage: "/images/trees/flor-de-itabo.jpg"
 publishedAt: "2026-02-09"
-updatedAt: "2026-02-09"
+updatedAt: "2026-02-12"
 # Safety Information
 toxicityLevel: "low"
 toxicParts: ["roots"]
@@ -357,6 +357,13 @@ Choose a location with full sun to partial shade and well-drained soil. The plan
 - No fertilizer needed; excessive fertility can reduce the plant's natural character
 - Remove dead lower leaves periodically for aesthetic purposes
 - Trim sharp leaf tips if planted near walkways or areas with children
+
+### Companion Planting for Living Fences
+
+- **Fence-line backbone**: Combine with _Jocote_ and _Madero Negro_ to build multi-species living fences that provide flowers, forage, and resilient boundary structure.
+- **Dryland orchard edges**: Use Flor de Itabo on the windward side of small orchards to reduce heat stress on young fruit trees while keeping low irrigation demand.
+- **Pollinator and food matrix**: Interplant with herbaceous species that benefit from partial shelter (for example culinary herbs and seasonal vegetables) near homestead systems.
+- **Avoid**: Dense, shade-casting trees planted immediately south or west of Itabo rows in narrow spaces; reduced light lowers flowering and edible bud production.
 
 ### Care Calendar
 

--- a/content/trees/en/papayillo.mdx
+++ b/content/trees/en/papayillo.mdx
@@ -41,7 +41,7 @@ fruitingSeason:
   - "october"
 featuredImage: "/images/trees/papayillo.jpg"
 publishedAt: "2026-02-09"
-updatedAt: "2026-02-09"
+updatedAt: "2026-02-12"
 # Safety Information
 toxicityLevel: "low"
 toxicParts: ["fruit", "sap"]
@@ -345,6 +345,13 @@ The Papayillo requires cloud forest-like conditions: cool temperatures (10–25�
 - Mist the foliage regularly in dry periods or install a mist system
 - Protect from direct afternoon sun, especially below 1,500 m elevation
 - Stake the young plant — the slender trunk is vulnerable to wind
+
+### Companion Planting in Cloud-Forest Gardens
+
+- **Upper-story shade partners**: Establish beneath medium-canopy natives such as _Copey_ and _Aguacatillo_ to replicate filtered cloud-forest light.
+- **Moisture-retention understory**: Pair with ferns, shade palms, and other humidity-loving understory plants to stabilize microclimate and protect shallow roots.
+- **Genetic buffer strategy**: In conservation plots, plant multiple _Vasconcellea_ individuals with unrelated cloud-forest associates to reduce disease pressure from single-species clustering.
+- **Avoid**: Open, wind-exposed sites or direct pairing with heavy-feeding annual crops that disrupt mulch layers and root-zone humidity.
 
 ### Care Calendar
 

--- a/content/trees/en/sardinillo.mdx
+++ b/content/trees/en/sardinillo.mdx
@@ -58,7 +58,7 @@ fruitingSeason:
   - "november"
 featuredImage: "/images/trees/sardinillo.jpg"
 publishedAt: "2026-02-09"
-updatedAt: "2026-02-09"
+updatedAt: "2026-02-12"
 # Safety Information
 toxicityLevel: "low"
 toxicParts: ["leaves", "bark", "roots"]
@@ -361,6 +361,13 @@ Choose a location with full sun for best flowering performance. Sardinillo toler
 - Water regularly for first 2–3 months, then only during severe drought
 - Prune after each major flush to maintain shape and encourage reblooming
 - No fertilizer needed in most soils; excessive nitrogen promotes leaves over flowers
+
+### Companion Planting for Pollinator Corridors
+
+- **Flowering hedge mixes**: Pair with species such as _Flor de Itabo_ and native salvias to extend nectar availability across dry and wet seasons.
+- **Farm-edge companion**: Use as a sunny-border shrub around citrus, mango, and home-garden plots to attract beneficial insects and improve pollination.
+- **Soil-recovery strips**: Combine with deep-rooted pioneers in degraded soils to reduce erosion and accelerate revegetation on road cuts and pasture edges.
+- **Avoid**: Planting under dense tree canopies; flowering and medicinal leaf production drop sharply in heavy shade.
 
 ### Care Calendar
 

--- a/content/trees/es/corozo.mdx
+++ b/content/trees/es/corozo.mdx
@@ -40,7 +40,7 @@ fruitingSeason:
   - "december"
 featuredImage: "/images/trees/corozo.jpg"
 publishedAt: "2026-02-09"
-updatedAt: "2026-02-09"
+updatedAt: "2026-02-12"
 # Safety Information
 toxicityLevel: "none"
 toxicParts: []
@@ -385,6 +385,13 @@ Elija un sitio bajo con suelo constantemente húmedo a mojado y pleno sol. El Co
 - Aplique fertilizante balanceado (12-12-12) cada 6 meses para fructificación
 - Remueva frondas muertas cortando limpiamente desde el tronco
 - Monitoree para síntomas de pudrición cogollera (marchitamiento de la hoja lanza, decoloración marrón)
+
+### Plantas Compañeras para Restauración en Sitios Húmedos
+
+- **Soporte de dosel superior**: Combínelo con árboles de planicie inundable como _Higuerón_ y _Guácimo_ para crear hábitat estratificado y amortiguar viento alrededor de palmas jóvenes de Corozo.
+- **Sotobosque de humedal**: Use plantas de sotobosque amantes de la humedad (por ejemplo heliconias nativas y helechos adaptados a sombra) para proteger el suelo, retener humedad y reducir presión de malezas.
+- **Corredores ribereños**: Integre el Corozo con otras especies nativas de zonas húmedas en franjas a lo largo de quebradas y riberas para mejorar el movimiento de fauna y reducir erosión de taludes.
+- **Evitar**: Especies de bosque seco y cultivos que requieren secado frecuente del suelo; el Corozo funciona mal en arreglos diseñados para árboles tolerantes a sequía.
 
 ### Calendario de Cuidados
 

--- a/content/trees/es/cortez-blanco.mdx
+++ b/content/trees/es/cortez-blanco.mdx
@@ -39,7 +39,7 @@ fruitingSeason:
   - "june"
 featuredImage: "/images/trees/cortez-blanco.jpg"
 publishedAt: "2026-02-09"
-updatedAt: "2026-02-09"
+updatedAt: "2026-02-12"
 # Safety Information
 toxicityLevel: "none"
 toxicParts: []
@@ -352,6 +352,13 @@ Las semillas son el método principal de propagación. Recolecte las cápsulas c
 ### Plantación
 
 Trasplante las plántulas al inicio de la estación lluviosa (mayo–junio) para mejor establecimiento. Cave hoyos de plantación de 50 × 50 × 50 cm y enmiende con compost si el suelo es pobre. Riegue abundantemente después de plantar y proporcione riego suplementario semanal durante la primera estación seca. Puede ser necesario tutorar en sitios ventosos.
+
+### Plantas Compañeras e Integración en Bosque Seco
+
+- **Capa de apoyo a polinizadores**: Plante arbustos nectaríferos como _Sardinillo_ cerca para mantener actividad de polinizadores antes y después de los picos de floración del Cortez Blanco.
+- **Aliados fijadores de nitrógeno**: Incluya especies como _Madero Negro_ en bloques mixtos de reforestación para mejorar fertilidad del suelo y moderar el microclima durante el establecimiento.
+- **Asociación urbana**: En parques y avenidas, combínelo con ornamentales de estrato bajo tolerantes a la estación seca para reducir calentamiento del suelo alrededor de las raíces.
+- **Evitar**: Compañeras perennifolias densas plantadas demasiado cerca de la copa; la sombra pesada reduce la intensidad de floración y la arquitectura característica.
 
 ### Calendario de Cuidados
 

--- a/content/trees/es/flor-de-itabo.mdx
+++ b/content/trees/es/flor-de-itabo.mdx
@@ -42,7 +42,7 @@ fruitingSeason:
   - "july"
 featuredImage: "/images/trees/flor-de-itabo.jpg"
 publishedAt: "2026-02-09"
-updatedAt: "2026-02-09"
+updatedAt: "2026-02-12"
 # Safety Information
 toxicityLevel: "low"
 toxicParts: ["roots"]
@@ -365,6 +365,13 @@ Elija una ubicación con pleno sol a sombra parcial y suelo bien drenado. La pla
 - No se necesita fertilizante; la fertilidad excesiva puede reducir el carácter natural de la planta
 - Remueva hojas inferiores muertas periódicamente con fines estéticos
 - Recorte puntas afiladas de hojas si está plantada cerca de senderos o áreas con niños
+
+### Plantas Compañeras para Cercas Vivas
+
+- **Estructura principal de linderos**: Combínela con _Jocote_ y _Madero Negro_ para formar cercas vivas multiespecie que aportan floración, forraje y límites duraderos.
+- **Bordes de frutales de secano**: Use Flor de Itabo en el lado de barlovento de huertos pequeños para reducir estrés térmico en árboles jóvenes con baja demanda de riego.
+- **Matriz de polinizadores y alimento**: Intercale especies herbáceas que se beneficien de sombra ligera (por ejemplo hierbas culinarias y hortalizas estacionales) en sistemas de patio.
+- **Evitar**: Árboles densos que proyecten sombra inmediata al sur u oeste en espacios angostos; la reducción de luz disminuye floración y producción de capullos comestibles.
 
 ### Calendario de Cuidados
 

--- a/content/trees/es/papayillo.mdx
+++ b/content/trees/es/papayillo.mdx
@@ -41,7 +41,7 @@ fruitingSeason:
   - "october"
 featuredImage: "/images/trees/papayillo.jpg"
 publishedAt: "2026-02-09"
-updatedAt: "2026-02-09"
+updatedAt: "2026-02-12"
 # Safety Information
 toxicityLevel: "low"
 toxicParts: ["fruit", "sap"]
@@ -352,6 +352,13 @@ El Papayillo requiere condiciones similares al bosque nuboso: temperaturas fresc
 - Nebulice el follaje regularmente en períodos secos o instale un sistema de nebulización
 - Proteja del sol directo de la tarde, especialmente por debajo de 1,500 m de elevación
 - Estacar la planta joven — el tronco esbelto es vulnerable al viento
+
+### Plantas Compañeras en Jardines de Bosque Nuboso
+
+- **Aliados de sombra alta**: Establézcalo bajo nativas de dosel medio como _Copey_ y _Aguacatillo_ para replicar la luz filtrada del bosque nuboso.
+- **Sotobosque retenedor de humedad**: Combínelo con helechos, palmas de sombra y otras plantas de sotobosque amantes de humedad para estabilizar el microclima y proteger raíces superficiales.
+- **Estrategia de amortiguamiento genético**: En parcelas de conservación, plante varios individuos de _Vasconcellea_ con acompañantes no emparentados del bosque nuboso para reducir presión de enfermedades por agrupación monoespecífica.
+- **Evitar**: Sitios abiertos y ventosos o asociación directa con cultivos anuales de alta demanda que rompan el acolchado y la humedad de la rizosfera.
 
 ### Calendario de Cuidados
 

--- a/content/trees/es/sardinillo.mdx
+++ b/content/trees/es/sardinillo.mdx
@@ -58,7 +58,7 @@ fruitingSeason:
   - "november"
 featuredImage: "/images/trees/sardinillo.jpg"
 publishedAt: "2026-02-09"
-updatedAt: "2026-02-09"
+updatedAt: "2026-02-12"
 # Safety Information
 toxicityLevel: "low"
 toxicParts: ["leaves", "bark", "roots"]
@@ -372,6 +372,13 @@ Elija una ubicación con pleno sol para mejor rendimiento de floración. El Sard
 - Regar regularmente durante los primeros 2–3 meses, luego solo durante sequía severa
 - Podar después de cada oleada principal para mantener la forma y estimular refloración
 - No se necesita fertilizante en la mayoría de suelos; el exceso de nitrógeno promueve hojas sobre flores
+
+### Plantas Compañeras para Corredores de Polinizadores
+
+- **Setos florales mixtos**: Combínelo con especies como _Flor de Itabo_ y salvias nativas para extender disponibilidad de néctar durante estación seca y lluviosa.
+- **Compañero de borde agrícola**: Úselo como arbusto de borde soleado alrededor de cítricos, mango y huertos caseros para atraer insectos benéficos y mejorar polinización.
+- **Franjas de recuperación de suelo**: Asócielo con pioneras de raíz profunda en suelos degradados para reducir erosión y acelerar revegetación en taludes y bordes de potrero.
+- **Evitar**: Plantarlo bajo doseles densos; la floración y la producción de hojas con uso medicinal disminuyen fuertemente en sombra pesada.
 
 ### Calendario de Cuidados
 

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -10,7 +10,7 @@
 - **Species**: 160/175 (91%) - Target: 175+ documented species
 - **Comparison Guides**: 20/20 (100%) ✅ Complete
 - **Glossary Terms**: 100/150 (67%) - Target: 150+ terms
-- **Care Guidance**: 60/128 (47%) - Target: 100/128 (78%)
+- **Care Guidance**: 80/128 (63%) - Target: 100/128 (78%)
 
 ### Technical Health
 
@@ -223,8 +223,8 @@ Recent additions completed:
 
 ### 1.3: Expand Care Guidance
 
-**Status:** 🚧 In Progress (Week 1: 10/10 complete ✅ | Week 2: 15/30 in progress)  
-**Current:** 75/128 (59%) → **Target:** 100/128 (78%)
+**Status:** 🚧 In Progress (Week 1: 10/10 complete ✅ | Week 2: 20/30 in progress)  
+**Current:** 80/128 (63%) → **Target:** 100/128 (78%)
 
 #### Week 1: Common Planted Trees (10 species) ✅ COMPLETE
 
@@ -267,7 +267,7 @@ All 10 Week 1 species now have comprehensive advanced care guidance:
 9. **Pochote** - Living fence establishment and dry forest restoration
 10. **Corteza Amarilla** - Ornamental flowering tree optimization and landscape design
 
-#### Weeks 2-4: Additional 30 Species (🚧 In Progress: 15/30)
+#### Weeks 2-4: Additional 30 Species (🚧 In Progress: 20/30)
 
 **Recently Completed (2026-02-08):**
 
@@ -286,10 +286,15 @@ All 10 Week 1 species now have comprehensive advanced care guidance:
 - [x] **Palma Yolillo (Batch 4, 2026-02-12)** - Wetland restoration-focused management (hydrology, monitoring, and seasonal restoration calendar)
 - [x] **Palma Suita (Batch 4, 2026-02-12)** - Deep-shade understory cultivation with humidity management and companion planting
 - [x] **Palma Cacho de Venado (Batch 4, 2026-02-12)** - High-rainfall canopy palm care with fruiting-season safety and agroforestry companions
+- [x] **Corozo (Batch 5, 2026-02-12)** - Wet-site companion planting guidance for floodplain restoration and riparian design
+- [x] **Cortez Blanco (Batch 5, 2026-02-12)** - Dry-forest companion planting strategy for pollinator support and mixed reforestation
+- [x] **Flor de Itabo (Batch 5, 2026-02-12)** - Living-fence companion planting patterns for homestead and agroecological systems
+- [x] **Papayillo (Batch 5, 2026-02-12)** - Cloud-forest companion planting framework focused on humidity and microclimate stability
+- [x] **Sardinillo (Batch 5, 2026-02-12)** - Pollinator-corridor companion planting for farm edges and degraded-site recovery
 
 **In Progress:**
 
-- [ ] Add care guidance to 15 additional mid-priority species
+- [ ] Add care guidance to 10 additional mid-priority species
 
 **Care Guidance Template:**
 

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -10,7 +10,7 @@
 - **Species**: 160/175 (91%) - Target: 175+ documented species
 - **Comparison Guides**: 20/20 (100%) ✅ Complete
 - **Glossary Terms**: 100/150 (67%) - Target: 150+ terms
-- **Care Guidance**: 80/128 (63%) - Target: 100/128 (78%)
+- **Care Guidance**: 65/128 (51%) - Target: 100/128 (78%)
 
 ### Technical Health
 

--- a/docs/NEXT_AGENT_HANDOFF.md
+++ b/docs/NEXT_AGENT_HANDOFF.md
@@ -6,18 +6,18 @@ Last updated: 2026-02-12
 
 - Repository path: `<REPO_ROOT>` (resolve via `git rev-parse --show-toplevel`)
 - Canonical base branch: `main`
-- Main commit at handoff creation: `66c51d5`
-- Most recent merged PRs:
-  - #362 `[ImgBot] Optimize images`
-  - #361 `feat: expand care guidance for 4 medium-priority palm species`
+- Main commit at handoff update: `e8b5e23`
+- Relevant PR state:
+  - Open: #364 `feat: expand care guidance for 5 mid-priority species`
+  - Most recent merged PRs: #362 `[ImgBot] Optimize images`, #361 `feat: expand care guidance for 4 medium-priority palm species`
 
 ## Highest-Priority Remaining Work
 
 From `<REPO_ROOT>/docs/IMPLEMENTATION_PLAN.md`:
 
 - Priority 1.3 remains active.
-- Week 2 progress: `15/30`.
-- Open task: `Add care guidance to 15 additional mid-priority species`.
+- Week 2 progress: `20/30`.
+- Open task: `Add care guidance to 10 additional mid-priority species`.
 
 ## Operator Preferences (Persistent)
 
@@ -74,15 +74,15 @@ MANDATORY END-OF-RUN DIRECTIVES
    - If PR merged, clean associated branches (remote and local) when safe.
    - Ensure local main can be fast-forwarded cleanly.
 2. Handoff:
-   - Update $REPO_ROOT/docs/NEXT_AGENT_HANDOFF.md with latest state (commit, merged PR, remaining top task).
-   - Write a fresh next-agent prompt that explicitly references this handoff file.
+   - Update $REPO_ROOT/docs/NEXT_AGENT_HANDOFF.md with latest state (commit, merged/open PR, remaining top task).
+   - Write a fresh next-agent prompt that explicitly references $REPO_ROOT/docs/NEXT_AGENT_HANDOFF.md.
 ```
 
 ## End-of-Run Checklist
 
-- [ ] `main` synced to `origin/main`
-- [ ] Feature/fix/content/docs branch used for changes
-- [ ] PR opened (and merged if applicable)
+- [x] `main` synced to `origin/main`
+- [x] Feature/fix/content/docs branch used for changes
+- [x] PR opened (and merged if applicable)
 - [ ] Associated merged branches cleaned up (remote + local)
-- [ ] `docs/NEXT_AGENT_HANDOFF.md` updated
-- [ ] Next-agent prompt generated and references `docs/NEXT_AGENT_HANDOFF.md`
+- [x] `docs/NEXT_AGENT_HANDOFF.md` updated
+- [x] Next-agent prompt generated and references `docs/NEXT_AGENT_HANDOFF.md`


### PR DESCRIPTION
## Summary
- expand care guidance in EN/ES for Corozo, Cortez Blanco, Flor de Itabo, Papayillo, and Sardinillo
- add companion planting guidance for each species and update `updatedAt` metadata
- update implementation plan progress from 15/30 to 20/30 for Week 2-4 care guidance

## Verification
- npm run lint (passes with existing warnings)
- npm run build (passes)
