### PR TITLE
feat(content): expand ES parity for six Priority 1.4 targets

### DIFF
--- a/content/trees/es/guanabana-cimarrona.mdx
+++ b/content/trees/es/guanabana-cimarrona.mdx
@@ -580,12 +580,16 @@ Se reportan usos etnobotánicos en hojas, corteza y semillas, pero existen riesg
 
 Usos tradicionales reportados (no recomendados sin supervisión experta):
 
-- Infusiones de hojas para malestares varios.
-- Aplicaciones de corteza en tratamientos externos.
-- Uso de semillas trituradas como insecticida tradicional.
+<SimpleList
+  items={[
+    "Infusiones de hojas para malestares varios",
+    "Aplicaciones de corteza en tratamientos externos",
+    "Uso de semillas trituradas como insecticida tradicional",
+  ]}
+/>
 
-  El uso crónico de extractos de anonáceas se ha asociado a riesgo neurológico
-  en ciertos contextos poblacionales.
+El uso crónico de extractos de anonáceas se ha asociado a riesgo neurológico
+en ciertos contextos poblacionales.
 
   </Callout>
 

--- a/content/trees/es/guanabana-cimarrona.mdx
+++ b/content/trees/es/guanabana-cimarrona.mdx
@@ -384,7 +384,383 @@ La Guanábana Cimarrona es un árbol perenne pequeño a mediano con copa densa y
 
 </Callout>
 
-_(Contenido completo continúa con secciones de Distribución Geográfica, Ecología, Usos, Conservación, Guía de Cultivo, Agroforestería, Comparación, Dónde Encontrar, Significado Cultural, Referencias y Resumen, siguiendo el mismo patrón detallado y comprensivo que la versión en inglés, manteniendo paridad bilingüe completa, aproximadamente 1000+ líneas totales)_
+## Distribución Geográfica
+
+### Rango Nativo
+
+<DataTable
+  headers={["Región", "Estatus", "Tipo de hábitat"]}
+  rows={[
+    ["Centroamérica", "Nativa", "Bosques húmedos y bordes de bosque"],
+    ["Islas del Caribe", "Nativa", "Bosques tropicales de baja elevación"],
+    ["Colombia", "Nativa", "Bosques lluviosos de tierras bajas"],
+    ["Venezuela", "Nativa", "Bosques húmedos tropicales"],
+    ["Ecuador", "Nativa", "Bosques bajos de vertiente pacífica"],
+    ["Perú", "Nativa", "Tierras bajas amazónicas"],
+    ["Brasil", "Nativa", "Bosques amazónicos y atlánticos"],
+    ["Introducida en trópicos", "Naturalizada", "Cultivo pantropical limitado"],
+  ]}
+/>
+
+### Distribución en Costa Rica
+
+_Annona montana_ aparece de forma natural en zonas húmedas de baja altitud en Caribe y Pacífico, con presencia ocasional en sistemas agroforestales y fincas rurales.
+
+<DataTable
+  headers={["Provincia o región", "Frecuencia", "Notas"]}
+  rows={[
+    [
+      "Limón (Caribe)",
+      "Común en estado silvestre",
+      "Bosques húmedos y áreas alteradas",
+    ],
+    [
+      "Puntarenas (Pacífico húmedo)",
+      "Ocasional",
+      "Península de Osa y zonas lluviosas",
+    ],
+    ["Alajuela (San Carlos)", "Ocasional", "Márgenes de ríos y suelos húmedos"],
+    [
+      "San José (sectores bajos)",
+      "Rara",
+      "Cultivo disperso o ejemplares escapados",
+    ],
+    ["Guanacaste", "Muy rara", "Solo en zonas de transición con alta humedad"],
+  ]}
+/>
+
+### Elevación y Clima
+
+<TwoColumn>
+<Column>
+
+#### Rango altitudinal
+
+- **Óptimo**: 0-600 m
+- **Rango general**: 0-1000 m
+- **Límite superior**: Poco frecuente arriba de 1000 m
+
+#### Requerimientos climáticos
+
+- **Temperatura**: 22-32°C
+- **Precipitación**: 2000-4000 mm/año
+- **Humedad**: Alta (70-95%)
+- **Estacionalidad**: Resiste humedad alta; peor respuesta en sequías largas
+
+</Column>
+<Column>
+
+#### Preferencias de hábitat
+
+- Bosques tropicales húmedos y márgenes ribereños
+- Sol pleno a semisombra
+- Suelo constantemente húmedo; tolera encharcamiento
+- Coloniza bordes de bosque y sitios perturbados
+
+#### Estado de conservación
+
+- **UICN**: Preocupación Menor (LC)
+- **Amenaza principal**: pérdida de hábitat por deforestación
+- **Tendencia**: estable a escala amplia
+
+</Column>
+</TwoColumn>
+
+---
+
+## Ecología y Hábitat
+
+### Rol en el Bosque
+
+_Annona montana_ funciona como árbol frutal de tamaño medio en bosques húmedos tropicales. Aunque su fruto no es tan palatable para humanos como el de _A. muricata_, sí participa en redes tróficas y procesos de regeneración.
+
+<TwoColumn>
+<Column>
+
+#### Funciones ecológicas
+
+- Recurso alimenticio para fauna oportunista
+- Dispersión de semillas por mamíferos y aves
+- Oferta de néctar y recursos florales para polinizadores
+- Colonización de bordes y claros en sucesión temprana
+
+</Column>
+<Column>
+
+#### Interacciones con fauna
+
+**Polinizadores principales**:
+
+- Escarabajos nitidúlidos
+- Otros coleópteros florícolas
+
+**Dispersores potenciales**:
+
+- Monos aulladores y capuchinos
+- Murciélagos frugívoros
+- Aves grandes frugívoras
+- Dispersión hídrica ocasional en cursos de agua
+
+</Column>
+</TwoColumn>
+
+### Biología Reproductiva
+
+Como otras _Annona_, presenta **protoginia** (fase femenina previa a la masculina), lo que favorece cruzamiento. En entornos forestales húmedos suele lograr cuaje aceptable sin polinización manual.
+
+### Suelo y Agua
+
+<DataTable
+  headers={["Factor", "Preferencia", "Tolerancia"]}
+  rows={[
+    [
+      "Tipo de suelo",
+      "Húmedo con materia orgánica",
+      "Amplia (incluye arcillas pesadas)",
+    ],
+    ["pH", "4.5-7.0", "Buena tolerancia a acidez"],
+    ["Materia orgánica", "Media-alta", "Flexible según sitio"],
+    ["Humedad", "Constante a alta", "Alta tolerancia a encharcamiento"],
+    ["Drenaje", "Variable", "Más tolerante que A. muricata"],
+    ["Fertilidad", "Baja a moderada", "No muy exigente"],
+  ]}
+/>
+
+<Callout type="success" title="Ventaja en Sitios Húmedos">
+  A diferencia de la guanábana cultivada (_A. muricata_), la guanábana cimarrona
+  soporta mejor suelos pesados y condiciones periódicamente inundables. Es una
+  opción viable donde otros frutales tropicales fallan por exceso de humedad.
+</Callout>
+
+---
+
+## Usos Tradicionales y Modernos
+
+### Uso Culinario (Limitado)
+
+El fruto se consume de forma limitada por su acidez marcada y textura fibrosa. Aun así, en zonas rurales se aprovecha para bebidas y mezclas.
+
+<DataTable
+  headers={["Preparación", "Descripción", "Observaciones"]}
+  rows={[
+    [
+      "Jugo muy endulzado",
+      "Pulpa diluida con agua y bastante azúcar",
+      "Uso tradicional local",
+    ],
+    [
+      "Bebidas mixtas",
+      "Combinada con frutas más dulces",
+      "Reduce acidez extrema",
+    ],
+    [
+      "Fermentados artesanales",
+      "Preparaciones regionales puntuales",
+      "Poco común",
+    ],
+    ["Consumo fresco", "Generalmente no recomendado", "Muy ácida y fibrosa"],
+    ["Postres", "Baja aptitud culinaria", "Mejor usar A. muricata"],
+  ]}
+/>
+
+<FeatureBox title="Preparación de Jugo de Guanábana Cimarrona" icon="🥤">
+  1. Use frutos maduros (ligeramente blandos). 2. Abra y extraiga pulpa. 3.
+  **Retire todas las semillas** (tóxicas). 4. Licúe con 3-4 partes de agua por 1
+  de pulpa. 5. Cuele para reducir fibra. 6. Endulce en mayor proporción que una
+  guanábana cultivada. 7. Puede mezclar con jugos dulces (piña, mango, banano).
+</FeatureBox>
+
+### Medicina Tradicional
+
+Se reportan usos etnobotánicos en hojas, corteza y semillas, pero existen riesgos significativos por compuestos neurotóxicos.
+
+<Callout type="danger" title="Uso Medicinal Tradicional: Riesgo Alto">
+  **Precaución**: salvo la pulpa sin semillas, las partes de la planta contienen
+  acetogeninas y alcaloides potencialmente tóxicos.
+
+Usos tradicionales reportados (no recomendados sin supervisión experta):
+
+- Infusiones de hojas para malestares varios.
+- Aplicaciones de corteza en tratamientos externos.
+- Uso de semillas trituradas como insecticida tradicional.
+
+  El uso crónico de extractos de anonáceas se ha asociado a riesgo neurológico
+  en ciertos contextos poblacionales.
+
+  </Callout>
+
+### Interés de Investigación
+
+- Perfil de acetogeninas con actividad biológica in vitro.
+- Potencial antimicrobiano de extractos.
+- Estudios comparativos de toxicidad frente a _A. muricata_.
+- Evaluación de riesgos neurotóxicos por exposición prolongada.
+
+---
+
+## Estado de Conservación
+
+<ConservationStatusBox
+  status="Least Concern (LC)"
+  trend="Stable"
+  threatLevel="Low"
+/>
+
+### Estado Actual
+
+<DataTable
+  headers={["Factor", "Estado", "Detalle"]}
+  rows={[
+    ["Lista Roja UICN", "Preocupación Menor", "Amplia distribución"],
+    ["Tendencia poblacional", "Estable", "Sin declive severo conocido"],
+    ["Amenaza principal", "Pérdida de hábitat", "Deforestación localizada"],
+    ["Presencia en áreas protegidas", "Sí", "Registros en reservas y parques"],
+    ["Estado de cultivo", "Limitado", "Uso no comercial generalizado"],
+  ]}
+/>
+
+La especie no requiere medidas de rescate específicas a gran escala, pero sí se beneficia de la protección de bosques húmedos y corredores riparios.
+
+---
+
+## Guía de Cultivo
+
+### ¿Cuándo Vale la Pena Plantarla?
+
+<Callout type="info" title="Defina el Objetivo Antes de Plantar">
+  **Sí conviene plantarla si**:
+
+✅ Necesita un árbol resistente para sombra en suelos húmedos.  
+ ✅ Quiere una especie rústica para cercas vivas o bordes de finca.  
+ ✅ Busca recurso alimenticio para fauna silvestre.  
+ ✅ Le interesa conservar parientes silvestres de frutales.
+
+❌ **No es ideal si** busca fruta agradable para consumo fresco regular.
+
+</Callout>
+
+### Propagación
+
+**Desde semilla** (método más simple):
+
+1. Extraer semillas de fruto maduro.
+2. Lavar restos de pulpa.
+3. Sembrar frescas (mejor viabilidad).
+4. Mantener sustrato húmedo y cálido.
+5. Germinación habitual en 2-4 semanas.
+
+**Injerto**: posible en programas especializados, pero poco común para uso doméstico.
+
+### Selección de Sitio y Plantación
+
+- Climas cálidos húmedos (0-1000 m).
+- Sol pleno o semisombra.
+- Suelos de textura variable, incluso pesados.
+- Distancias de 6-8 m para desarrollo de copa.
+- Establecer preferiblemente en temporada lluviosa.
+
+### Manejo General
+
+- Riego de establecimiento durante 1-2 años.
+- Aporte de compost 2-3 veces/año para acelerar crecimiento.
+- Poda ligera sanitaria y de estructura.
+- Monitoreo básico de plagas (escama, mosca de la fruta).
+
+### Cosecha
+
+Cosechar cuando el fruto ablanda ligeramente o cae por madurez. Procesar pronto por vida útil corta poscosecha.
+
+---
+
+## Aplicaciones Agroforestales
+
+En sistemas diversificados de zonas húmedas puede cumplir funciones útiles:
+
+- Sombra media para cacao y cultivos asociados.
+- Componente de cercas vivas y linderos biológicos.
+- Aporte a corredores de fauna en mosaicos rurales.
+- Opción para sitios con drenaje limitado.
+
+Asociaciones frecuentes: cacao, banano, pejibaye, guabas y especies de sotobosque húmedo.
+
+---
+
+## Comparación con Guanábana Cultivada
+
+### Diferencias Clave: _A. montana_ vs _A. muricata_
+
+<DataTable
+  headers={[
+    "Característica",
+    "A. montana (cimarrona)",
+    "A. muricata (cultivada)",
+  ]}
+  rows={[
+    ["Sabor", "Muy ácido y astringente", "Dulce-ácido balanceado"],
+    ["Textura", "Fibrosa y granulada", "Cremosa y jugosa"],
+    ["Tamaño de fruto", "15-20 cm", "20-30+ cm"],
+    ["Color al madurar", "Amarillo-verdoso", "Verde oscuro a verde claro"],
+    ["Vigor", "Más rústica y vigorosa", "Menor vigor relativo"],
+    ["Tolerancia a suelos húmedos", "Alta", "Baja-media"],
+    ["Uso principal", "Sombra/fauna/usos puntuales", "Fruta de mesa y jugos"],
+  ]}
+/>
+
+<Callout type="warning">
+  Para producción frutal de calidad culinaria, la opción recomendada sigue
+  siendo _A. muricata_. _A. montana_ destaca más por rusticidad ecológica que
+  por sabor.
+</Callout>
+
+---
+
+## Dónde Encontrarla en Costa Rica
+
+### Ambientes Silvestres
+
+- Tierras bajas húmedas del Caribe (Limón y Talamanca).
+- Sectores lluviosos de Osa y Pacífico sur.
+- Bordes de río y zonas alteradas con alta humedad.
+
+### Ambientes Semi-cultivados
+
+- Fincas rurales en zonas húmedas donde se usa como sombra.
+- Colecciones botánicas y parcelas experimentales.
+- Mercados locales: aparición ocasional, no comercial estable.
+
+<Callout type="tip">
+  Si desea observar esta especie, consulte guías locales y productores de zonas
+  húmedas. La identificación se facilita comparando sabor y textura del fruto
+  con la guanábana cultivada.
+</Callout>
+
+---
+
+## Significado Cultural
+
+Su presencia cultural es menor frente a la guanábana cultivada, pero mantiene valor en:
+
+- Conocimiento tradicional de comunidades rurales e indígenas.
+- Uso histórico en preparaciones medicinales locales.
+- Referencia botánica como pariente silvestre útil para investigación.
+- Conservación de diversidad genética dentro de las anonáceas.
+
+---
+
+## Referencias y Lecturas Recomendadas
+
+### Literatura científica
+
+1. Rainer, H. (2007). Estudios monográficos del género _Annona_.
+2. Liaw, C.C. et al. (2010). Acetogeninas en especies de _Annona_.
+3. Caparós-Lefebvre, D. et al. (2002). Evidencia de parkinsonismo atípico asociado a exposición crónica a anonáceas.
+4. Bernal, H.Y. et al. (2011). _Plantas Medicinales de los Andes_.
+
+### Recursos en línea
+
+- iNaturalist: observaciones de _Annona montana_
+- Tropicos (Missouri Botanical Garden)
+- Useful Tropical Plants
 
 ---
 

