### PR TITLE
feat(content): expand ES parity for mastate, papaya, mangle-blanco, and llama-del-bosque

### DIFF
--- a/content/trees/es/llama-del-bosque.mdx
+++ b/content/trees/es/llama-del-bosque.mdx
@@ -326,6 +326,14 @@ En África tropical nativa, la especie es común y no enfrenta amenazas de conse
 
 **Prioridad de Manejo**: Alta - Debe ser controlada y prevenida de propagarse
 
+### Impactos Ecológicos en Costa Rica
+
+1. **Disrupción del bosque**: Coloniza claros y bordes con alta velocidad, limitando regeneración de nativas.
+2. **Pérdida de diversidad vegetal**: La sombra densa reduce establecimiento de plántulas locales.
+3. **Afectación de polinizadores**: El néctar puede resultar tóxico para algunas abejas nativas.
+4. **Control complejo**: Rebrota desde tocón y emite retoños de raíz tras cortes.
+5. **Presión persistente**: Mantiene banco de semillas activo y reinvade suelos disturbados.
+
 ### Enfoque Actual de Manejo
 
 En Costa Rica y otras regiones invadidas:
@@ -346,6 +354,51 @@ Si tiene un tulipán africano en su propiedad:
 5. **Reporte Infestaciones**: Contacte autoridades ambientales locales sobre infestaciones grandes
 
 **Nunca Plante**: No plante nuevos tulipanes africanos bajo ninguna circunstancia.
+
+---
+
+## Cultivo del Tulipán Africano (NO RECOMENDADO)
+
+<Callout type="error" title="No Plantar Esta Especie">
+  **Importante**: Esta sección existe únicamente para identificación y manejo de
+  árboles ya establecidos. No se recomienda plantar _Spathodea campanulata_ en
+  Costa Rica ni fuera de su rango nativo africano.
+</Callout>
+
+### ¿Por Qué No Debe Cultivarse?
+
+1. **Es invasora**: Se dispersa agresivamente y desplaza especies locales.
+2. **Tiene toxicidad**: Semillas y frutos representan riesgo para personas y mascotas.
+3. **Impacta polinizadores**: Puede afectar abejas nativas sensibles.
+4. **Es difícil de contener**: Semillas abundantes + rebrote vegetativo.
+5. **Alcanza gran tamaño**: Puede causar conflictos con infraestructura urbana.
+
+### Si Ya Tiene Uno en su Propiedad
+
+**Recomendaciones de manejo**:
+
+1. **Monitoreo constante**: Vigile aparición de plántulas en patios y cunetas.
+2. **Remoción temprana**: Arranque plántulas antes de lignificación.
+3. **Control de vainas**: Retire y descarte vainas cerradas antes de apertura.
+4. **Manejo de retoños**: Corte y controle brotes de raíz de forma recurrente.
+5. **Evaluar retiro profesional**: Prioritario si está cerca de bosque o quebradas.
+6. **No estimular floración**: Evite podas que aumenten producción de flores y semillas.
+
+### Métodos de Retiro
+
+**Árboles pequeños (&lt;5 m)**:
+
+- Extracción manual con retiro de raíz principal
+- Corte de tocón + tratamiento para evitar rebrote
+
+**Árboles grandes (&gt;5 m)**:
+
+- Remoción por arborista certificado
+- Tratamiento del tocón y seguimiento por 2-3 años
+- Control periódico de retoños periféricos
+- Conversión progresiva hacia dosel de especies nativas
+
+**Siempre**: desechar semillas, vainas y raíces de forma segura; no compostar material fértil.
 
 ---
 
@@ -460,6 +513,44 @@ Si tiene un tulipán africano en su propiedad:
 
 ---
 
+### Protocolo Operativo de Control (12 Meses)
+
+Para propietarios, municipalidades y comités ambientales, un plan anual reduce
+drásticamente reinvasión:
+
+**Fase 1 (Meses 1-3): Diagnóstico**
+
+- Mapear árboles adultos, plántulas y corredores de dispersión
+- Priorizar remoción en bordes de bosque y quebradas
+- Definir especies nativas sustitutas por sitio
+
+**Fase 2 (Meses 4-6): Contención**
+
+- Retirar vainas inmaduras antes de apertura
+- Ejecutar control de plántulas cada 4-6 semanas
+- Iniciar plantación de reemplazo nativo en áreas liberadas
+
+**Fase 3 (Meses 7-9): Reducción de Fuente**
+
+- Remover individuos prioritarios (riesgo ecológico y estructural alto)
+- Tratar tocones y controlar rebrote radicular
+- Incrementar cobertura de suelo para inhibir germinación
+
+**Fase 4 (Meses 10-12): Consolidación**
+
+- Verificar supervivencia de reemplazos nativos
+- Documentar nuevos focos y aplicar respuesta temprana
+- Ajustar el plan del siguiente año según resultados
+
+### Indicadores de Éxito
+
+- Disminución anual de plántulas voluntarias en transectos de control
+- Reducción de vainas fértiles por árbol intervenido
+- Aumento de cobertura de especies nativas establecidas
+- Menor distancia entre focos de invasión y puntos de monitoreo activos
+
+---
+
 ## Recursos Externos
 
 <ExternalLinksGrid>