--- a/content/trees/es/lorito.mdx
+++ b/content/trees/es/lorito.mdx
@@ -206,63 +206,254 @@ El nombre común **"Lorito"** (lorito pequeño) se refiere a la forma de la hoja
 
 ## Descripción Física
 
-El **Lorito** es un árbol perennifolio pequeño a mediano o arbusto grande que típicamente alcanza 8-15 metros de altura con un diámetro de tronco de 15-30 cm.
+### Forma del Árbol
+
+El **Lorito** es un árbol perennifolio pequeño a mediano (a veces arbusto grande) que suele alcanzar 8-15 metros de altura, con tronco de 15-30 cm de diámetro.
+
+- **Tronco**: Generalmente único, aunque puede ser multitronco en sitios expuestos.
+- **Corteza**: Lisa, gris a gris parda, con lenticelas claras.
+- **Copa**: Redondeada a irregular, relativamente abierta.
+- **Arquitectura**: Ramas extendidas y silueta característica en bosques nubosos.
+- **Comportamiento foliar**: Mantiene hojas durante todo el año.
 
 ### Hojas
 
-Las hojas son la característica más distintiva del árbol. Grandes y profundamente lobuladas de manera palmada (5-9 lóbulos), se asemejan a una mano extendida o pie de loro—de ahí los nombres comunes. Cada lóbulo mide 8-15 cm de largo. Las hojas tienden a agruparse en las puntas de las ramas, creando una apariencia en capas atractiva.
+<PropertiesGrid>
+  <PropertyCard icon="🍃" label="Tipo" value="Simple, palmada (muy lobulada)" />
+  <PropertyCard icon="📏" label="Tamaño" value="15-30 cm de diámetro" />
+  <PropertyCard icon="🌿" label="Lóbulos" value="5-9 lóbulos profundos" />
+  <PropertyCard
+    icon="🎨"
+    label="Color"
+    value="Verde oscuro arriba, más clara por debajo"
+  />
+  <PropertyCard icon="✋" label="Forma" value="Mano abierta o pie de loro" />
+  <PropertyCard
+    icon="🔄"
+    label="Disposición"
+    value="Alterna, agrupada en puntas de ramas"
+  />
+</PropertiesGrid>
 
-Las hojas juveniles pueden tener menos lóbulos y una forma diferente que las hojas maduras, un fenómeno común en la familia Araliaceae.
+Las hojas son la característica más distintiva del árbol. Cada lóbulo suele medir 8-15 cm de largo, con margen dentado fino. Los pecíolos son largos (10-20 cm), lo que da movimiento al follaje bajo viento y neblina. En individuos jóvenes puede haber heterofilia (hojas juveniles con menos lóbulos o forma distinta), algo común en Araliaceae.
 
 ### Flores
 
-Las flores son pequeñas e inconspicuas individualmente pero producidas en inflorescencias terminales compuestas (umbelas o panículas) de 10-20 cm de ancho en los extremos de las ramas. Cada flor es pequeña (3-5 mm), de color blanco-verdoso a crema.
+<PropertiesGrid>
+  <PropertyCard icon="🌸" label="Color" value="Blanco verdoso a crema" />
+  <PropertyCard icon="📐" label="Tamaño" value="Pequeñas, 3-5 mm" />
+  <PropertyCard icon="🌺" label="Forma" value="Estrellada, 5 pétalos" />
+  <PropertyCard
+    icon="📍"
+    label="Disposición"
+    value="Umbelas/panículas terminales"
+  />
+  <PropertyCard icon="📅" label="Temporada" value="Marzo-Mayo" />
+  <PropertyCard
+    icon="🐝"
+    label="Polinización"
+    value="Insectos (abejas y moscas)"
+  />
+</PropertiesGrid>
+
+Las flores son discretas de forma individual, pero aparecen en inflorescencias compuestas de 10-20 cm al final de las ramas. Aunque no son vistosas como las de especies ornamentales típicas, aportan recursos de néctar y polen al ensamble de insectos del bosque montano.
 
 ### Fruto y Semillas
 
 - **Tipo**: Baya pequeña (drupa)
 - **Tamaño**: 4-6 mm de diámetro
-- **Color**: Verde cuando joven, madurando a púrpura-negro
+- **Color**: Verde al inicio, púrpura-negro en madurez
+- **Forma**: Esférica, en racimos densos
+- **Semillas**: 2-5 por fruto
 - **Temporada**: Junio-Agosto
-- **Fauna**: Alimento importante para aves montanas
+- **Función ecológica**: Recurso trófico clave para aves montanas
 
 ---
 
 ## Distribución Geográfica
 
-_Oreopanax xalapensis_ tiene una amplia distribución a través de las tierras altas centroamericanas, desde **México** (estados del sur) a través de **Guatemala, El Salvador, Honduras, Nicaragua, Costa Rica, hasta Panamá**.
+### Rango Nativo
 
-En Costa Rica, el Lorito ocurre en todas las cordilleras: Cordillera Volcánica Central (volcanes Poás, Barva, Irazú, Turrialba), Cordillera de Talamanca (Cerro de la Muerte, Chirripó, La Amistad), Cordillera de Tilarán (Monteverde, área de Arenal) y Cordillera Volcánica de Guanacaste (laderas superiores de Rincón de la Vieja, Tenorio).
+_Oreopanax xalapensis_ se distribuye ampliamente en tierras altas de Mesoamérica: desde el sur de **México**, pasando por **Guatemala, El Salvador, Honduras, Nicaragua y Costa Rica**, hasta **Panamá**. Es una especie típica de bosques montanos húmedos y nubosos.
+
+### Distribución en Costa Rica
+
+<PropertiesGrid>
+  <PropertyCard
+    icon="🗺️"
+    label="Provincias"
+    value="Todas las regiones de montaña"
+  />
+  <PropertyCard icon="⛰️" label="Elevación" value="1500-3200 m" />
+  <PropertyCard
+    icon="🌡️"
+    label="Zona climática"
+    value="Premontana a montana alta"
+  />
+  <PropertyCard
+    icon="💧"
+    label="Humedad"
+    value="Bosque nuboso y montano húmedo"
+  />
+</PropertiesGrid>
+
+En Costa Rica aparece en:
+
+- **Cordillera Volcánica Central**: Poás, Barva, Irazú, Turrialba.
+- **Cordillera de Talamanca**: Cerro de la Muerte, Chirripó, La Amistad.
+- **Cordillera de Tilarán**: Monteverde y entorno de Arenal.
+- **Cordillera de Guanacaste**: Sectores altos de Rincón de la Vieja y Tenorio.
 
 ---
 
 ## Hábitat y Ecología
 
-El Lorito desempeña varios roles importantes en los ecosistemas de bosque nuboso:
+<PropertiesGrid>
+  <PropertyCard icon="⛰️" label="Elevación" value="1500-3200 m" />
+  <PropertyCard icon="🌡️" label="Temperatura media" value="10-20°C" />
+  <PropertyCard icon="💧" label="Precipitación" value="2000-4000 mm/año" />
+  <PropertyCard
+    icon="🌫️"
+    label="Humedad atmosférica"
+    value="Alta, con niebla frecuente"
+  />
+  <PropertyCard
+    icon="🪨"
+    label="Suelos"
+    value="Ácidos, volcánicos, ricos en materia orgánica"
+  />
+  <PropertyCard icon="☀️" label="Luz" value="Sombra parcial a sol filtrado" />
+</PropertiesGrid>
 
-1. **Capa Media del Dosel**: Forma parte del sotobosque hasta dosel medio en bosques maduros
-2. **Alimento de Fauna**: Las bayas son fuente importante de alimento para aves montanas
-3. **Especie Pionera**: Puede colonizar áreas perturbadas, ayudando en la regeneración forestal
-4. **Control de Erosión**: El sistema de raíces ayuda a estabilizar pendientes en terreno empinado
-5. **Soporte de Biodiversidad**: Proporciona hábitat y alimento para varios insectos y aves
+### Rol Ecológico
 
-Las aves montanas dependen del Lorito para alimento y hábitat, incluyendo tucancillo esmeralda, quetzal resplandeciente, solitario carinegro, y varias otras especies que consumen las bayas y dispersan semillas.
+El Lorito cumple funciones importantes en los bosques nubosos:
+
+1. **Estrato intermedio**: Ocupa sotobosque y subdosel en bosques maduros.
+2. **Fuente de frutos**: Sus bayas alimentan aves residentes y migratorias altitudinales.
+3. **Especie facilitadora**: Se establece en claros y áreas perturbadas.
+4. **Control de erosión**: Sus raíces contribuyen a estabilizar laderas.
+5. **Soporte de biodiversidad**: Provee refugio, sustrato y alimento a fauna asociada.
+
+### Asociaciones con Fauna
+
+<Accordion>
+<AccordionItem title="Aves">
+
+Varias aves de montaña usan el Lorito:
+
+- **Tucancillo esmeralda** (_Aulacorhynchus prasinus_): consume frutos maduros.
+- **Quetzal resplandeciente** (_Pharomachrus mocinno_): uso ocasional del recurso.
+- **Solitario carinegro** (_Myadestes melanops_): forrajeo en frutos.
+- **Zorzales y tangaras**: aprovechan frutos e insectos asociados.
+
+La dispersión por aves favorece la regeneración en bordes de bosque y claros.
+
+</AccordionItem>
+<AccordionItem title="Insectos">
+
+- Abejas y dípteros visitan flores por néctar y polen.
+- Diversos herbívoros foliares utilizan hojas sin causar daño severo habitual.
+- Insectos asociados convierten al árbol en punto de alimentación para aves insectívoras.
+
+</AccordionItem>
+<AccordionItem title="Otra fauna">
+
+- Pequeños mamíferos pueden consumir frutos caídos.
+- La arquitectura de ramas sirve de percha y microhábitat.
+
+</AccordionItem>
+</Accordion>
+
+### Dinámica del Bosque
+
+- **Sucesión**: Puede establecerse relativamente temprano en áreas abiertas.
+- **Tolerancia de sombra**: Moderada en fases juveniles; requiere más luz al madurar.
+- **Longevidad**: Intermedia para bosque montano (aprox. 50-80 años).
+- **Sensibilidad al fuego**: Alta, como la mayoría de especies de bosque nuboso.
 
 ---
 
 ## Usos y Aplicaciones
 
-El Lorito tiene potencial como ornamental en climas apropiados, con follaje distintivo que crea interés arquitectónico. Es excelente para jardines nativos de tierras altas y jardines de fauna, atrayendo aves con bayas.
+<PropertiesGrid>
+  <PropertyCard
+    icon="🌳"
+    label="Ornamental"
+    value="Follaje distintivo en jardines de altura"
+  />
+  <PropertyCard
+    icon="🏞️"
+    label="Restauración"
+    value="Reforestación de bosque nuboso"
+  />
+  <PropertyCard
+    icon="🛡️"
+    label="Control de erosión"
+    value="Estabilización de taludes"
+  />
+  <PropertyCard
+    icon="💊"
+    label="Tradicional"
+    value="Usos medicinales reportados"
+  />
+  <PropertyCard
+    icon="🐦"
+    label="Fauna"
+    value="Alimento y estructura para aves"
+  />
+</PropertiesGrid>
+
+### Horticultura Ornamental
+
+En climas montanos adecuados, el Lorito es atractivo por:
+
+- Hojas grandes con forma muy reconocible.
+- Tamaño manejable para jardines medianos.
+- Valor en jardines nativos y de observación de aves.
+- Bajo mantenimiento una vez establecido en sitio correcto.
 
 ### Usos Tradicionales e Indígenas
 
-Los pueblos indígenas han usado especies de _Oreopanax_ medicinalmente: hojas en decocciones o emplastos aplicados a heridas o condiciones de la piel, corteza en infusiones para problemas digestivos, y decocciones para artritis y reumatismo. **Nota importante**: Estos usos tradicionales no están validados científicamente y no deben intentarse sin orientación experta.
+<Accordion>
+<AccordionItem title="Aplicaciones medicinales reportadas">
+
+En distintas regiones mesoamericanas se reportan usos de especies de _Oreopanax_:
+
+- **Hojas**: decocciones y emplastos en aplicaciones externas.
+- **Corteza**: infusiones para molestias digestivas en medicina tradicional.
+- **Preparaciones mixtas**: para dolor articular o reumático.
+
+**Precaución**: estos usos no sustituyen atención médica ni implican seguridad universal de consumo.
+
+</AccordionItem>
+<AccordionItem title="Valor cultural">
+
+- El patrón de hoja ha inspirado nombres locales como "Mano de León".
+- Se asocia con paisajes de montaña y bosque nuboso.
+- Es una especie de referencia para educación ambiental en zonas altas.
+
+</AccordionItem>
+</Accordion>
 
 ### Valor de Conservación y Restauración
 
-- **Restauración de Bosque Nuboso**: Buena especie para proyectos de restauración
-- **Control de Erosión**: Útil para estabilizar pendientes en áreas montanas degradadas
-- **Biodiversidad**: Apoya fauna montana a través de provisión de frutos y hábitat
+- **Restauración ecológica**: útil en proyectos de recuperación de cuencas altas.
+- **Conectividad funcional**: aporta recursos para redes tróficas de aves.
+- **Recuperación de laderas**: contribuye a reducir pérdida de suelo.
+- **Diversidad nativa**: fortalece composición florística local.
+
+---
+
+## Significado Cultural e Histórico
+
+### En la Cultura de Tierras Altas
+
+En comunidades de altura, el Lorito se reconoce fácilmente y suele asociarse con ambientes frescos, neblinosos y bosques en buen estado. Su presencia es usada de forma empírica como indicador de condiciones montanas húmedas.
+
+### Interés Botánico
+
+El género _Oreopanax_ (aprox. 50 especies) es importante para entender la diversificación de Araliaceae en montañas tropicales. El Lorito destaca por la variación de forma foliar entre fases juveniles y adultas y por su papel en redes de dispersión por aves.
 
 ---
 
@@ -274,7 +465,23 @@ Los pueblos indígenas han usado especies de _Oreopanax_ medicinalmente: hojas e
   trend="estable"
 />
 
-_Oreopanax xalapensis_ está evaluado como **Preocupación Menor (LC)** debido a su amplia distribución de México a Panamá, ocurrencia en numerosas áreas protegidas y adaptabilidad relativa a hábitats perturbados.
+### Evaluación General
+
+_Oreopanax xalapensis_ se considera **Preocupación Menor (LC)** por su amplia distribución, presencia en múltiples áreas protegidas y capacidad de persistir en mosaicos de bosque secundario montano.
+
+### Amenazas y Retos
+
+Aunque no está en categoría de amenaza alta, enfrenta presiones:
+
+1. **Pérdida de hábitat** por cambio de uso de suelo.
+2. **Fragmentación** que afecta flujo de semillas y genética local.
+3. **Cambio climático** con posibles desplazamientos altitudinales.
+4. **Expansión vial y urbana** en corredores de montaña.
+
+### Protección
+
+- Presente en parques y reservas como Poás, Chirripó, Monteverde y La Amistad.
+- Su conservación depende de mantener continuidad de bosque nuboso y gradientes altitudinales funcionales.
 
 ---
 
@@ -282,43 +489,116 @@ _Oreopanax xalapensis_ está evaluado como **Preocupación Menor (LC)** debido a
 
 ### Propagación
 
-Las semillas son el método principal de propagación. La germinación es variable y puede tomar 4-8 semanas o más. Los esquejes semi-leñosos se pueden intentar con tratamiento de hormona de enraizamiento, pero la tasa de éxito es moderada.
+<PropertiesGrid>
+  <PropertyCard icon="🌱" label="Semillas" value="Método principal" />
+  <PropertyCard
+    icon="✂️"
+    label="Esquejes"
+    value="Posibles, con éxito variable"
+  />
+  <PropertyCard icon="⏱️" label="Germinación" value="4-8 semanas o más" />
+  <PropertyCard icon="🌡️" label="Temperatura" value="15-20°C ideal en vivero" />
+</PropertiesGrid>
+
+**Desde semilla**:
+
+1. Recolectar frutos maduros (junio-agosto).
+2. Retirar pulpa y lavar semillas.
+3. Sembrar semilla fresca por pérdida rápida de viabilidad.
+4. Usar sustrato drenante con buen contenido orgánico.
+5. Mantener humedad constante sin saturación.
+
+**Desde esqueje**:
+
+- Usar material semileñoso saludable.
+- Aplicar hormona de enraizamiento.
+- Mantener alta humedad ambiental.
+- Esperar respuestas lentas y variables.
 
 ### Requisitos del Sitio
 
-**Crítico**: El Lorito es una **especie de tierras altas** y no prosperará en condiciones cálidas de tierras bajas.
+**Crítico**: el Lorito es especie de altura; en tierras bajas cálidas falla con frecuencia.
 
-- **Elevación**: Por encima de 1500 m preferido
-- **Temperatura**: Fresca (10-20°C promedio)
-- **Humedad**: Consistente, alta humedad
-- **pH del Suelo**: Ácido (4.5-6.0)
-- **Luz**: Sombra parcial a pleno sol
+<PropertiesGrid>
+  <PropertyCard icon="⛰️" label="Elevación" value="Preferible >1500 m" />
+  <PropertyCard icon="🌡️" label="Temperatura" value="10-20°C" />
+  <PropertyCard icon="💧" label="Humedad" value="Alta y estable" />
+  <PropertyCard icon="🪨" label="pH" value="Ácido (4.5-6.0)" />
+  <PropertyCard icon="☀️" label="Luz" value="Sombra parcial a sol suave" />
+</PropertiesGrid>
+
+### Plantación y Establecimiento
+
+1. **Época**: inicio de lluvias o periodos húmedos continuos.
+2. **Distancia**:
+   - Jardinería: 5-8 m.
+   - Restauración: 3-4 m.
+3. **Preparación**: incorporar materia orgánica y asegurar drenaje.
+4. **Cuidados iniciales**:
+   - Mulch orgánico.
+   - Protección frente a ramoneo.
+   - Control de competencia herbácea.
+
+### Crecimiento y Mantenimiento
+
+- Crecimiento lento a moderado (30-60 cm/año).
+- Poda mínima para mantener estructura natural.
+- Fertilización ligera o nula en suelos montanos funcionales.
+- Revisar daños por viento, pastoreo y compactación del suelo.
 
 ### Tiempo hasta Madurez
 
-- Comienza a producir flores y frutos a los **5-8 años**
-- Alcanza tamaño atractivo a los **15-20 años**
-- Madurez completa a los **30-40 años**
+- Floración/fructificación inicial: **5-8 años**.
+- Tamaño paisajístico notorio: **15-20 años**.
+- Madurez ecológica amplia: **30-40 años**.
 
 ---
 
 ## Dónde Ver Lorito en Costa Rica
 
-**Reserva del Bosque Nuboso Monteverde**: Común a lo largo de senderos en toda la reserva, fácil de identificar por hojas distintivas.
+### Parques y Sitios Protegidos
 
-**Parque Nacional Volcán Poás**: Presente en zonas de bosque nuboso con senderos accesibles cerca de instalaciones para visitantes.
+<Accordion>
+<AccordionItem title="Sitios accesibles">
 
-**Parque Nacional Los Quetzales**: Ocurre en hábitat de bosque nuboso, buena ubicación para observar aves alimentándose de bayas.
+**Reserva Biológica Bosque Nuboso Monteverde**:
 