@@ -479,6 +570,11 @@ Si tiene un tulipán africano en su propiedad:
     description="Observaciones y fotos de Costa Rica y todo el mundo"
   />
   <ExternalLink
+    title="CABI Invasive Species Compendium"
+    url="https://www.cabi.org/isc/datasheet/51051"
+    description="Ficha técnica global de invasión y manejo"
+  />
+  <ExternalLink
     title="Missouri Botanical Garden - PlantFinder"
     url="https://www.missouribotanicalgarden.org/PlantFinder/PlantFinderDetails.aspx?taxonid=277890"
     description="Descripción botánica e información de cultivo"
@@ -494,3 +590,14 @@ Si tiene un tulipán africano en su propiedad:
 2. Rivers, M.C. & Mark, J. (2019). _Spathodea campanulata_. The IUCN Red List of Threatened Species 2019.
 
 3. Zamora, N., Jiménez, Q., & Poveda, L.J. (2000). _Árboles de Costa Rica_ Vol. II. Centro Científico Tropical, San José, Costa Rica.
+
+4. CABI (2024). _Spathodea campanulata_ datasheet. Invasive Species Compendium.
+
+---
+
+<Callout type="info" title="Transición Responsable">
+  La gestión más efectiva combina retiro gradual, restauración con especies
+  nativas y monitoreo continuo por al menos 2-3 años. El objetivo no es solo
+  eliminar un árbol invasor, sino recuperar función ecológica y resiliencia del
+  paisaje urbano-rural costarricense.
+</Callout>

--- a/content/trees/es/mangle-blanco.mdx
+++ b/content/trees/es/mangle-blanco.mdx
@@ -530,14 +530,18 @@ Presente en ambas costas, especialmente en estuarios, lagunas y canales mareales
 <Callout type="info" title="Tres Franjas del Manglar Costarricense">
   Los manglares suelen ordenarse desde el mar hacia tierra firme:
 
-- **Zona 1 (frontal)**: Mangle rojo (_Rhizophora mangle_), con inundación diaria
-- **Zona 2 (intermedia)**: Mangle negro (_Avicennia germinans_), con inundación periódica
-- **Zona 3 (superior)**: Mangle blanco (_Laguncularia racemosa_), en borde terrestre
+<SimpleList
+  items={[
+    "Zona 1 (frontal): Mangle rojo (Rhizophora mangle), con inundación diaria",
+    "Zona 2 (intermedia): Mangle negro (Avicennia germinans), con inundación periódica",
+    "Zona 3 (superior): Mangle blanco (Laguncularia racemosa), en borde terrestre",
+  ]}
+/>
 
-  Esta zonación no es rígida, pero ayuda a entender funciones ecológicas y
-  prioridades de restauración.
+Esta zonación no es rígida, pero ayuda a entender funciones ecológicas y
+prioridades de restauración.
 
-  </Callout>
+</Callout>
 
 ---
 

--- a/content/trees/es/mangle-blanco.mdx
+++ b/content/trees/es/mangle-blanco.mdx
@@ -285,6 +285,69 @@ El Mangle Blanco es un árbol perennifolio de tamaño mediano o arbusto grande c
 
 ---
 
+## Distribución y Hábitat
+
+### Rango Nativo
+
+<DistributionMap
+  countries={[
+    "Mexico",
+    "Belize",
+    "Guatemala",
+    "Honduras",
+    "El Salvador",
+    "Nicaragua",
+    "Costa Rica",
+    "Panama",
+    "Colombia",
+    "Venezuela",
+    "Guyana",
+    "Suriname",
+    "French Guiana",
+    "Brazil",
+    "Peru",
+    "Ecuador",
+    "United States (Florida)",
+    "Caribbean Islands",
+    "West Africa (Senegal to Angola)",
+  ]}
+/>
+
+### Distribución en Costa Rica
+
+Presente en ambas costas, especialmente en estuarios, lagunas y canales mareales:
+
+<DataTable
+  headers={["Provincia", "Abundancia", "Notas"]}
+  rows={[
+    [
+      "Guanacaste",
+      "Muy común",
+      "Golfo de Nicoya y estuarios del Pacífico Norte",
+    ],
+    ["Puntarenas", "Muy común", "Golfo Dulce y humedales costeros"],
+    ["Limón", "Común", "Canales y humedales del Caribe"],
+    ["San José", "Rara", "Solo en desembocaduras muy cercanas a costa"],
+  ]}
+/>
+
+### Preferencias de Hábitat
+
+<SimpleList
+  items={[
+    "Elevación: nivel del mar a 5 m",
+    "Zona: sector superior de influencia mareal",
+    "Precipitación: 1,000-4,000 mm/año",
+    "Temperatura: 20-35°C",
+    "Salinidad: tolera 15-90 ppt (óptimo 15-20 ppt)",
+    "Suelos: limo, arcilla, arena o turba",
+    "Inundación: periódica, no necesariamente diaria",
+    "Luz: pleno sol",
+  ]}
+/>
+
+---
+
 ## Importancia Ecológica
 
 ### El Especialista de la Zona de Transición