-**Cerro de la Muerte** (Carretera 2): Visible a lo largo de carreteras y en parches de bosque con múltiples puntos de acceso.
+- Frecuente en senderos de bosque maduro y secundario.
+- Excelente para observar interacción planta-ave.
+
+**Parque Nacional Volcán Poás**:
+
+- Presente en franjas de bosque nuboso con acceso relativamente sencillo.
+
+**Parque Nacional Los Quetzales**:
+
+- Buen sitio para observar fructificación y aves montanas asociadas.
+
+</AccordionItem>
+<AccordionItem title="Otros paisajes de montaña">
+
+**Cerro de la Muerte (Ruta 2)**:
+
+- Visible en bordes de carretera y parches de bosque.
+
+**Sector Irazú-Turrialba**:
+
+- Registros en relictos y corredores de bosque montano.
+
+**Entorno de Monteverde y Tilarán**:
+
+- Común en reservas privadas y proyectos de restauración.
+
+</AccordionItem>
+</Accordion>
 
 ### Consejos de Identificación
 
-- Buscar **hojas grandes profundamente lobuladas palmadas** que son inconfundibles
-- La forma de la hoja se asemeja a una **mano extendida o pie de loro**
-- Las hojas a menudo **agrupadas en puntas de ramas**
-- **Árbol pequeño o arbusto grande** en sotobosque a dosel medio de bosque nuboso
-- Buscar **pequeñas bayas púrpura-negro** en temporada (junio-agosto)
+- Buscar hojas palmadas profundas de gran tamaño.
+- Verificar agrupación de hojas en puntas de ramas.
+- Confirmar hábito de árbol pequeño/subdosel.
+- En temporada, ubicar racimos de bayas oscuras.
+- Diferenciar de otras Araliaceae por lóbulos más marcados y silueta montana.
 
 ---
 
@@ -328,17 +608,22 @@ Las semillas son el método principal de propagación. La germinación es variab
   <ExternalLink
     title="iNaturalist - Oreopanax xalapensis"
     url="https://www.inaturalist.org/taxa/347634-Oreopanax-xalapensis"
-    description="Observaciones de la comunidad, fotos y mapas de distribución"
+    description="Observaciones comunitarias, fotos y mapas de distribución"
   />
   <ExternalLink
     title="Tropicos - Oreopanax xalapensis"
     url="https://www.tropicos.org/name/50269093"
-    description="Base de datos botánica con nomenclatura y especímenes"
+    description="Nomenclatura y registros botánicos"
   />
   <ExternalLink
     title="GBIF - Oreopanax xalapensis"
     url="https://www.gbif.org/species/7630562"
-    description="Datos de ocurrencia global e información de biodiversidad"
+    description="Datos globales de ocurrencia y biodiversidad"
+  />
+  <ExternalLink
+    title="Plants of the World Online - Oreopanax xalapensis"
+    url="https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:295893-2"
+    description="Ficha taxonómica del Royal Botanic Gardens, Kew"
   />
 </ExternalLinksGrid>
 
@@ -352,6 +637,7 @@ Las semillas son el método principal de propagación. La germinación es variab
     year="2010"
     title="The genus Oreopanax (Araliaceae) in Brazil"
     journal="Brittonia 62(3): 277-293"
+    url="https://doi.org/10.1007/s12228-010-9168-1"
   />
   <Reference
     authors="Haber, W.A."
@@ -359,6 +645,12 @@ Las semillas son el método principal de propagación. La germinación es variab
     title="Plants and Vegetation of Monteverde, Costa Rica"
     journal="Monteverde: Ecology and Conservation of a Tropical Cloud Forest"
     pages="pp. 39-94"
+  />
+  <Reference
+    authors="Standley, P.C. and Steyermark, J.A."
+    year="1949"
+    title="Flora of Guatemala - Araliaceae"
+    journal="Fieldiana: Botany 24(6): 433-457"
   />
   <Reference
     authors="Kappelle, M."
@@ -371,4 +663,4 @@ Las semillas son el método principal de propagación. La germinación es variab
 
 ---
 
-_El Lorito (Oreopanax xalapensis) puede no ser tan famoso como algunos de los otros árboles de tierras altas de Costa Rica, pero sus distintivas hojas de pie de loro lo hacen una de las especies más reconocibles en bosques nubosos. Este árbol pequeño desempeña roles importantes en ecosistemas montanos—proporcionando alimento para aves, estabilizando pendientes y colonizando áreas perturbadas. Para visitantes a las tierras altas de Costa Rica, avistar un Lorito con sus hojas inconfundibles es una parte memorable de experimentar la espectacular biodiversidad de bosque nuboso del país._
+_El Lorito (\_Oreopanax xalapensis_) puede pasar desapercibido frente a especies más famosas, pero en los bosques nubosos de Costa Rica es una referencia visual y ecológica de gran valor. Sus hojas profundamente lobuladas, su aporte alimenticio para aves montanas y su utilidad en restauración lo convierten en un componente clave del paisaje de altura. Para visitantes y residentes de zonas montanas, reconocer un Lorito es reconocer parte de la identidad biológica del bosque nuboso costarricense.\_

--- a/content/trees/es/lorito.mdx
+++ b/content/trees/es/lorito.mdx
@@ -663,4 +663,4 @@ Aunque no está en categoría de amenaza alta, enfrenta presiones:
 
 ---
 
-_El Lorito (\_Oreopanax xalapensis_) puede pasar desapercibido frente a especies más famosas, pero en los bosques nubosos de Costa Rica es una referencia visual y ecológica de gran valor. Sus hojas profundamente lobuladas, su aporte alimenticio para aves montanas y su utilidad en restauración lo convierten en un componente clave del paisaje de altura. Para visitantes y residentes de zonas montanas, reconocer un Lorito es reconocer parte de la identidad biológica del bosque nuboso costarricense.\_
+_El Lorito (_Oreopanax xalapensis_) puede pasar desapercibido frente a especies más famosas, pero en los bosques nubosos de Costa Rica es una referencia visual y ecológica de gran valor. Sus hojas profundamente lobuladas, su aporte alimenticio para aves montanas y su utilidad en restauración lo convierten en un componente clave del paisaje de altura. Para visitantes y residentes de zonas montanas, reconocer un Lorito es reconocer parte de la identidad biológica del bosque nuboso costarricense._

--- a/content/trees/es/mamon-chino.mdx
+++ b/content/trees/es/mamon-chino.mdx
@@ -175,6 +175,41 @@ commonProblems:
 
 ---
 
+## Taxonomía y Clasificación
+
+<PropertiesGrid>
+  <PropertyCard title="Reino" value="Plantae" />
+  <PropertyCard title="Clado" value="Angiospermas" />
+  <PropertyCard title="Clado" value="Eudicotiledóneas" />
+  <PropertyCard title="Orden" value="Sapindales" />
+  <PropertyCard title="Familia" value="Sapindaceae" />
+  <PropertyCard title="Género" value="Nephelium" />
+  <PropertyCard title="Especie" value="N. lappaceum" />
+</PropertiesGrid>
+
+<Callout type="info" title="Origen de los Nombres">
+  - **Nephelium**: Del griego _nephele_ ("nube"), por referencias históricas al
+  recubrimiento de la semilla. - **lappaceum**: Del latín "similar a un erizo o
+  burr", por sus espinas suaves. - **Rambután**: Del malayo _rambut_, "cabello".
+  - **Mamón Chino**: Nombre costarricense que vincula su forma de consumo con el
+  mamón local y su origen asiático.
+</Callout>
+
+### Nombres Comunes
+
+<DataTable
+  headers={["Idioma o Región", "Nombre común", "Notas"]}
+  rows={[
+    ["Costa Rica", "Mamón Chino", "Nombre más usado en mercados"],
+    ["Internacional", "Rambután", "Nombre comercial global"],
+    ["Malasia e Indonesia", "Rambutan", "Nombre original"],
+    ["Guatemala y Honduras", "Achotillo", "Uso regional"],
+    ["Otros países hispanos", "Lichas", "Nombre coloquial variable"],
+  ]}
+/>
+
+---
+
 ## Por Qué "Mamón Chino"
 
 <FeatureBox title="Historia del Nombre" icon="📖">
@@ -230,6 +265,49 @@ Otros nombres en Latinoamérica:
 
 El árbol de mamón chino es siempreverde con copa densa y amplia. Las hojas son compuestas pinnadas con 2-4 pares de folíolos. Los árboles son típicamente dioicos (árboles masculinos y femeninos separados) o hermafroditas.
 
+### Características de Identificación
+
+<TwoColumn>
+<Column>
+
+#### Corteza y Tronco
+
+- **Color de corteza**: Gris pardo
+- **Textura**: Lisa a ligeramente áspera
+- **Tronco**: Recto y bien formado
+- **Ramificación**: Densa y extendida
+
+#### Hojas
+
+- **Tipo**: Compuestas pinnadas
+- **Folíolos**: 2-4 pares (4-8 en total)
+- **Tamaño**: 7-20 cm de largo
+- **Color**: Verde oscuro brillante
+- **Brote nuevo**: Tonos rojizos
+
+</Column>
+<Column>
+
+#### Flores
+
+- **Tamaño**: Pequeñas (2-5 mm)
+- **Color**: Blanco verdosas
+- **Disposición**: Panículas terminales y axilares
+- **Fragancia**: Suave, ligeramente dulce
+- **Tipos florales**: Masculinas, femeninas y hermafroditas
+
+#### Fruto (rasgo clave)
+
+- **Forma**: Ovalada a redonda
+- **Tamaño**: 3-6 cm
+- **Cáscara**: Roja o amarilla con espinas flexibles
+- **Pulpa**: Blanca translúcida, firme y jugosa
+- **Semilla**: Central, grande y marrón
+- **Sabor**: Dulce, aromático, con acidez leve
+
+</Column>
+</TwoColumn>
+
 ### El Fruto
 
 - **Forma**: Ovoide, 3-6 cm de largo
@@ -268,6 +346,97 @@ El árbol de mamón chino es siempreverde con copa densa y amplia. Las hojas son
 
 ---
 
+## Historia en Costa Rica
+
+<FeatureBox title="Cómo Llegó el Rambután al País" icon="🚢">
+  **Cronología resumida**:
+
+- **Inicios del siglo XX**: Se introducen los primeros árboles.
+- **1909-1913**: Inmigrantes alemanes establecen plantaciones en Limón.
+- **Mitad del siglo XX**: Se dispersa por tierras bajas húmedas del Caribe.
+- **Décadas de 1970-1980**: Inicia el cultivo comercial organizado.
+- **Décadas recientes**: Costa Rica se consolida como productor relevante en América.
+
+  **Razones de éxito**:
+
+- Alta precipitación anual en el Caribe (3000-4000 mm)
+- Temperaturas cálidas relativamente estables
+- Humedad ambiental elevada
+- Suelos profundos y fértiles
+
+</FeatureBox>
+
+---
+
+## Ecología y Hábitat
+
+### Distribución en Costa Rica
+
+<DataTable
+  headers={["Región", "Nivel productivo", "Notas"]}
+  rows={[
+    ["Limón", "Muy alto", "Condiciones húmedas óptimas"],
+    ["Sarapiquí (Heredia)", "Alto", "Área productiva en expansión"],
+    ["San Carlos (Alajuela)", "Medio", "Producción comercial intermedia"],
+    ["Zona Sur de Puntarenas", "Medio-bajo", "Sitios húmedos favorables"],
+    ["Valle Central", "Bajo", "Limitado por sequía o frío estacional"],
+  ]}
+/>
+
+### Requerimientos Climáticos
+
+<TwoColumn>
+<Column>
+
+#### Condiciones óptimas
+
+- **Temperatura**: 22-30°C
+- **Precipitación**: 2500-4000 mm/año
+- **Humedad relativa**: 75-90%
+- **Elevación**: 0-800 m
+- **Suelo**: Profundo, fértil y bien drenado
+
+</Column>
+<Column>
+
+#### Sensibilidades
+
+- **Frío**: Muy sensible a heladas
+- **Sequía**: Baja tolerancia
+- **Viento fuerte**: Puede dañar ramas y frutos
+- **Estrés hídrico**: Reduce cuaje y tamaño de fruta
+- **Encharcamiento**: Favorece problemas radiculares
+
+</Column>
+</TwoColumn>
+
+### Biología de Polinización
+
+<TwoColumn>
+<Column>
+
+#### Tipos de flores
+
+- Flores masculinas
+- Flores funcionalmente femeninas
+- Flores hermafroditas según cultivar
+- Floración en pulsos relativamente sincronizados
+
+</Column>
+<Column>
+
+#### Polinizadores
+
+- Abejas como agentes principales
+- Moscas como visitantes secundarios
+- Polinización cruzada mejora el cuaje
+- Viento con papel limitado
+
+</Column>
+</TwoColumn>
+
+---
+
 ## Producción en Costa Rica
 
 ### Zonas de Cultivo
@@ -295,7 +464,102 @@ Costa Rica es uno de los principales productores de mamón chino en Centroaméri
 
 ---
 
+## Usos
+
+### Aplicaciones Culinarias
+
+<DataTable
+  headers={["Uso", "Descripción", "Frecuencia"]}
+  rows={[
+    ["Consumo fresco", "Pelado directo y consumo inmediato", "Muy alta"],
+    ["Conserva en almíbar", "Procesamiento para exportación", "Alta"],
+    ["Ensaladas de fruta", "Combinado con otras frutas tropicales", "Media"],
+    ["Jugos y batidos", "Pulpa licuada", "Media"],
+    ["Postres", "Helados, repostería y jaleas", "Media-baja"],
+    ["Mermeladas", "Preparaciones artesanales", "Baja"],
+  ]}
+/>
+
+### Usos Medicinales Tradicionales
+
+<DataTable
+  headers={["Uso tradicional", "Parte", "Aplicación reportada"]}
+  rows={[
+    ["Fiebre", "Hojas y corteza", "Decocciones tradicionales"],
+    ["Molestias digestivas", "Corteza", "Infusión popular"],
+    ["Control glucémico", "Semilla", "Uso tradicional no clínico"],
+    ["Cuidado capilar", "Hojas", "Preparados locales"],
+    ["Afecciones cutáneas", "Hojas", "Uso tópico tradicional"],
+  ]}
+/>
+
+### Otros Usos
+
+<DataTable
+  headers={["Uso", "Parte", "Notas"]}
+  rows={[
+    [
+      "Ornamental",
+      "Árbol completo",
+      "Alto valor paisajístico en fructificación",
+    ],
+    ["Sombra", "Copa", "Útil en patios y huertas"],
+    ["Madera local", "Tronco", "Uso menor no estructural"],
+    ["Tinte tradicional", "Cáscara del fruto", "Aplicaciones artesanales"],
+  ]}
+/>
+
+---
+
 ## Cultivo
+
+### Cultivar Mamón Chino en Costa Rica
+
+<Accordion>
+  <AccordionItem title="Selección del sitio">
+    **Condiciones recomendadas**:
+
+    - Clima cálido-húmedo de tierras bajas.
+    - Lluvia alta y bien distribuida durante el año.
+    - Suelo profundo con buen drenaje.
+    - Sitios protegidos de vientos fuertes.
+    - Exposición de pleno sol para máxima producción.
+
+    **Regiones favorables**: Limón, Sarapiquí y zonas húmedas del norte y sur.
+
+    **Retos comunes fuera de estas regiones**:
+
+    - Pacífico seco: estrés hídrico en estación seca.
+    - Valles altos: temperaturas bajas que reducen rendimiento.
+
+  </AccordionItem>
+  <AccordionItem title="Propagación y establecimiento">
+    **Injerto o yema (preferido en producción comercial)**:
+
+    - Mantiene calidad de fruta y uniformidad.
+    - Fructificación en 3-5 años.
+    - Permite manejar mejor vigor y arquitectura.
+
+    **Acodo aéreo**:
+
+    - Conserva características varietales.
+    - Entrada en producción intermedia.
+
+    **Semilla**:
+
+    - Útil para portainjertos o huertas no comerciales.
+    - Variabilidad alta y posible presencia de árboles poco productivos.
+    - Fructificación más tardía (5-8 años).
+
+  </AccordionItem>
+  <AccordionItem title="Manejo del huerto">
+    - **Distancia**: 8-12 m entre árboles según sistema.
+    - **Riego**: esencial en periodos secos, especialmente de floración a llenado.
+    - **Nutrición**: aplicaciones regulares de NPK con mayor potasio en fructificación.
+    - **Poda**: formar copa baja y accesible; eliminar ramas cruzadas.
+    - **Sanidad**: vigilar mosca de la fruta y antracnosis; mejorar ventilación.
+  </AccordionItem>
+</Accordion>
 
 ### Condiciones Ideales
 
@@ -306,19 +570,57 @@ Costa Rica es uno de los principales productores de mamón chino en Centroaméri
   <PropertyCard icon="🌱" title="Suelo" value="Profundo, bien drenado" />
 </PropertiesGrid>
 
-<Accordion>
-  <AccordionItem title="🌱 Propagación">
-    - **Por semilla**: Fácil pero variable; puede dar árboles masculinos
-    estériles - **Por injerto**: Método preferido para asegurar árboles
-    productivos - **Por acodo**: También utilizado para mantener características
-    - Injertos producen en 2-4 años vs. 5-6 años por semilla
-  </AccordionItem>
-  <AccordionItem title="🍎 Cosecha">
-    - Frutos maduran 15-18 semanas después de floración - Cosechar cuando el
-    color rojo es uniforme - Cortar racimos completos, no frutas individuales -
-    Manejar con cuidado para evitar daño a espinas
-  </AccordionItem>
-</Accordion>
+### Ciclo Productivo
+
+<DataTable
+  headers={["Etapa", "Época", "Observaciones"]}
+  rows={[
+    [
+      "Floración",
+      "Febrero-Abril",
+      "Suele activarse con reducción temporal de lluvias",
+    ],
+    ["Desarrollo de fruto", "3-4 meses", "Crítico mantener humedad uniforme"],
+    [
+      "Cosecha principal",
+      "Julio-Octubre",
+      "Cortar racimos cuando color es uniforme",
+    ],
+    [
+      "Segunda cosecha",
+      "Noviembre-Diciembre (algunas zonas)",
+      "Depende de clima y manejo",
+    ],
+  ]}
+/>
+
+### Tipos Cultivados en Costa Rica
+
+<DataTable
+  headers={["Tipo", "Características", "Uso"]}
+  rows={[
+    [
+      "Variedades rojas",
+      "Aspecto clásico y alta aceptación",
+      "Mercado fresco y exportación",
+    ],
+    [
+      "Variedades amarillas",
+      "Menos comunes, sabor dulce similar",
+      "Mercados especializados",
+    ],
+    [
+      "Pulpa separable",
+      "Semilla se desprende con facilidad",
+      "Preferida para consumo fresco",
+    ],
+    [
+      "Pulpa adherida",
+      "Pulpa más pegada a la semilla",
+      "Útil para industria y conserva",
+    ],
+  ]}
+/>
 
 ---
 
@@ -354,3 +656,82 @@ El mamón chino es parte integral de la experiencia veraniega costarricense. Dur
   cosecha con vecinos y amigos, manteniendo una tradición de comunidad alrededor
   de esta deliciosa fruta.
 </Callout>
+
+---
+
+## Comparación: Mamón vs Mamón Chino
+
+<DataTable
+  headers={["Característica", "Mamón (Quenepa)", "Mamón Chino (Rambután)"]}
+  rows={[
+    ["Nombre científico", "Melicoccus bijugatus", "Nephelium lappaceum"],
+    ["Origen", "Caribe", "Sudeste Asiático"],
+    ["Textura de cáscara", "Lisa y quebradiza", "Flexible, con espinas suaves"],
+    ["Color de cáscara", "Verde", "Rojo o amarillo"],
+    ["Pulpa", "Salmón y gelatinosa", "Blanca translúcida y más gruesa"],
+    [
+      "Forma de comer",
+      "Chupar pulpa adherida",
+      "Separar pulpa alrededor de semilla",
+    ],
+    ["Sabor", "Dulce-ácido", "Dulce aromático"],
+    ["Temporada principal en CR", "Junio-Agosto", "Julio-Octubre"],
+  ]}
+/>
+
+---
+
+## Estado de Conservación
+
+<Callout type="info" title="Notas de Conservación">
+  **Estado general**: Sin amenaza de conservación inmediata en contexto de
+  cultivo comercial.
+
+En Costa Rica el mamón chino se maneja principalmente como frutal introducido
+de importancia productiva y de mercado. La gestión se centra en calidad de
+fruta, sanidad y sostenibilidad agronómica más que en conservación de
+poblaciones silvestres locales.
+
+</Callout>
+
+---
+
+## Guía Rápida de Identificación
+
+<FeatureBox title="Claves para reconocerlo en segundos" icon="🔍">
+  1. Árbol siempreverde de copa amplia (12-20 m si no se poda). 2. Hojas
+  compuestas brillantes con brotes nuevos rojizos. 3. Racimos colgantes de
+  frutos rojos o amarillos. 4. Cáscara con espinas suaves flexibles, nunca
+  rígidas o punzantes. 5. Pulpa blanca translúcida alrededor de una semilla
+  grande central.
+</FeatureBox>
+
+---
+
+## Referencias y Lecturas Recomendadas
+
+<DataTable
+  headers={["Recurso", "Tipo", "Enfoque"]}
+  rows={[
+    [
+      "Morton, J. Fruits of Warm Climates",
+      "Libro",
+      "Descripción botánica y usos",
+    ],
+    [
+      "Manual técnico de rambután de CATIE",
+      "Manual",
+      "Manejo productivo en Centroamérica",
+    ],
+    [
+      "Datos de exportación de Costa Rica",
+      "Estadística",
+      "Dimensión económica",
+    ],
+    [
+      "Revisiones de Sapindaceae",
+      "Literatura científica",
+      "Relaciones taxonómicas",
+    ],
+  ]}
+/>

--- a/content/trees/es/mangle-botoncillo.mdx
+++ b/content/trees/es/mangle-botoncillo.mdx
@@ -236,6 +236,111 @@ commonProblems:
 
 ---
 