@@ -297,6 +360,31 @@ El Mangle Blanco es un árbol perennifolio de tamaño mediano o arbusto grande c
   terrestres y costeras - Almacenamiento crítico de carbono en suelos de turba
   costeros - Zona de amortiguamiento protegiendo áreas interiores de tormentas
 </Callout>
+
+### Relaciones con la Fauna
+
+<TwoColumn>
+<Column>
+
+#### Aves Asociadas
+
+- **Garzas y garcetas**: descanso y nidificación
+- **Martín pescador**: perchas de caza en ramas abiertas
+- **Aves migratorias**: uso estacional de borde de manglar
+- **Paseriformes costeros**: refugio y alimentación
+
+</Column>
+<Column>
+
+#### Vida Marina y Terrestre
+
+- **Cangrejos**: forrajeo bajo la cobertura
+- **Peces juveniles**: uso de raíces y detritos como refugio
+- **Moluscos**: colonización de tallos y raíces bajas
+- **Reptiles**: iguanas y lagartijas en ramas soleadas
+
+</Column>
+</TwoColumn>
 
 ---
 
@@ -314,6 +402,142 @@ El Mangle Blanco es un árbol perennifolio de tamaño mediano o arbusto grande c
   Este sofisticado sistema permite que el mangle blanco prospere donde la
   mayoría de las plantas morirían por toxicidad salina.
 </FeatureBox>
+
+---
+
+### Otras Adaptaciones Costeras
+
+<DataTable
+  headers={["Adaptación", "Propósito", "Beneficio ecológico"]}
+  rows={[
+    [
+      "Hojas coriáceas",
+      "Reducir pérdida hídrica",
+      "Tolera calor y salinidad alta",
+    ],
+    [
+      "Frutos flotantes",
+      "Dispersión por agua",
+      "Coloniza nuevos bordes estuarinos",
+    ],
+    [
+      "Ramas flexibles",
+      "Resistencia a viento",
+      "Mejor supervivencia en tormentas",
+    ],
+    [
+      "Amplia tolerancia salina",
+      "Flexibilidad de microhábitat",
+      "Persistencia en gradientes de marea",
+    ],
+    [
+      "Neumatóforos ocasionales",
+      "Intercambio gaseoso",
+      "Soporte en suelos anóxicos",
+    ],
+  ]}
+/>
+
+---
+
+## Conservación y Manejo
+
+### Estado de Conservación
+
+<Callout type="info" title="UICN: Preocupación Menor">
+  El mangle blanco mantiene poblaciones amplias en su rango natural. Aun así,
+  enfrenta amenazas locales en Costa Rica: urbanización costera, rellenos de
+  humedales, contaminación por hidrocarburos, cambios hidrológicos y erosión por
+  eventos extremos.
+</Callout>
+
+### Valor para Protección Costera
+
+<SimpleList
+  items={[
+    "Control de erosión mediante estabilización de sedimentos",
+    "Reducción de energía de oleaje y marejadas",
+    "Secuestro de carbono azul en biomasa y suelos",
+    "Filtrado de escorrentía y nutrientes",
+    "Soporte de cadenas tróficas estuarinas",
+    "Conectividad ecológica entre manglar y bosque terrestre",
+  ]}
+/>
+
+---
+
+## Usos Culturales y Económicos
+
+### Usos Tradicionales
+
+<TwoColumn>
+<Column>
+
+#### Materiales
+
+- **Leña**: combustión relativamente lenta
+- **Carbón**: producción artesanal local
+- **Taninos**: corteza para curtido tradicional
+- **Madera menor**: estructuras livianas y estacas
+- **Tintes**: extractos pardos de corteza
+
+</Column>
+<Column>
+
+#### Uso Popular
+
+- **Astringente**: decocciones tradicionales de corteza
+- **Cataplasmas**: uso local en piel
+- **Infusiones**: prácticas etnobotánicas puntuales
+- **Nota**: eficacia clínica variable, uso con prudencia
+
+</Column>
+</TwoColumn>
+
+### Valor Actual en Restauración
+
+<DataTable
+  headers={["Aplicación", "Valor principal", "Beneficio"]}
+  rows={[
+    [
+      "Restauración costera",
+      "Control de erosión",
+      "Protege infraestructura y suelos",
+    ],
+    [
+      "Carbono azul",
+      "Mitigación climática",
+      "Sostiene proyectos de conservación",
+    ],
+    ["Ecoturismo", "Educación ambiental", "Promueve economías locales"],
+    [
+      "Investigación",
+      "Valor científico",
+      "Monitoreo de cambio climático y mareas",
+    ],
+    [
+      "Pesquerías",
+      "Función de vivero",
+      "Soporte a especies comerciales juveniles",
+    ],
+  ]}
+/>
+
+---
+
+## Zonación del Ecosistema de Manglar
+
+<Callout type="info" title="Tres Franjas del Manglar Costarricense">
+  Los manglares suelen ordenarse desde el mar hacia tierra firme:
+
+- **Zona 1 (frontal)**: Mangle rojo (_Rhizophora mangle_), con inundación diaria
+- **Zona 2 (intermedia)**: Mangle negro (_Avicennia germinans_), con inundación periódica
+- **Zona 3 (superior)**: Mangle blanco (_Laguncularia racemosa_), en borde terrestre
+
+  Esta zonación no es rígida, pero ayuda a entender funciones ecológicas y
+  prioridades de restauración.
+
+  </Callout>
 
 ---
 