+## Descripción Física
+
+### Forma General
+
+El botoncillo suele presentarse como arbusto grande o árbol pequeño de copa densa y redondeada, con frecuencia multitronco. En manejo paisajístico puede mantenerse compacto; sin poda puede alcanzar 15-20 m.
+
+<StatsGroup>
+  <StatBar label="Altura madura" value={17} max={20} unit="metros" />
+  <StatBar label="Extensión de copa" value={8} max={12} unit="metros" />
+  <StatBar label="Diámetro de tronco" value={30} max={60} unit="cm" />
+  <StatBar label="Vida útil típica" value={50} max={80} unit="años" />
+</StatsGroup>
+
+### Rasgos de Identificación
+
+<TwoColumn>
+<Column>
+
+#### Hojas
+
+- **Disposición**: Alterna (a diferencia de mangles verdaderos con hojas opuestas)
+- **Forma**: Oblonga a elíptica
+- **Tamaño**: 2-7 cm de largo
+- **Textura**: Coriácea y cerosa
+- **Color**: Verde oscuro o plateado según variedad
+- **Glándulas de sal**: Visibles en la base foliar
+
+#### Flores tipo "botón"
+
+- Muy pequeñas e inconspicuas
+- Agrupadas en cabezuelas densas
+- Color blanco verdoso
+- Floración principal en estación lluviosa temprana
+
+</Column>
+<Column>
+
+#### Frutos
+
+- Infrutescencia cónica/ovalada
+- Color café rojizo al madurar
+- Semillas aladas para dispersión
+- Persisten en ramas durante semanas
+
+#### Corteza y arquitectura
+
+- Corteza gris parda, escamosa a fisurada
+- Ramas relativamente fuertes
+- Raíces convencionales en la mayoría de sitios
+- Puede formar estructuras respiratorias en suelos muy inundados
+
+</Column>
+</TwoColumn>
+
+<Callout type="tip" title="Claves de identificación rápida">
+  1. Hojas alternas con glándulas de sal en la base. 2. Inflorescencias y frutos
+  tipo "botón". 3. Ubicación frecuente en borde terrestre del manglar. 4.
+  Ausencia de raíces zanco prominentes en la mayoría de sitios.
+</Callout>
+
+---
+
+## Distribución y Hábitat
+
+### Rango Nativo
+
+<DistributionMap
+  countries={[
+    "Estados Unidos (Florida, Texas)",
+    "México",
+    "Centroamérica",
+    "Caribe insular",
+    "Norte y oeste de Sudamérica",
+    "África occidental",
+  ]}
+/>
+
+### Distribución en Costa Rica
+
+<DataTable
+  headers={["Provincia", "Abundancia", "Notas"]}
+  rows={[
+    ["Guanacaste", "Común", "Costas y manglares del golfo de Nicoya"],
+    ["Puntarenas", "Común", "Pacífico central y sur"],
+    ["Limón", "Común", "Sectores costeros del Caribe"],
+    ["San José", "Rara", "Principalmente plantado en paisajismo"],
+  ]}
+/>
+
+### Preferencias de Hábitat
+
+<SimpleList
+  items={[
+    "Elevación: nivel del mar a bajas cotas interiores",
+    "Zona: borde terrestre del manglar y ambientes costeros adyacentes",
+    "Salinidad: amplia tolerancia (halófita facultativa)",
+    "Suelos: arenosos, arcillosos o calcáreos",
+    "Drenaje: prefiere drenaje medio-bueno, tolera inundación temporal",
+    "Luz: pleno sol",
+    "Clima: tropical/subtropical sin heladas",
+  ]}
+/>
+
+---
+
 ## Importancia Ecológica
 
 ### El Facilitador de la Zona de Transición
@@ -251,6 +356,56 @@ commonProblems:
   sitios terrestres perturbados - Extiende beneficios del ecosistema de manglar
   hacia tierra
 </Callout>
+
+### Relaciones con Fauna
+
+<TwoColumn>
+<Column>
+
+#### Aves
+
+- Garzas y otras aves costeras usan la copa para refugio.
+- Paseriformes forrajean en follaje y ramas.
+- Algunas especies consumen semillas o invertebrados asociados.
+
+</Column>
+<Column>
+
+#### Otra fauna
+
+- Cangrejos y artrópodos aprovechan hojarasca.
+- Reptiles pequeños usan troncos y ramas para termorregulación.
+- Insectos polinizadores y herbívoros sostienen redes tróficas locales.
+
+</Column>
+</TwoColumn>
+
+---
+
+## Adaptaciones y Ecología
+
+### Estrategia de Manejo de Sal
+
+<FeatureBox title="Halófita Facultativa" icon="💧">
+  El botoncillo tolera sal, pero no depende de ella:
+
+- Puede crecer en ambientes salobres, salinos moderados o agua dulce.
+- Usa glándulas foliares para manejar exceso de sales.
+- Compite mejor que mangles verdaderos en el borde más terrestre.
+- Esto explica su valor en paisajismo costero e incluso urbano interior.
+  </FeatureBox>
+
+### Competencia y Zonación
+
+<DataTable
+  headers={["Zona", "Especie dominante", "Papel del botoncillo"]}
+  rows={[
+    ["Franja marina", "Mangle rojo", "Ausente o muy escaso"],
+    ["Franja media", "Mangle negro", "Ocasional"],
+    ["Franja interior de manglar", "Mangle blanco", "Coocurre"],
+    ["Borde terrestre", "Botoncillo", "Frecuentemente dominante"],
+  ]}
+/>
 
 ---
 
@@ -316,6 +471,18 @@ commonProblems:
   ]}
 />
 
+### Usos Tradicionales
+
+<SimpleList
+  items={[
+    "Leña y carbón de buena combustión",
+    "Taninos de corteza para curtido tradicional",
+    "Tintes artesanales de tonos café",
+    "Postes y estructuras rurales menores",
+    "Aplicaciones medicinales locales con documentación limitada",
+  ]}
+/>
+
 ---
 
 ## Cultivo y Cuidado
@@ -329,6 +496,52 @@ commonProblems:
   bien sin sal - **Setos**: Variedad plateada hace hermoso seto formal -
   **Restauración**: Excelente para plantaciones ecológicas
 </Callout>
+
+### Propagación
+
+<TwoColumn>
+<Column>
+
+#### Desde semilla
+
+- Recolectar estructuras maduras de color café.
+- Extraer semillas y sembrar frescas en sustrato húmedo.
+- Germinación típica en 2-4 semanas.
+- Trasplantar cuando plántulas alcancen 10-15 cm.
+
+</Column>
+<Column>
+
+#### Desde esqueje
+
+- Usar material semileñoso de 15-20 cm.
+- Aplicar hormona de enraizamiento.
+- Mantener humedad alta y drenaje adecuado.
+- Enraizamiento usual entre 6-8 semanas.
+
+</Column>
+</TwoColumn>
+
+### Calendario de Mantenimiento
+
+<DataTable
+  headers={["Periodo", "Tarea", "Notas"]}
+  rows={[
+    [
+      "Todo el año",
+      "Riego en sequías largas",
+      "Árbol maduro tolera sequía moderada",
+    ],
+    ["Estación seca", "Poda de forma", "Útil para setos y control de tamaño"],
+    [
+      "Inicio de lluvias",
+      "Plantación y reposición",
+      "Mejor ventana de establecimiento",
+    ],
+    ["Según necesidad", "Vigilancia fitosanitaria", "Escamas ocasionales"],
+    ["Anual", "Renovar acolchado", "Mejora humedad y estructura superficial"],
+  ]}
+/>
 
 ---
 

--- a/content/trees/es/mangle-botoncillo.mdx
+++ b/content/trees/es/mangle-botoncillo.mdx
@@ -389,10 +389,14 @@ El botoncillo suele presentarse como arbusto grande o árbol pequeño de copa de
 <FeatureBox title="Halófita Facultativa" icon="💧">
   El botoncillo tolera sal, pero no depende de ella:
 
-- Puede crecer en ambientes salobres, salinos moderados o agua dulce.
-- Usa glándulas foliares para manejar exceso de sales.
-- Compite mejor que mangles verdaderos en el borde más terrestre.
-- Esto explica su valor en paisajismo costero e incluso urbano interior.
+  <SimpleList
+    items={[
+      "Puede crecer en ambientes salobres, salinos moderados o agua dulce",
+      "Usa glándulas foliares para manejar exceso de sales",
+      "Compite mejor que mangles verdaderos en el borde más terrestre",
+      "Esto explica su valor en paisajismo costero e incluso urbano interior",
+    ]}
+  />
   </FeatureBox>
 
 ### Competencia y Zonación

--- a/content/trees/es/mangle-pinuela.mdx
+++ b/content/trees/es/mangle-pinuela.mdx
@@ -207,6 +207,131 @@ commonProblems:
 
 ---
 
+### Nombres Comunes
+
+<DataTable
+  headers={["Idioma o región", "Nombre común", "Origen o significado"]}
+  rows={[
+    [
+      "Costa Rica",
+      "Mangle piñuela, piñuela",
+      "Referencia a base en forma cónica",
+    ],
+    ["Inglés", "Tea Mangrove", "Uso histórico de hojas como sustituto de té"],
+    ["Panamá", "Mangle piña", "Nombre regional"],
+    ["Colombia", "Mangle de té", "Uso tradicional foliar"],
+    ["Nombre científico", "Pelliciera", "Género monotípico"],
+  ]}
+/>
+
+---
+
+## Descripción Física
+
+### Forma General
+
+El mangle piñuela es reconocible por su base cónica formada por capas de raíces adventicias. Esta estructura ayuda al intercambio gaseoso en suelos anóxicos y representa una adaptación singular dentro de los manglares.
+
+<StatsGroup>
+  <StatBar label="Altura madura" value={17} max={20} unit="metros" />
+  <StatBar label="Extensión de copa" value={6} max={10} unit="metros" />
+  <StatBar label="Diámetro de tronco" value={25} max={40} unit="cm" />
+  <StatBar label="Diámetro base cónica" value={80} max={150} unit="cm" />
+</StatsGroup>
+
+### Características Distintivas
+
+<TwoColumn>
+<Column>
+
+#### Base cónica característica
+
+- Formada por raíces adventicias superpuestas
+- Tejido externo esponjoso y corchoso
+- Función respiratoria en suelos saturados
+- Rasgo diagnóstico frente a otros mangles
+
+#### Hojas
+
+- Simples y opuestas
+- 8-15 cm de largo, gruesas y coriáceas
+- Verde oscuro brillante en haz
+- Con taninos y compuestos astringentes
+
+</Column>
+<Column>
+
+#### Flores vistosas
+
+- Grandes (5-8 cm de diámetro)
+- Tonos rosados o blanco verdosos según población
+- Alto contenido de néctar
+- Polinizadas por colibríes y murciélagos
+
+#### Frutos y semillas
+
+- Tipo cápsula elipsoide
+- 3-5 cm de longitud
+- Múltiples semillas pequeñas
+- Dispersión principalmente por agua
+
+</Column>
+</TwoColumn>
+
+<Callout type="tip" title="Identificación rápida">
+  1. Base cónica en la parte baja del tronco. 2. Hojas gruesas y oscuras. 3.
+  Flores grandes y llamativas en época de floración. 4. Presencia en zonas
+  salobres específicas del Pacífico.
+</Callout>
+
+---
+
+## Distribución y Hábitat
+
+### Rango Pacífico Restringido
+
+<DistributionMap
+  countries={[
+    "Nicaragua (costa del Pacífico)",
+    "Costa Rica (solo Pacífico)",
+    "Panamá (Pacífico)",
+    "Colombia (Pacífico)",
+    "Ecuador (Pacífico)",
+  ]}
+/>
+
+### Distribución en Costa Rica
+
+<DataTable
+  headers={["Provincia", "Abundancia", "Ubicaciones clave"]}
+  rows={[
+    ["Puntarenas", "Rara", "Térraba-Sierpe, Golfo Dulce, Península de Osa"],
+    ["Guanacaste", "Muy rara", "Sectores puntuales del golfo de Nicoya"],
+    ["Limón", "Ausente", "No registrada en Caribe costarricense"],
+  ]}
+/>
+
+### Requisitos de Hábitat
+
+<SimpleList
+  items={[
+    "Elevación: nivel del mar a ~3 m",
+    "Salinidad: 8-15 ppt (menor que mangles rojo y negro)",
+    "Zona: interfaces salobres donde se mezcla agua dulce y marina",
+    "Sustrato: lodos anaeróbicos de dinámica mareal",
+    "Luz: pleno sol",
+    "Alta sensibilidad a perturbación y cambios hidrológicos",
+  ]}
+/>
+
+<Callout type="warning" title="Por qué es tan rara">
+  Su rareza se explica por un nicho ecológico estrecho, fragmentación de
+  poblaciones, competencia con mangles más tolerantes a salinidad alta y pérdida
+  de humedales costeros por desarrollo humano y cambio climático.
+</Callout>
+
+---
+
 ## Importancia Ecológica
 
 ### Una Asociación Crítica con Fauna Silvestre
@@ -223,6 +348,41 @@ commonProblems:
   cualquier especie amenaza a la otra - Esfuerzos de conservación conjuntos
   esenciales
 </FeatureBox>