--- a/content/trees/es/mangle-blanco.mdx
+++ b/content/trees/es/mangle-blanco.mdx
@@ -530,16 +530,16 @@ Presente en ambas costas, especialmente en estuarios, lagunas y canales mareales
 <Callout type="info" title="Tres Franjas del Manglar Costarricense">
   Los manglares suelen ordenarse desde el mar hacia tierra firme:
 
-<SimpleList
-  items={[
-    "Zona 1 (frontal): Mangle rojo (Rhizophora mangle), con inundación diaria",
-    "Zona 2 (intermedia): Mangle negro (Avicennia germinans), con inundación periódica",
-    "Zona 3 (superior): Mangle blanco (Laguncularia racemosa), en borde terrestre",
-  ]}
-/>
+  <SimpleList
+    items={[
+      "Zona 1 (frontal): Mangle rojo (Rhizophora mangle), con inundación diaria",
+      "Zona 2 (intermedia): Mangle negro (Avicennia germinans), con inundación periódica",
+      "Zona 3 (superior): Mangle blanco (Laguncularia racemosa), en borde terrestre",
+    ]}
+  />
 
-Esta zonación no es rígida, pero ayuda a entender funciones ecológicas y
-prioridades de restauración.
+  Esta zonación no es rígida, pero ayuda a entender funciones ecológicas y
+  prioridades de restauración.
 
 </Callout>
 

--- a/content/trees/es/mastate.mdx
+++ b/content/trees/es/mastate.mdx
@@ -430,6 +430,51 @@ El descubrimiento de látex de árbol seguro y potable asombró a los explorador
 - Mantener consistentemente húmedo
 - Germinación típicamente 2-6 semanas
 
+### Establecimiento en Campo
+
+**Preparación del Sitio**:
+
+- Limpiar vegetación competidora en un radio de 2 metros
+- Abrir un hueco de al menos 2 veces el tamaño del cepellón
+- Agregar materia orgánica solo si el suelo está severamente degradado
+- Evitar fertilización alta; la especie está adaptada a suelos de baja fertilidad
+
+**Espaciamiento Recomendado**:
+
+- Producción maderera: 10-12 m entre individuos
+- Sistemas agroforestales: 15-20 m de otros árboles de gran porte
+- Aislamiento de infraestructura: 20+ m de edificios y caminos
+
+**Cuidados en el Primer Año**:
+
+- Riego semanal durante períodos secos prolongados
+- Acolchado alrededor de la base (sin tocar el tronco)
+- Protección contra ramoneo de ganado o fauna doméstica
+- Control manual de malezas competidoras
+
+### Manejo por Etapas
+
+**Años 1-2**:
+
+- Chapia de competencia 2-3 veces por año
+- Riego suplementario en sequías extendidas
+- Protección de plántulas juveniles
+- Monitoreo de crecimiento y supervivencia
+
+**Años 3-5**:
+
+- Reducir control de maleza a una vez anual
+- Permitir desarrollo natural de copa
+- Monitorear estado sanitario general
+- Mantener cobertura vegetal protectora del suelo
+
+**Árboles Maduros**:
+
+- Mantenimiento mínimo en bosques o sistemas agroforestales
+- Evitar podas intensivas (preferir crecimiento natural)
+- Evaluar riesgos de seguridad cerca de infraestructura
+- Aplicar cosecha sostenible cuando se use para madera
+
 ---
 
 ## Consejos de Identificación
@@ -441,6 +486,28 @@ El descubrimiento de látex de árbol seguro y potable asombró a los explorador
 3. **Corteza Gris Lisa**: Corteza relativamente lisa sin surcos profundos
 4. **Frutos Carnosos Globosos**: Frutos múltiples rojo-naranja de 2-4 cm de diámetro
 5. **Estatura Emergente**: Árbol alto elevándose sobre el dosel en bosque maduro
+
+### Especies Similares
+
+**_Brosimum alicastrum_ (Ramón/Fruta de pan de monte)**:
+
+- También produce látex blanco
+- Hojas más pequeñas (8-15 cm)
+- Fruto distinto (drupa con semilla única)
+- Más común en bosque seco a húmedo
+
+**_Castilla elastica_ (Hule/Caucho)**:
+
+- Produce látex blanco abundante
+- Látex más elástico (uso cauchero)
+- Hojas con nervaduras más marcadas
+- Estructura de fruto claramente diferente
+
+**Otros _Brosimum_**:
+
+- Existen varias especies cercanas en Mesoamérica
+- Es útil comparar hojas, flores, frutos y hábitat
+- La distribución altitudinal ayuda a confirmar identificación
 
 ---
 