+
+---
+
+### Función Ecosistémica
+
+<TwoColumn>
+<Column>
+
+#### Soporte de fauna
+
+- Fuente crítica de néctar para el colibrí de manglar
+- Polinización nocturna adicional por murciélagos
+- Microhábitat para invertebrados de humedal
+- Refugio y percha para aves costeras
+- Contribución a tramas tróficas de estuario
+
+</Column>
+<Column>
+
+#### Función costera
+
+- Estabilización de sedimentos finos
+- Amortiguamiento frente a oleaje y eventos extremos
+- Aporte al secuestro de carbono azul
+- Filtración biogeoquímica en gradientes salobres
+- Incremento de heterogeneidad estructural del manglar
+
+</Column>
+</TwoColumn>
+
+<Callout type="info" title="Especie Indicadora">
+  La presencia de mangle piñuela suele reflejar condiciones salobres
+  funcionales, conectividad hidrológica y continuidad de hábitat para especies
+  altamente especializadas del Pacífico tropical.
+</Callout>
 
 ---
 
@@ -263,6 +423,57 @@ commonProblems:
     ["Cambio climático", "Múltiples impactos en idoneidad de hábitat", "ALTO"],
   ]}
 />
+
+### Esfuerzos de Conservación
+
+<SimpleList
+  items={[
+    "Protección dentro de humedales nacionales y áreas marino-costeras",
+    "Programas de monitoreo poblacional en Térraba-Sierpe y Golfo Dulce",
+    "Investigación universitaria sobre dinámica de salinidad y regeneración",
+    "Acciones de conservación vinculadas al Colibrí de Manglar",
+    "Educación ambiental para comunidades costeras y operadores turísticos",
+    "Restauración experimental en sitios degradados (éxito variable)",
+  ]}
+/>
+
+---
+
+## Valor Cultural y Científico
+
+### Usos Tradicionales
+
+<TwoColumn>
+<Column>
+
+#### Históricos
+
+- Hojas usadas en infusiones sustitutas de té
+- Aprovechamiento de taninos de corteza
+- Presencia en conocimiento tradicional costero
+- Indicador local de ambientes salobres funcionales
+
+</Column>
+<Column>
+
+#### Valor científico
+
+- Linaje antiguo con registro fósil relevante
+- Modelo para estudiar evolución de manglares
+- Importante para genética de adaptaciones costeras
+- Especie bandera para conservación de humedales
+
+</Column>
+</TwoColumn>
+
+### Valor de Conservación Actual
+
+<Callout type="success" title="Por qué su conservación importa">
+  Proteger _Pelliciera rhizophorae_ no solo evita la pérdida de una especie
+  rara; también protege servicios ecosistémicos de zonas salobres
+  (almacenamiento de carbono, amortiguamiento de oleaje, refugio de fauna y
+  conectividad ecológica costera).
+</Callout>
 
 ---
 

--- a/content/trees/es/pomarrosa.mdx
+++ b/content/trees/es/pomarrosa.mdx
@@ -178,6 +178,52 @@ commonProblems:
 
 ---
 
+## Taxonomía y Clasificación
+
+<PropertiesGrid>
+  <PropertyCard icon="👑" label="Reino" value="Plantae" />
+  <PropertyCard icon="🌸" label="Clado" value="Angiospermas" />
+  <PropertyCard icon="🌿" label="Orden" value="Myrtales" />
+  <PropertyCard icon="🪴" label="Familia" value="Myrtaceae" />
+  <PropertyCard icon="🌳" label="Género" value="Syzygium" />
+  <PropertyCard icon="🔬" label="Especie" value="S. jambos" />
+</PropertiesGrid>
+
+<Accordion>
+<AccordionItem title="📍 Nombres comunes por región">
+
+<DataTable
+  headers={["Región", "Nombre común", "Notas"]}
+  rows={[
+    ["Costa Rica", "Pomarrosa", "Nombre más usado"],
+    ["Costa Rica", "Manzana rosa", "Variante local frecuente"],
+    ["México", "Manzana rosa, pomarrosa", "Uso regional similar"],
+    ["Inglés", "Rose Apple", "Traducción directa"],
+    ["Malasia", "Jambu mawar", "Origen lingüístico malayo"],
+    ["Brasil", "Jambo-amarelo", "Nombre en portugués"],
+    ["Sinónimo botánico", "Eugenia jambos", "Nombre histórico"],
+  ]}
+/>
+
+</AccordionItem>
+<AccordionItem title="🔬 Etimología y notas taxonómicas">
+
+El nombre **Syzygium** deriva del griego _syzygos_ ("unido" o "emparejado"), aludiendo a la disposición de hojas opuestas en muchas especies del grupo.  
+El epíteto **jambos** proviene del término malayo _jambu_, utilizado para varias frutas tropicales emparentadas.
+
+Sinónimos históricos reportados:
+
+- _Eugenia jambos_
+- _Jambosa vulgaris_
+- _Jambos jambos_
+
+El género _Syzygium_ incluye más de mil especies y es uno de los géneros más amplios de plantas con flor en regiones tropicales.
+
+</AccordionItem>
+</Accordion>
+
+---
+
 ## Por Qué "Manzana Rosa"
 
 El nombre describe perfectamente esta fruta:
@@ -271,6 +317,13 @@ La Pomarrosa forma un árbol siempreverde denso y extendido perfecto para sombra
 - La fragancia es tan importante como el sabor
 - Pruebe con jugo de limón y sal (estilo costarricense)
 
+**Otras preparaciones**:
+
+- Mermeladas suaves
+- Ensaladas de frutas
+- Compotas con especias
+- Preparaciones rellenas en cocina asiática
+
 </FeatureBox>
 
 <Callout type="tip" title="Estilo Costarricense">
@@ -322,6 +375,13 @@ La Pomarrosa pertenece a un género grande con muchos miembros comestibles:
   ]}
 />
 
+<Callout type="info" title="Conexión con la Manzana de Agua">
+  La **manzana de agua** (_Syzygium malaccense_) es un pariente cercano también
+  común en Costa Rica. Se diferencia por frutos más grandes y rojos, mientras
+  que la pomarrosa suele presentar frutos amarillos y una fragancia a rosa más
+  marcada.
+</Callout>
+
 ---
 
 ## Usos
@@ -352,15 +412,14 @@ La Pomarrosa pertenece a un género grande con muchos miembros comestibles:
 
 ---
 
-## Importancia Cultural
+## Significado Social
 
-<Callout type="leaf" title="Un Árbol Adoptado">
-  Aunque introducida de Asia, la Pomarrosa se ha vuelto completamente
-  costarricense. Adorna innumerables jardines, patios de escuelas y esquinas de
-  parques en todo el Valle Central. La experiencia de recoger pomarrosas maduras
-  en una tarde cálida, su fragancia llenando el aire, es un recuerdo compartido
-  por muchos costarricenses. Este árbol adoptado ha ganado su lugar en el
-  patrimonio botánico y cultural del país.
+<Callout type="leaf" title="Presencia Cotidiana">
+  Además de su valor ornamental, la pomarrosa cumple una función social en
+  barrios y comunidades: ofrece sombra para espacios de encuentro, fruta de
+  acceso local y una referencia estacional fácilmente reconocible. En muchos
+  patios escolares y familiares, sigue siendo un árbol asociado con convivencia,
+  merienda y memoria intergeneracional.
 </Callout>
 
 ---
@@ -374,3 +433,183 @@ La Pomarrosa pertenece a un género grande con muchos miembros comestibles:
 La Pomarrosa no está amenazada—todo lo contrario. Como especie introducida que se ha naturalizado, no requiere protección y puede incluso necesitar manejo en algunas áreas de conservación.
 
 </Callout>
+
+---
+
+## Cultivo
+
+### Cómo Cultivar Pomarrosa
+
+<PropertiesGrid>
+  <PropertyCard icon="☀️" title="Luz" value="Pleno sol a semisombra" />
+  <PropertyCard icon="💧" title="Agua" value="Riego regular" />
+  <PropertyCard icon="🌡️" title="Temperatura" value="Sensible a heladas" />
+  <PropertyCard
+    icon="🌱"
+    title="Suelo"
+    value="Adaptable, mejor en suelos fértiles"
+  />
+</PropertiesGrid>
+
+### Propagación
+
+<FeatureBox title="Propagando Manzana Rosa" icon="🌱">
+  **Desde semilla** (método más común):
+
+- Semillas frescas germinan bien.
+- Germinación típica en 2-6 semanas.
+- Conviene sembrar inmediatamente tras extraer.
+- Entrada en producción usual: 4-6 años.
+
+  **Desde acodo aéreo**:
+
+- Entrada en producción más rápida (2-3 años).
+- Mantiene rasgos del árbol madre.
+- Mejor ejecutar en estación lluviosa.
+
+  **Cuidados juveniles**:
+
+- Riego regular los primeros años.
+- Mantillo orgánico para conservar humedad.
+- Poda ligera de formación.
+- Tolerancia a sequía moderada una vez establecido.
+
+</FeatureBox>
+
+---
+
+## Rol Ecológico
+
+### En el Ambiente Costarricense
+
+<DataTable
+  headers={["Interacción", "Especies/Proceso", "Notas"]}
+  rows={[
+    ["Polinización", "Abejas y mariposas", "Flores útiles para insectos"],
+    [
+      "Dispersión de semillas",
+      "Aves, murciélagos y mamíferos",
+      "Favorece naturalización",
+    ],
+    [
+      "Sombra y microhábitat",
+      "Plantas de sotobosque",
+      "Mejora confort térmico local",
+    ],
+    ["Competencia", "Flora nativa", "Puede desplazar en sitios perturbados"],
+  ]}
+/>
+
+---
+
+## Importancia Cultural
+
+<Callout type="leaf" title="Un Árbol Adoptado">
+  Aunque introducida de Asia, la Pomarrosa se ha vuelto completamente
+  costarricense. Adorna innumerables jardines, patios de escuelas y esquinas de
+  parques en todo el Valle Central. La experiencia de recoger pomarrosas maduras
+  en una tarde cálida, su fragancia llenando el aire, es un recuerdo compartido
+  por muchos costarricenses. Este árbol adoptado ha ganado su lugar en el
+  patrimonio botánico y cultural del país.
+</Callout>
+
+---
+
+## Dónde Ver Pomarrosa
+
+<FeatureBox icon="📍" title="Dónde Encontrarla en Costa Rica" variant="highlight">
+
+**Entornos urbanos y jardines:**
+
+<SimpleList
+  items={[
+    "Ciudades del Valle Central: parques, jardines y arbolado urbano",
+    "Heredia centro: ejemplares en áreas históricas",
+    "Alajuela residencial: muy frecuente en patios",
+    "San José: parques metropolitanos y vecinales",
+  ]}
+/>
+
+**Entornos rurales:**
+
+<SimpleList
+  items={[
+    "Fincas cafetaleras tradicionales como árbol de sombra",
+    "Bordes de caminos rurales donde se naturaliza",
+    "Patios de escuelas y plazas comunitarias",
+    "Huertas familiares con frutales mixtos",
+  ]}
+/>
+
+</FeatureBox>
+
+<Callout type="tip" title="Mejor época de observación">
+  Visite durante la **floración** (marzo-mayo) para observar las flores de
+  estambres abundantes, o en **fructificación** (mayo-agosto) para percibir su
+  aroma floral característico y probar frutos en buen punto.
+</Callout>
+
+---
+
+## Recursos Externos
+
+<ExternalLinksGrid>
+  <ExternalLink
+    title="iNaturalist: Syzygium jambos"
+    url="https://www.inaturalist.org/taxa/128632"
+    description="Observaciones comunitarias y fotografías"
+  />
+  <ExternalLink
+    title="Plants of the World Online (Kew)"
+    url="https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:603068-1"
+    description="Ficha botánica y nomenclatura"
+  />
+  <ExternalLink
+    title="Useful Tropical Plants"
+    url="https://tropical.theferns.info/viewtropical.php?id=Syzygium+jambos"
+    description="Usos tradicionales y horticultura"
+  />
+  <ExternalLink
+    title="Tropicos - Syzygium jambos"
+    url="https://www.tropicos.org/name/22102227"
+    description="Base de datos taxonómica del Missouri Botanical Garden"
+  />
+</ExternalLinksGrid>
+
+---
+
+## Referencias
+
+<ReferencesSection>
+  <Reference
+    authors="Morton, J.F."
+    year="1987"
+    title="Rose Apple (Syzygium jambos)"
+    journal="Fruits of Warm Climates"
+    pages="383-386"
+  />
+  <Reference
+    authors="Whistler, W.A."
+    year="2000"
+    title="Tropical Ornamentals: A Guide"
+    journal="Timber Press"
+  />
+  <Reference
+    authors="Govaerts, R. et al."
+    year="2008"
+    title="World Checklist of Myrtaceae"
+    journal="Royal Botanic Gardens, Kew"
+  />
+  <Reference
+    authors="Craven, L.A. & Biffin, E."
+    year="2010"
+    title="An infrageneric classification of Syzygium (Myrtaceae)"
+    journal="Blumea"
+    volume="55"
+    pages="94-99"
+  />
+</ReferencesSection>
+
+---
+
+_La Pomarrosa (\_Syzygium jambos_) muestra cómo una especie introducida puede integrarse profundamente en la vida local cuando encuentra clima favorable y uso cultural. Sus frutos aromáticos, su sombra densa y su valor ornamental la mantienen vigente en jardines y paisajes de Costa Rica.\_

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -363,6 +363,13 @@ All 10 Week 1 species now have comprehensive advanced care guidance:
   - Expanded `content/trees/es/lorito.mdx` from 375 → 618 lines (EN counterpart 700).
   - Audit short-page backlog reduced from 35 → 33 species.
   - Next priority candidates by parity gap: `pomarrosa` (EN 618 | ES 377), `guanabana-cimarrona` (EN 890 | ES 469), then `mangle-botoncillo` (EN 705 | ES 457).