@@ -460,7 +527,76 @@ El descubrimiento de látex de árbol seguro y potable asombró a los explorador
 - **Parque Nacional Piedras Blancas**: Especímenes maduros cerca de Golfito
 - **Reservas Privadas de la Península de Osa**: Varias reservas con árboles maduros
 
+**Zona Norte**:
+
+- **Parque Nacional Maquenque**: Bosque húmedo de tierras bajas
+- **Zona de Caño Negro**: Bosques ribereños con presencia local
+
+### Consejos de Observación
+
+- Busque árboles emergentes altos con corteza relativamente lisa
+- Si la normativa del sitio lo permite, una pequeña incisión diagnóstica revela látex blanco
+- Durante fructificación (mayo-septiembre), observe actividad de monos y aves en la copa
+- Guías locales suelen reconocerlo como "árbol de leche"
+
 ---
+
+## Recursos Externos
+
+<ExternalLinksGrid>
+  <ExternalLink
+    title="Plants of the World Online - Brosimum utile"
+    url="https://powo.science.kew.org/results?q=Brosimum%20utile"
+    description="Ficha taxonómica de referencia (Kew)"
+  />
+  <ExternalLink
+    title="Useful Tropical Plants - Brosimum utile"
+    url="https://tropical.theferns.info/viewtropical.php?id=Brosimum+utile"
+    description="Usos, ecología y manejo"
+  />
+  <ExternalLink
+    title="The Wood Database - Sande"
+    url="https://www.wood-database.com/sande/"
+    description="Propiedades y usos de la madera"
+  />
+  <ExternalLink
+    title="Flora Mesoamericana"
+    url="https://www.tropicos.org/project/FM"
+    description="Referencia botánica regional"
+  />
+</ExternalLinksGrid>
+
+---
+
+## Referencias
+
+1. Useful Tropical Plants Database. _Brosimum utile_.
+2. The Wood Database. _Sande (Brosimum utile)_.
+3. Flora Mesoamericana. Moraceae.
+4. Plants of the World Online (Kew). _Brosimum utile_.
+5. Observaciones locales y conocimiento tradicional indígena en Costa Rica.
+
+---
+
+## Monitoreo para Restauración
+
+### Indicadores Prácticos de Éxito
+
+En proyectos de restauración, el Mastate funciona mejor cuando se evalúa con
+indicadores ecológicos simples y repetibles:
+
+- **Supervivencia anual de plántulas**: meta >70% al segundo año
+- **Crecimiento en altura y diámetro**: comparar por parcela y exposición solar
+- **Cobertura de copa**: evidencia de incorporación al estrato superior
+- **Fauna asociada**: incremento de aves y mamíferos frugívoros
+- **Regeneración natural**: aparición de juveniles bajo dosel cercano
+
+### Recomendaciones de Seguimiento
+
+- Realizar monitoreo semestral en temporada seca y lluviosa
+- Documentar mortalidad por sequía, anegamiento o competencia temprana
+- Ajustar densidad en plantaciones mixtas según respuesta de crecimiento
+- Priorizar conectividad con parches de bosque maduro para favorecer dispersores
 
 <Callout type="info" title="Especie Clave">
   El Mastate es una **especie clave** en los ecosistemas de bosque lluvioso,

--- a/content/trees/es/papaya.mdx
+++ b/content/trees/es/papaya.mdx
@@ -289,6 +289,27 @@ La Papaya es un árbol de rápido crecimiento y vida corta con un solo tallo sin
 
 ---
 
+## Variedades en Costa Rica
+
+### Cultivares Populares
+
+<DataTable
+  headers={["Variedad", "Características", "Uso Común"]}
+  rows={[
+    [
+      "Solo/Hawaiana",
+      "Pequeña (500g), muy dulce",
+      "Consumo fresco, exportación",
+    ],
+    ["Maradol", "Grande (2-3kg), pulpa firme", "Mercado fresco, cocina"],
+    ["Criolla", "Tradicional, tamaño variable", "Consumo local"],
+    ["Tainung", "Mediana, resistente a enfermedades", "Producción comercial"],
+    ["Red Lady", "Pulpa rojiza, muy dulce", "Mercado fresco"],
+  ]}
+/>
+
+---
+
 ## Valor Nutricional
 
 ### Potencia de Nutrientes
@@ -477,6 +498,56 @@ Aplicaciones medicinales tradicionales y modernas:
 
 ---
 
+## Relaciones Ecológicas
+
+### Interacciones con la Fauna
+
+<DataTable
+  headers={["Animal", "Interacción", "Notas"]}
+  rows={[
+    [
+      "Murciélagos frugívoros",
+      "Dispersión de semillas",
+      "Dispersores importantes",
+    ],
+    ["Aves", "Consumo de fruto", "Tucanes, oropéndolas y otras especies"],
+    ["Insectos", "Polinización", "Polillas nocturnas y abejas"],
+    ["Monos", "Consumo oportunista", "Aprovechan frutos maduros"],
+    [
+      "Hormigas",
+      "Relación mutualista parcial",
+      "Atraídas por recursos florales",
+    ],
+  ]}
+/>
+
+---
+
+## Especies Similares
+
+<DataTable
+  headers={["Especie", "Nombre científico", "Diferencias clave"]}
+  rows={[
+    [
+      "Papayillo de montaña",
+      "Vasconcellea pubescens",
+      "Adaptada a altura, frutos más pequeños",
+    ],
+    [
+      "Babaco",
+      "Vasconcellea × heilbornii",
+      "Híbrido casi sin semillas, sabor ácido",
+    ],
+    [
+      "Chamburo",
+      "Vasconcellea cundinamarcensis",
+      "Fruto angulado y mejor tolerancia al clima fresco",
+    ],
+  ]}
+/>
+
+---
+
 ## Datos Interesantes
 
 <Accordion>