+- **2026-02-14 batch update:** Continued Priority 1.4 maintenance on the next four highest-impact short ES pages from the refreshed audit.
+  - Expanded `content/trees/es/pomarrosa.mdx` from 377 → 602 lines (EN counterpart 618).
+  - Expanded `content/trees/es/guanabana-cimarrona.mdx` from 469 → 812 lines (EN counterpart 890).
+  - Expanded `content/trees/es/mangle-botoncillo.mdx` from 457 → 662 lines (EN counterpart 705).
+  - Expanded `content/trees/es/mangle-pinuela.mdx` from 396 → 603 lines (EN counterpart 612).
+  - Audit short-page backlog reduced from 33 → 29 species.
+  - Next priority candidates by parity gap: `mastate` (EN 688 | ES 473), `papaya` (EN 736 | ES 530), `mangle-blanco` (EN 605 | ES 416), and `llama-del-bosque` (EN 682 | ES 497).
 
 See `audit-content-report.md` for full details.
 

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -358,6 +358,11 @@ All 10 Week 1 species now have comprehensive advanced care guidance:
   - Expanded `content/trees/es/ira-rosa.mdx` from 341 → 675 lines (EN counterpart 749).
   - Audit short-page backlog reduced from 37 → 35 species.
   - Next priority candidates by parity gap: `mamon-chino`, `lorito`, `pomarrosa`, and `guanabana-cimarrona` (all EN substantially longer than ES).
+- **2026-02-14 follow-up update:** Additional Priority 1.4 maintenance pass completed (`npm run content:audit`) on the highest-parity ES pages.
+  - Expanded `content/trees/es/mamon-chino.mdx` from 357 → 684 lines (EN counterpart 653).
+  - Expanded `content/trees/es/lorito.mdx` from 375 → 618 lines (EN counterpart 700).
+  - Audit short-page backlog reduced from 35 → 33 species.
+  - Next priority candidates by parity gap: `pomarrosa` (EN 618 | ES 377), `guanabana-cimarrona` (EN 890 | ES 469), then `mangle-botoncillo` (EN 705 | ES 457).
 
 See `audit-content-report.md` for full details.
 

--- a/docs/NEXT_AGENT_HANDOFF.md
+++ b/docs/NEXT_AGENT_HANDOFF.md
@@ -6,32 +6,32 @@ Last updated: 2026-02-14
 
 - Repository path: `<REPO_ROOT>` (resolve via `git rev-parse --show-toplevel`)
 - Canonical base branch: `main`
-- Current `origin/main` commit: `15b2f65`
-- Current working branch for this cycle: `codex/content/priority-1-4-audit-maintenance`
+- Current `origin/main` commit: `030a646`
+- Current working branch for this cycle: `codex/content/priority-1-4-maintenance-rerun`
 - Working branch head commit: resolve via `git rev-parse --short HEAD`
 - Most recent merged PRs:
+  - #375 `feat(content): improve ES parity pages and harden MDX table rendering`
   - #374 `fix: correct 200+ missing Spanish diacritics in five ES tree content files`
   - #373 `feat(content): full expansion pass for five low-priority short pages`
   - #372 `[ImgBot] Optimize images`
   - #371 `fix(deps): upgrade next-mdx-remote to v6`
-  - #370 `🖼️ Weekly Image Quality & Optimization (210 files)`
 - Open PRs from current cycle:
-  - #375 `feat(content): improve ES parity pages and harden MDX table rendering` (branch: `codex/content/priority-1-4-audit-maintenance`)
+  - #377 `feat(content): expand ES parity for mamon-chino and lorito` (branch: `codex/content/priority-1-4-maintenance-rerun`)
 
 ## Highest-Priority Remaining Work
 
 From `<REPO_ROOT>/docs/IMPLEMENTATION_PLAN.md`:
 
 - Priority 1.4 remains active as **ongoing short-page quality maintenance**.
-- Latest maintenance rerun completed (`npm run content:audit`): short-page backlog reduced **37 -> 35**.
+- Latest maintenance rerun completed (`npm run content:audit`): short-page backlog reduced **35 -> 33**.
 - This cycle completed high-impact parity lifts:
-  - `content/trees/es/granadillo.mdx` 167 -> 931 lines
-  - `content/trees/es/ira-rosa.mdx` 341 -> 675 lines
+  - `content/trees/es/mamon-chino.mdx` 357 -> 684 lines (EN 653)
+  - `content/trees/es/lorito.mdx` 375 -> 618 lines (EN 700)
 - Next maintenance targets by bilingual depth gap (highest impact first):
-  1. `mamon-chino` (EN 653 | ES 357)
-  2. `lorito` (EN 700 | ES 375)
-  3. `pomarrosa` (EN 618 | ES 377)
-  4. `guanabana-cimarrona` (EN 890 | ES 469)
+  1. `guanabana-cimarrona` (EN 890 | ES 469)
+  2. `pomarrosa` (EN 618 | ES 377)
+  3. `mangle-botoncillo` (EN 705 | ES 457)
+  4. `mangle-pinuela` (EN 612 | ES 396)
 - If Priority 1.4 findings are cleared, move to the highest unchecked item in `docs/IMPLEMENTATION_PLAN.md`.
 
 ## Operator Preferences (Persistent)
@@ -56,7 +56,7 @@ Repository
 Mission
 - Continue Priority 1.4 short-page maintenance from the latest audit baseline.
 - Sync to latest main, rerun `npm run content:audit`, and address the highest-impact EN/ES parity gaps.
-- Start with: `mamon-chino`, `lorito`, `pomarrosa`, and `guanabana-cimarrona` (unless a fresh audit reprioritizes).
+- Start with: `guanabana-cimarrona`, `pomarrosa`, `mangle-botoncillo`, and `mangle-pinuela` (unless a fresh audit reprioritizes).
 - Do not ask questions if answer exists in repo docs.
 - If Priority 1.4 shows no actionable gaps, move to the next highest unchecked item in IMPLEMENTATION_PLAN.md.
 

--- a/docs/NEXT_AGENT_HANDOFF.md
+++ b/docs/NEXT_AGENT_HANDOFF.md
@@ -23,15 +23,17 @@ Last updated: 2026-02-14
 From `<REPO_ROOT>/docs/IMPLEMENTATION_PLAN.md`:
 
 - Priority 1.4 remains active as **ongoing short-page quality maintenance**.
-- Latest maintenance rerun completed (`npm run content:audit`): short-page backlog reduced **35 -> 33**.
+- Latest maintenance rerun completed (`npm run content:audit`): short-page backlog reduced **33 -> 29**.
 - This cycle completed high-impact parity lifts:
-  - `content/trees/es/mamon-chino.mdx` 357 -> 684 lines (EN 653)
-  - `content/trees/es/lorito.mdx` 375 -> 618 lines (EN 700)
+  - `content/trees/es/pomarrosa.mdx` 377 -> 602 lines (EN 618)
+  - `content/trees/es/guanabana-cimarrona.mdx` 469 -> 812 lines (EN 890)
+  - `content/trees/es/mangle-botoncillo.mdx` 457 -> 662 lines (EN 705)
+  - `content/trees/es/mangle-pinuela.mdx` 396 -> 603 lines (EN 612)
 - Next maintenance targets by bilingual depth gap (highest impact first):
-  1. `guanabana-cimarrona` (EN 890 | ES 469)
-  2. `pomarrosa` (EN 618 | ES 377)
-  3. `mangle-botoncillo` (EN 705 | ES 457)
-  4. `mangle-pinuela` (EN 612 | ES 396)
+  1. `mastate` (EN 688 | ES 473)
+  2. `papaya` (EN 736 | ES 530)
+  3. `mangle-blanco` (EN 605 | ES 416)
+  4. `llama-del-bosque` (EN 682 | ES 497)
 - If Priority 1.4 findings are cleared, move to the highest unchecked item in `docs/IMPLEMENTATION_PLAN.md`.
 
 ## Operator Preferences (Persistent)
@@ -56,7 +58,7 @@ Repository
 Mission
 - Continue Priority 1.4 short-page maintenance from the latest audit baseline.
 - Sync to latest main, rerun `npm run content:audit`, and address the highest-impact EN/ES parity gaps.
-- Start with: `guanabana-cimarrona`, `pomarrosa`, `mangle-botoncillo`, and `mangle-pinuela` (unless a fresh audit reprioritizes).
+- Start with: `mastate`, `papaya`, `mangle-blanco`, and `llama-del-bosque` (unless a fresh audit reprioritizes).
 - Do not ask questions if answer exists in repo docs.
 - If Priority 1.4 shows no actionable gaps, move to the next highest unchecked item in IMPLEMENTATION_PLAN.md.
 


### PR DESCRIPTION
## Summary
- expand six high-impact ES parity pages in Priority 1.4 maintenance:
  - `content/trees/es/mamon-chino.mdx`
  - `content/trees/es/lorito.mdx`
  - `content/trees/es/pomarrosa.mdx`
  - `content/trees/es/guanabana-cimarrona.mdx`
  - `content/trees/es/mangle-botoncillo.mdx`
  - `content/trees/es/mangle-pinuela.mdx`
- update Priority 1.4 maintenance log and next-target ordering in:
  - `docs/IMPLEMENTATION_PLAN.md`
  - `docs/NEXT_AGENT_HANDOFF.md`

## Verification
- `npm run content:audit` (short-page backlog `35 -> 33 -> 29`)
- `npm run lint` (warnings only, no errors)
- `npm run build` (pass)

## Notes
- This PR now includes the original two targets (`mamon-chino`, `lorito`) plus the requested next four targets (`pomarrosa`, `guanabana-cimarrona`, `mangle-botoncillo`, `mangle-pinuela`).
- Next recommended Priority 1.4 targets from current audit: `mastate`, `papaya`, `mangle-blanco`, `llama-del-bosque`.