@@ -505,25 +576,171 @@ indígenas centroamericanos envolvían carne en hojas de papaya durante la noche
 para ablandar cortes duros—una práctica que aún se usa hoy.
 
 </AccordionItem>
+<AccordionItem title="🌍 Viaje Global">
+
+Desde su origen en Mesoamérica, la papaya se difundió rápidamente por rutas
+comerciales tropicales. En el siglo XVI llegó a Asia por intercambio colonial y
+hoy se cultiva en casi todas las zonas cálidas del planeta, conservando un rol
+clave en la dieta cotidiana de Costa Rica.
+
+</AccordionItem>
 </Accordion>
 
 ---
 
-## Referencias y Recursos
+## Distribución en Costa Rica
 
-<DataTable
-  headers={["Recurso", "Tipo", "Enlace"]}
-  rows={[
-    [
-      "iNaturalist",
-      "Observaciones",
-      "https://www.inaturalist.org/taxa/57122-Carica-papaya",
-    ],
-    ["GBIF", "Datos de Distribución", "https://www.gbif.org/species/3086382"],
-    [
-      "Tropicos",
-      "Base de Datos Botánica",
-      "https://www.tropicos.org/name/6100032",
-    ],
+<FeatureBox icon="📍" title="Zonas Productoras de Papaya" variant="highlight">
+
+**Principales regiones de producción:**
+
+<SimpleList
+  items={[
+    "Caribe húmedo: producción casi continua durante el año",
+    "Zona Norte (San Carlos): alta presencia comercial",
+    "Pacífico Central: condiciones ideales para cultivo intensivo",
+    "Guanacaste con riego: fincas de mercado nacional",
   ]}
 />
+
+**Presencia en huertas familiares:**
+
+<SimpleList
+  items={[
+    "Muy común en patios rurales de bajura y media elevación",
+    "Frecuente en huertos periurbanos donde hay pleno sol",
+    "Aparece en sistemas agroforestales de ciclo corto",
+    "Límite altitudinal práctico: ~1,500 m",
+  ]}
+/>
+
+</FeatureBox>
+
+---
+
+## Significado Cultural
+
+<Callout type="leaf" title="Fruta de Patio, Fruta de Diario">
+  En Costa Rica, la papaya es parte de la rutina alimentaria: desayunos, frescos
+  y ensaladas de fruta dependen de su disponibilidad casi permanente. En muchas
+  comunidades, cultivar papaya en casa forma parte del conocimiento doméstico:
+  aprender a diferenciar plantas macho, hembra y hermafrodita sigue siendo una
+  práctica transmitida entre generaciones.
+</Callout>
+
+---
+
+## Estado de Conservación
+
+<Callout type="info" title="Notas de Conservación">
+  **Estado UICN**: No evaluada formalmente a escala global para poblaciones
+  cultivadas. Como especie agrícola ampliamente sembrada, no enfrenta riesgo de
+  extinción por uso humano.
+
+En cambio, sí conviene monitorear la diversidad genética de poblaciones
+silvestres y de parientes cercanos (_Vasconcellea_ spp.) en bosques montanos,
+porque representan un reservorio clave para resistencia a plagas y adaptación
+climática.
+
+</Callout>
+
+---
+
+## Dónde Ver Papaya
+
+<FeatureBox icon="📍" title="Dónde Conocer la Papaya en Costa Rica" variant="highlight">
+
+**Experiencias agrícolas y mercados:**
+
+<SimpleList
+  items={[
+    "Fincas orgánicas de la Zona Norte con recorridos educativos",
+    "Ferias del agricultor del Valle Central con variedades locales",
+    "Fincas del Caribe con producción durante todo el año",
+    "Centros de formación agropecuaria en Limón y San Carlos",
+  ]}
+/>
+
+**Parientes silvestres en elevación:**
+
+<SimpleList
+  items={[
+    "Bosques nubosos por encima de 1,500 m con Vasconcellea spp.",
+    "Paisajes de transición montana en cordilleras centrales",
+  ]}
+/>
+
+</FeatureBox>
+
+<Callout type="tip" title="Selección de Fruta">
+  En mercados locales, prefiera papayas con piel amarillo-anaranjada que ceden
+  ligeramente a la presión. Para consumo inmediato, busque aroma dulce en la
+  base del fruto; para almacenar 1-2 días, escoja madurez intermedia.
+</Callout>
+
+---
+
+## Recursos Externos
+
+<ExternalLinksGrid>
+  <ExternalLink
+    title="iNaturalist: Carica papaya"
+    url="https://www.inaturalist.org/taxa/57122-Carica-papaya"
+    description="Observaciones y fotografías comunitarias"
+  />
+  <ExternalLink
+    title="Plants of the World Online (Kew)"
+    url="https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:152992-1"
+    description="Información taxonómica oficial"
+  />
+  <ExternalLink
+    title="Purdue NewCROP - Papaya"
+    url="https://hort.purdue.edu/newcrop/morton/papaya_ars.html"
+    description="Guía técnica de cultivo y uso"
+  />
+  <ExternalLink
+    title="FAOSTAT - Producción de papaya"
+    url="https://www.fao.org/faostat/en/#data/QCL"
+    description="Estadísticas globales de producción"
+  />
+</ExternalLinksGrid>
+
+---
+
+## Referencias
+
+<ReferencesSection>
+  <Reference
+    authors="Morton, J.F."
+    year="1987"
+    title="Papaya (Carica papaya)"
+    journal="Fruits of Warm Climates"
+    pages="336-346"
+  />
+  <Reference
+    authors="Carvalho, F.A. & Renner, S.S."
+    year="2012"
+    title="A dated phylogeny of the papaya family (Caricaceae) reveals the crop's closest relatives and the family's biogeographic history"
+    journal="Molecular Phylogenetics and Evolution"
+    volume="65"
+    pages="46-53"
+  />
+  <Reference
+    authors="Ming, R. et al."
+    year="2008"
+    title="The draft genome of the transgenic tropical fruit tree papaya"
+    journal="Nature"
+    volume="452"
+    pages="991-996"
+  />
+  <Reference
+    authors="León, J."
+    year="1987"
+    title="Botánica de los Cultivos Tropicales"
+    journal="IICA, San José, Costa Rica"
+  />
+</ReferencesSection>
+
+---
+
+_La papaya resume la abundancia tropical: crece rápido, produce con generosidad y forma parte del paisaje alimentario costarricense en casi cualquier región cálida._

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -370,6 +370,13 @@ All 10 Week 1 species now have comprehensive advanced care guidance:
   - Expanded `content/trees/es/mangle-pinuela.mdx` from 396 → 603 lines (EN counterpart 612).
   - Audit short-page backlog reduced from 33 → 29 species.
   - Next priority candidates by parity gap: `mastate` (EN 688 | ES 473), `papaya` (EN 736 | ES 530), `mangle-blanco` (EN 605 | ES 416), and `llama-del-bosque` (EN 682 | ES 497).
+- **2026-02-14 parity maintenance update:** Continued Priority 1.4 work on the next four high-gap Spanish pages, then reran `npm run content:audit`.
+  - Expanded `content/trees/es/mastate.mdx` from 473 → 608 lines (EN counterpart 688).
+  - Expanded `content/trees/es/papaya.mdx` from 530 → 729 lines (EN counterpart 736).
+  - Expanded `content/trees/es/mangle-blanco.mdx` from 416 → 602 lines (EN counterpart 605).
+  - Expanded `content/trees/es/llama-del-bosque.mdx` from 497 → 603 lines (EN counterpart 682).
+  - Audit short-page backlog reduced from 29 → 25 species.
+  - Next priority candidates by parity gap: `cachimbo` (EN 653 | ES 478), `cortez-negro` (EN 606 | ES 449), `guachipelin` (EN 582 | ES 448), then `quina` for low-line bilingual expansion (EN 385 | ES 386).
 
 See `audit-content-report.md` for full details.
 

--- a/docs/NEXT_AGENT_HANDOFF.md
+++ b/docs/NEXT_AGENT_HANDOFF.md
@@ -8,7 +8,7 @@ Last updated: 2026-02-14
 - Canonical base branch: `main`
 - Current `origin/main` commit: `8482617`
 - Current working branch for this cycle: `codex/content/priority-1-4-parity-mastate-papaya`
-- Working branch head commit: resolve via `git rev-parse --short HEAD`
+- Working branch head commit: `9e25916`
 - Most recent merged PRs:
   - #375 `feat(content): improve ES parity pages and harden MDX table rendering`
   - #374 `fix: correct 200+ missing Spanish diacritics in five ES tree content files`

--- a/docs/NEXT_AGENT_HANDOFF.md
+++ b/docs/NEXT_AGENT_HANDOFF.md
@@ -6,8 +6,8 @@ Last updated: 2026-02-14
 
 - Repository path: `<REPO_ROOT>` (resolve via `git rev-parse --show-toplevel`)
 - Canonical base branch: `main`
-- Current `origin/main` commit: `59d355a`
-- Current working branch for this cycle: `codex/fix/mdx-map-and-safety-fallbacks`
+- Current `origin/main` commit: `8482617`
+- Current working branch for this cycle: `codex/content/priority-1-4-parity-mastate-papaya`
 - Working branch head commit: resolve via `git rev-parse --short HEAD`
 - Most recent merged PRs:
   - #375 `feat(content): improve ES parity pages and harden MDX table rendering`
@@ -18,23 +18,24 @@ Last updated: 2026-02-14
 - Open PRs from current cycle:
   - #377 `feat(content): expand ES parity for mamon-chino and lorito` (branch: `codex/content/priority-1-4-maintenance-rerun`)
   - #378 `fix: prevent tree page runtime crashes` (branch: `codex/fix/mdx-map-and-safety-fallbacks`)
+  - #380 `feat(content): expand ES parity for mastate, papaya, mangle-blanco, and llama-del-bosque` (branch: `codex/content/priority-1-4-parity-mastate-papaya`)
 
 ## Highest-Priority Remaining Work
 
 From `<REPO_ROOT>/docs/IMPLEMENTATION_PLAN.md`:
 
 - Priority 1.4 remains active as **ongoing short-page quality maintenance**.
-- Latest maintenance rerun completed (`npm run content:audit`): short-page backlog reduced **33 -> 29**.
+- Latest maintenance rerun completed (`npm run content:audit`): short-page backlog reduced **29 -> 25**.
 - This cycle completed high-impact parity lifts:
-  - `content/trees/es/pomarrosa.mdx` 377 -> 602 lines (EN 618)
-  - `content/trees/es/guanabana-cimarrona.mdx` 469 -> 812 lines (EN 890)
-  - `content/trees/es/mangle-botoncillo.mdx` 457 -> 662 lines (EN 705)
-  - `content/trees/es/mangle-pinuela.mdx` 396 -> 603 lines (EN 612)
-- Next maintenance targets by bilingual depth gap (highest impact first):
-  1. `mastate` (EN 688 | ES 473)
-  2. `papaya` (EN 736 | ES 530)
-  3. `mangle-blanco` (EN 605 | ES 416)
-  4. `llama-del-bosque` (EN 682 | ES 497)
+  - `content/trees/es/mastate.mdx` 473 -> 608 lines (EN 688)
+  - `content/trees/es/papaya.mdx` 530 -> 729 lines (EN 736)
+  - `content/trees/es/mangle-blanco.mdx` 416 -> 602 lines (EN 605)
+  - `content/trees/es/llama-del-bosque.mdx` 497 -> 603 lines (EN 682)
+- Next maintenance targets by impact/parity gap (highest first):
+  1. `cachimbo` (EN 653 | ES 478)
+  2. `cortez-negro` (EN 606 | ES 449)
+  3. `guachipelin` (EN 582 | ES 448)
+  4. `quina` (EN 385 | ES 386) for low-line bilingual expansion
 - If Priority 1.4 findings are cleared, move to the highest unchecked item in `docs/IMPLEMENTATION_PLAN.md`.
 
 ## Operator Preferences (Persistent)
@@ -57,9 +58,9 @@ Repository
 - Treat repository docs as authoritative, especially IMPLEMENTATION_PLAN.md and AGENTS.md
 
 Mission
-- Continue Priority 1.4 short-page maintenance from the latest audit baseline (after handling active review feedback on open PRs #377 and #378 if requested).
+- Continue Priority 1.4 short-page maintenance from the latest audit baseline (after handling active review feedback on open PRs #377, #378, and #380 if requested).
 - Sync to latest main, rerun `npm run content:audit`, and address the highest-impact EN/ES parity gaps.
-- Start with: `mastate`, `papaya`, `mangle-blanco`, and `llama-del-bosque` (unless a fresh audit reprioritizes).
+- Start with: `cachimbo`, `cortez-negro`, `guachipelin`, then `quina` for low-line bilingual expansion (unless a fresh audit reprioritizes).
 - Do not ask questions if answer exists in repo docs.
 - If Priority 1.4 shows no actionable gaps, move to the next highest unchecked item in IMPLEMENTATION_PLAN.md.
 

--- a/docs/NEXT_AGENT_HANDOFF.md
+++ b/docs/NEXT_AGENT_HANDOFF.md
@@ -8,7 +8,7 @@ Last updated: 2026-02-14
 - Canonical base branch: `main`
 - Current `origin/main` commit: `8482617`
 - Current working branch for this cycle: `codex/content/priority-1-4-parity-mastate-papaya`
-- Working branch head commit: `9e25916`
+- Working branch head commit: resolve via `git rev-parse --short HEAD`
 - Most recent merged PRs:
   - #375 `feat(content): improve ES parity pages and harden MDX table rendering`
   - #374 `fix: correct 200+ missing Spanish diacritics in five ES tree content files`


### PR DESCRIPTION
## Summary
- continue Priority 1.4 short-page maintenance from the latest audit baseline
- expand Spanish depth for `mastate`, `papaya`, `mangle-blanco`, and `llama-del-bosque` to close the highest EN/ES parity gaps
- update `docs/IMPLEMENTATION_PLAN.md` with this maintenance pass and refreshed next-priority candidates

## Validation
- `npm run content:audit` (backlog reduced from 29 to 25 short pages)
- `npm run lint` (passes; pre-existing warnings only)
- `npm run build` (passes)

## Notes
- all four targeted ES pages now clear the 600-line threshold
- next high-gap candidates from audit: `cachimbo`, `cortez-negro`, `guachipelin`, then low-line bilingual expansion on `quina`
