### PR TITLE
feat(content): add Nim species profiles and fix MDX component registry test

### DIFF
--- a/content/trees/en/nim.mdx
+++ b/content/trees/en/nim.mdx
@@ -1,0 +1,749 @@
+---
+title: "Neem"
+scientificName: "Azadirachta indica"
+family: "Meliaceae"
+locale: "en"
+slug: "nim"
+description: "Neem is a drought-tolerant tree native to the Indian subcontinent and widely planted in Costa Rica for shade, medicinal use, and botanical pest management; it is ecologically significant in dry urban and agroforestry landscapes."
+nativeRegion: "Indian subcontinent (India, Pakistan, Bangladesh, Nepal, Sri Lanka)"
+conservationStatus: "LC"
+maxHeight: "12-25 meters"
+uses:
+  - "Shade tree"
+  - "Traditional medicine"
+  - "Botanical pesticide"
+  - "Windbreak"
+  - "Soil rehabilitation"
+  - "Agroforestry"
+  - "Soap and cosmetic oils"
+tags:
+  - "introduced"
+  - "evergreen"
+  - "drought-tolerant"
+  - "medicinal"
+  - "agroforestry"
+  - "urban-tree"
+  - "pollinator-resource"
+distribution:
+  - "guanacaste"
+  - "puntarenas"
+  - "alajuela"
+  - "san-jose"
+  - "heredia"
+  - "limon"
+elevation: "0-1400m"
+floweringSeason:
+  - "january"
+  - "february"
+  - "march"
+  - "april"
+fruitingSeason:
+  - "april"
+  - "may"
+  - "june"
+  - "july"
+featuredImage: "/images/trees/nim.jpg"
+publishedAt: "2026-02-15"
+updatedAt: "2026-02-15"
+# Safety Information
+toxicityLevel: "moderate"
+toxicParts:
+  - "seeds"
+  - "seed-oil"
+  - "bark"
+skinContactRisk: "low"
+allergenRisk: "low"
+structuralRisks:
+  - "falling-branches"
+childSafe: false
+petSafe: false
+requiresProfessionalCare: false
+toxicityDetails: "Neem has useful medicinal compounds but should be treated with caution. Concentrated neem seed oil and seed extracts are not safe for children, pregnant people, or pets when ingested in significant quantities. Bitter compounds (including azadirachtin and related limonoids) can cause nausea, vomiting, and neurological symptoms in overdose situations. Raw seeds and highly concentrated homemade extracts should never be consumed."
+skinContactDetails: "Most people handle leaves and bark without major irritation. Sensitive individuals may develop mild dermatitis after prolonged contact with concentrated oil or fresh sap. Use gloves when preparing extracts or handling large quantities of seeds."
+allergenDetails: "Allergy risk is generally low, but pollen or strong neem odors can occasionally irritate sensitive people. Wood dust and concentrated oils may trigger mild respiratory irritation in exposed workers."
+structuralRiskDetails: "Neem develops a broad crown and can drop medium branches during strong winds or after prolonged drought stress. In compact urban sites, roots may lift pavements if planted too close. Prune periodically and plant away from narrow sidewalks and buried infrastructure."
+safetyNotes: "Neem is a valuable tree but not a snack tree. Keep seeds and concentrated oil products away from children and pets. Use standardized, diluted formulations for garden use and avoid improvised high-dose remedies. Planting is suitable in Costa Rica when managed responsibly and when spread is monitored in sensitive habitats."
+wildlifeRisks: "Generally moderate wildlife risk. Flowers can support insects, but concentrated seed products may harm non-target organisms if applied carelessly. Avoid spraying neem extracts during peak pollinator activity and never dump concentrated residues into waterways."
+# Care & Cultivation
+growthRate: "fast"
+growthRateDetails: "Fast in warm lowlands; often 0.8-1.5 m per year in establishment phase under full sun"
+matureSize: "12-25 m tall, crown spread 8-15 m depending on water and pruning"
+hardiness: "Best in tropical/subtropical lowlands and dry zones; tolerates heat and seasonal drought"
+soilRequirements: "Well-drained soils preferred; tolerates poor, sandy, and moderately alkaline soils; avoid prolonged waterlogging"
+waterNeeds: "low"
+waterDetails: "Low to moderate once established. Young trees need supplemental watering through first two dry seasons; mature trees tolerate extended dry periods."
+lightRequirements: "full-sun"
+spacing: "Plant 8-12 m from buildings and 6-10 m between trees for shade and airflow"
+propagationMethods:
+  - "seeds"
+  - "seedlings"
+  - "grafting"
+propagationDifficulty: "easy"
+plantingSeason: "Early rainy season (May-July) is ideal; container seedlings can be planted year-round with irrigation"
+maintenanceNeeds: "Low to moderate. Train a single central stem in first years, prune crossing limbs, and remove dead branches before storm season. Keep mulch ring weed-free during establishment. Monitor volunteer seedlings in disturbed sites and remove where spread is undesirable."
+commonProblems:
+  - "Root stress in heavy waterlogged soils"
+  - "Crown thinning under prolonged cold or shade"
+  - "Occasional branch drop in windy dry seasons"
+  - "Misuse of concentrated seed oil causing safety incidents"
+  - "Volunteer seedlings in open disturbed ground"
+---
+
+# Neem (Nim)
+
+<Callout type="tip" title="A Practical Tree for Dry Tropical Landscapes">
+  **Neem** (_Azadirachta indica_), known locally as **Nim**, is an introduced
+  but highly practical tree in Costa Rica’s dry and urban zones. It is valued
+  for shade, drought tolerance, and traditional plant-based pest management.
+  Neem is not a universal solution, but when managed correctly it can support
+  heat-resilient streetscapes, smallholder agroforestry, and low-input land
+  rehabilitation.
+</Callout>
+
+<TwoColumn>
+  <Column>
+    <QuickRef
+      title="Quick Reference"
+      items={[
+        { label: "Scientific Name", value: "Azadirachta indica" },
+        { label: "Family", value: "Meliaceae" },
+        { label: "Maximum Height", value: "12-25 m" },
+        { label: "Growth Rate", value: "Fast" },
+        { label: "Native Region", value: "Indian subcontinent" },
+        { label: "Status in Costa Rica", value: "Introduced, established" },
+        { label: "Best Use", value: "Shade + low-input agroforestry" },
+      ]}
+    />
+  </Column>
+  <Column>
+    <INaturalistEmbed
+      taxonId="319135"
+      taxonName="Azadirachta indica"
+      observationCount={1200}
+    />
+  </Column>
+</TwoColumn>
+
+---
+
+## 📸 Photo Gallery
+
+<ImageGallery>
+  <ImageCard
+    src="https://static.inaturalist.org/photos/29580912/medium.jpg"
+    alt="Azadirachta indica canopy and trunk"
+    title="Whole tree"
+    credit="(c) iNaturalist observer, all rights reserved"
+    license="CC BY-NC"
+    sourceUrl="https://www.inaturalist.org/taxa/319135-Azadirachta-indica/browse_photos"
+  />
+  <ImageCard
+    src="https://static.inaturalist.org/photos/61556304/medium.jpg"
+    alt="Neem compound leaves"
+    title="Leaves"
+    credit="(c) iNaturalist observer, all rights reserved"
+    license="CC BY-NC"
+    sourceUrl="https://www.inaturalist.org/taxa/319135-Azadirachta-indica/browse_photos"
+  />
+  <ImageCard
+    src="https://static.inaturalist.org/photos/40957759/medium.jpg"
+    alt="Neem flowers"
+    title="Flowers"
+    credit="(c) iNaturalist observer, all rights reserved"
+    license="CC BY-NC"
+    sourceUrl="https://www.inaturalist.org/taxa/319135-Azadirachta-indica/browse_photos"
+  />
+  <ImageCard
+    src="https://static.inaturalist.org/photos/40957767/medium.jpg"
+    alt="Neem fruit"
+    title="Fruit"
+    credit="(c) iNaturalist observer, all rights reserved"
+    license="CC BY-NC"
+    sourceUrl="https://www.inaturalist.org/taxa/319135-Azadirachta-indica/browse_photos"
+  />
+  <ImageCard
+    src="https://static.inaturalist.org/photos/40470404/medium.jpg"
+    alt="Neem bark"
+    title="Bark"
+    credit="(c) iNaturalist observer, all rights reserved"
+    license="CC BY-NC"
+    sourceUrl="https://www.inaturalist.org/taxa/319135-Azadirachta-indica/browse_photos"
+  />
+</ImageGallery>
+
+<Callout type="info">
+  Photos are linked from the iNaturalist community archive. Field verification
+  and local attribution review are recommended before using images for printed
+  educational assets.
+</Callout>
+
+---
+
+## Taxonomy & Classification
+
+<PropertiesGrid>
+  <PropertyCard icon="👑" label="Kingdom" value="Plantae" />
+  <PropertyCard icon="🌸" label="Clade" value="Angiosperms" />
+  <PropertyCard icon="🌿" label="Order" value="Sapindales" />
+  <PropertyCard icon="🪴" label="Family" value="Meliaceae" />
+  <PropertyCard icon="🌳" label="Genus" value="Azadirachta" />
+  <PropertyCard icon="🔬" label="Species" value="A. indica" />
+</PropertiesGrid>
+
+<Accordion>
+  <AccordionItem title="Common Names by Region" defaultOpen={true}>
+    <DataTable
+      headers={["Region", "Common name", "Notes"]}
+      rows={[
+        ["Costa Rica", "Nim, Neem", "Most widespread forms"],
+        ["India", "Neem, Nimba", "Classical Ayurvedic context"],
+        [
+          "Spanish-speaking Americas",
+          "Nim, Árbol de Neem",
+          "Urban/agroforestry use",
+        ],
+        ["English", "Neem", "Global trade name"],
+      ]}
+    />
+  </AccordionItem>
+  <AccordionItem title="Taxonomic Notes and Name Origin">
+    The genus name _Azadirachta_ traces to Persian expressions linked with “free
+    tree” or “noble tree,” reflecting historical utility in villages. The
+    species epithet _indica_ means “from India.” Neem belongs to the same family
+    as mahoganies, but ecologically it behaves as a hardy pioneer in hot,
+    seasonal climates.
+  </AccordionItem>
+</Accordion>
+
+---
+
+## Geographic Distribution
+
+<PropertiesGrid>
+  <PropertyCard icon="🌍" label="Native range" value="Indian subcontinent" />
+  <PropertyCard
+    icon="🇨🇷"
+    label="Costa Rica"
+    value="Introduced and established"
+  />
+  <PropertyCard icon="⛰️" label="Elevation" value="0-1400 m" />
+  <PropertyCard
+    icon="☀️"
+    label="Best climate"
+    value="Warm seasonal dry zones"
+  />
+</PropertiesGrid>
+
+### Global Context
+
+Neem has been planted across the tropics for more than a century, especially in
+regions seeking drought-tolerant shade and low-cost botanical pest management.
+It is now present in parts of Africa, Southeast Asia, the Caribbean, and the
+American tropics.
+
+### Distribution in Costa Rica
+
+In Costa Rica, neem appears mostly in:
+
+- **Guanacaste and dry Pacific sectors** (roadsides, farms, schools, parks)
+- **Urban heat islands** in lowland cities where shade demand is high
+- **Agroforestry edges** and mixed farms with low irrigation availability
+- **Demonstration plots** for botanical pest management
+
+Neem is less common in waterlogged Caribbean lowlands and cool, very wet
+highlands.
+
+### Establishment and Monitoring Considerations
+
+Neem is not currently documented as a top-tier invasive threat in Costa Rica at
+a national scale, but local monitoring is still advisable where disturbed,
+open habitats surround native dry-forest fragments.
+
+---
+
+## Habitat & Ecology
+
+### Environmental Preferences
+
+<DataTable
+  headers={["Factor", "Preferred", "Tolerance"]}
+  rows={[
+    ["Rainfall", "700-1500 mm/year", "~450-2000 mm with drainage"],
+    ["Temperature", "24-34°C", "Sensitive to prolonged cold"],
+    ["Soil", "Well-drained loam/sandy", "Poor soils if not waterlogged"],
+    ["Light", "Full sun", "Performs poorly in dense shade"],
+  ]}
+/>
+
+### Ecological Functions in Managed Landscapes
+
+<SimpleList
+  items={[
+    "Rapid shade in hot, exposed urban and farm edges",
+    "Leaf litter inputs in degraded soils",
+    "Wind buffering in mixed agroforestry lines",
+    "Nectar and pollen support for some insects during flowering windows",
+    "Dry-season microclimate moderation for understory crops",
+  ]}
+/>
+
+### Ecological Caveats
+
+<Callout type="warning" title="Use with ecological judgment">
+  Neem can be beneficial in built or heavily altered landscapes, but planting
+  should avoid sensitive restoration cores and dry-forest remnants where
+  introduced species pressure is already high. Prefer native species in priority
+  biodiversity corridors.
+</Callout>
+
+---
+
+## Botanical Description
+
+<Accordion>
+  <AccordionItem title="Tree Form" defaultOpen={true}>
+    Mature neem typically has a straight to slightly sinuous trunk, an open to
+    rounded crown, and a robust branching system that casts broad shade. Under
+    dry stress, canopy density can fluctuate seasonally.
+
+    <PropertiesGrid>
+      <PropertyCard icon="📏" label="Height" value="12-25 m" />
+      <PropertyCard icon="🪵" label="Trunk diameter" value="30-80 cm" />
+      <PropertyCard icon="☂️" label="Crown" value="Broad, irregular-rounded" />
+      <PropertyCard icon="🌬️" label="Wind response" value="Moderate branch-shed risk" />
+    </PropertiesGrid>
+
+  </AccordionItem>
+
+<AccordionItem title="Bark">
+  Bark is gray-brown to dark brown, fissuring with age. Inner bark is bitter,
+  reflecting limonoid chemistry associated with traditional medicinal use and
+  anti-herbivory properties.
+</AccordionItem>
+
+  <AccordionItem title="Leaves">
+    Leaves are alternate, pinnate, and strongly serrated at leaflet edges.
+    New flush can appear lighter green, maturing to medium-dark green.
+
+    <DataTable
+      headers={["Leaf trait", "Description"]}
+      rows={[
+        ["Type", "Alternate, pinnately compound"],
+        ["Leaflet count", "Typically 8-18"],
+        ["Leaflet margins", "Serrate to crenate-serrate"],
+        ["Texture", "Thin to moderately coriaceous"],
+      ]}
+    />
+
+  </AccordionItem>
+
+<AccordionItem title="Flowers">
+  Neem flowers are small, white to creamy-white, sweetly fragrant, and often
+  produced in panicles. Flowering can be heavy in trees with full-sun exposure
+  and pronounced dry-season transition.
+</AccordionItem>
+
+  <AccordionItem title="Fruit and Seeds">
+    Fruits are small drupes that mature yellow to yellow-green. Seeds are
+    oil-rich and are the source of most commercial neem extracts.
+
+    <Callout type="warning">
+      Raw seeds and concentrated seed oil are not general food products.
+      Household storage should be clearly labeled and secured away from children
+      and animals.
+    </Callout>
+
+  </AccordionItem>
+</Accordion>
+
+---
+
+## Uses & Applications
+
+<PropertiesGrid>
+  <PropertyCard
+    icon="🌳"
+    label="Shade"
+    value="High utility"
+    description="Heat mitigation"
+  />
+  <PropertyCard
+    icon="🧪"
+    label="Botanical extracts"
+    value="Widely used"
+    description="Pest suppression"
+  />
+  <PropertyCard
+    icon="🌱"
+    label="Land rehab"
+    value="Useful"
+    description="Low-input establishment"
+  />
+  <PropertyCard
+    icon="🏘️"
+    label="Urban planting"
+    value="Conditional"
+    description="Needs space + pruning"
+  />
+</PropertiesGrid>
+
+### Traditional and Community Uses
+
+<SimpleList
+  items={[
+    "Village shade near schools, clinics, and roads",
+    "Leaves and bark in traditional medicinal systems",
+    "Seed products in botanical pest management programs",
+    "Soap and topical products from seed oil",
+    "Mixed-farm wind and dust buffering",
+  ]}
+/>
+
+### Botanical Pest Management Context
+
+Neem-derived products can reduce pressure from certain pests when integrated
+with crop hygiene, biological control, and threshold-based scouting.
+
+<DataTable
+  headers={["Approach", "Potential benefit", "Important limit"]}
+  rows={[
+    [
+      "Neem extract sprays",
+      "Reduced feeding/egg-laying in some pests",
+      "Not instant knockdown",
+    ],
+    [
+      "Soil drench in nurseries",
+      "Early-stage pest pressure management",
+      "Risk to non-targets if overdosed",
+    ],
+    [
+      "Seed cake amendments",
+      "Soil organic input + some pest suppression",
+      "Variable quality by source",
+    ],
+  ]}
+/>
+
+<Callout type="info" title="Integrated management only">
+  Neem works best as one tool among many. Overreliance can produce poor results,
+  inconsistent control, and unintended impacts on beneficial organisms.
+</Callout>
+
+---
+
+## Safety & Public Health Considerations
+
+### Household Safety Matrix
+
+<DataTable
+  headers={["Item", "Risk", "Recommendation"]}
+  rows={[
+    ["Fresh leaves", "Low", "Avoid habitual ingestion without guidance"],
+    ["Raw seeds", "Moderate", "Do not ingest; keep away from children"],
+    [
+      "Concentrated seed oil",
+      "Moderate-High",
+      "Store locked and clearly labeled",
+    ],
+    [
+      "Diluted horticultural formulations",
+      "Low-Moderate",
+      "Use PPE and follow label",
+    ],
+  ]}
+/>
+
+### Sensitive Groups
+
+- Children
+- Pregnant or breastfeeding people
+- Pets (especially cats and small dogs)
+- Individuals with liver compromise
+
+### Good Practice Checklist
+
+<SimpleList
+  items={[
+    "Wear gloves when mixing concentrated products",
+    "Avoid spraying in midday heat and active pollinator windows",
+    "Do not apply directly to open water or fish ponds",
+    "Keep concentrated products in original containers",
+    "Do not use medicinally without qualified guidance",
+  ]}
+/>
+
+---
+
+## Cultivation Guide (Costa Rica)
+
+<Accordion>
+  <AccordionItem title="Site Selection" defaultOpen={true}>
+    Choose full-sun, well-drained sites with room for mature crown spread.
+    Avoid very narrow sidewalks and permanently wet soils.
+
+    <DataTable
+      headers={["Site type", "Suitability", "Notes"]}
+      rows={[
+        ["Dry urban park edge", "High", "Excellent shade candidate"],
+        ["Farm windbreak line", "High", "Combine with natives"],
+        ["Heavy clay waterlogged basin", "Low", "Root decline risk"],
+        ["Biodiversity restoration core", "Low", "Prefer native species"],
+      ]}
+    />
+
+  </AccordionItem>
+
+  <AccordionItem title="Propagation and Establishment">
+    Neem is often propagated by fresh seed or nursery seedlings. Germination is
+    best with fresh material; viability declines with long storage.
+
+    <SimpleList
+      items={[
+        "Use fresh, clean seed from healthy trees",
+        "Sow in well-drained substrate",
+        "Provide full light after early emergence",
+        "Harden seedlings before transplant",
+        "Plant early in rainy season for best survival",
+      ]}
+    />
+
+  </AccordionItem>
+
+  <AccordionItem title="Water and Nutrition">
+    Young trees need structured watering through first dry seasons.
+    Mature trees need minimal irrigation except in severe drought.
+
+    <DataTable
+      headers={["Phase", "Watering", "Nutrition"]}
+      rows={[
+        ["0-6 months", "2-3 times/week in dry spells", "Light compost at planting"],
+        ["6-24 months", "Weekly deep watering in dry season", "Optional annual organic topdress"],
+        ["2+ years", "Usually rainfall sufficient", "Minimal inputs unless growth is poor"],
+      ]}
+    />
+
+  </AccordionItem>
+
+  <AccordionItem title="Pruning and Risk Management">
+    Conduct formative pruning to establish strong branch architecture.
+    Remove crossing limbs and weak fork unions before storm season.
+
+    <SimpleList
+      items={[
+        "Formative prune years 1-4",
+        "Remove deadwood annually",
+        "Inspect after major wind events",
+        "Keep 8+ m clearance from electrical infrastructure",
+      ]}
+    />
+
+  </AccordionItem>
+
+  <AccordionItem title="Companion Planting and System Design">
+    Neem can function in mixed dryland systems if spacing and biodiversity goals
+    are respected.
+
+    <DataTable
+      headers={["Companion", "Compatibility", "Role"]}
+      rows={[
+        ["Madero negro", "High", "Nitrogen support and shade layering"],
+        ["Guanacaste (native)", "Moderate", "Long-term canopy succession"],
+        ["Mango", "Moderate", "Shared dry-season adaptation"],
+        ["Pollinator-native shrubs", "High", "Compensate floral resource gaps"],
+      ]}
+    />
+
+  </AccordionItem>
+
+  <AccordionItem title="Seasonal Care Calendar">
+    <DataTable
+      headers={["Season", "Priority actions"]}
+      rows={[
+        ["Dec-Apr (dry)", "Water young trees; inspect branch safety; mulch renewal"],
+        ["May-Jul (early rains)", "Planting window; light pruning; seedling replacement"],
+        ["Aug-Oct (peak rains)", "Monitor fungal stress in poorly drained spots"],
+        ["Nov transition", "Structure checks and next-cycle maintenance planning"],
+      ]}
+    />
+  </AccordionItem>
+</Accordion>
+
+---
+
+## Ecological Governance: Where Neem Fits and Where It Doesn’t
+
+<Callout type="warning" title="Use-context decision rule">
+  Neem is most appropriate in heat-stressed urban and heavily modified farm
+  landscapes. In restoration cores or high-value native biodiversity areas,
+  prioritize native trees first.
+</Callout>
+
+### Decision Table for Planting Programs
+
+<DataTable
+  headers={["Program goal", "Neem role", "Preferred strategy"]}
+  rows={[
+    [
+      "Urban heat mitigation",
+      "Supportive",
+      "Mixed palette with natives + neem in low-risk sites",
+    ],
+    [
+      "Dry-farm shelterbelt",
+      "Supportive",
+      "Use as one component, monitor recruitment",
+    ],
+    [
+      "Native forest restoration",
+      "Limited",
+      "Avoid; use native functional analogs",
+    ],
+    [
+      "School environmental gardens",
+      "Conditional",
+      "Only with safety education + locked extract storage",
+    ],
+  ]}
+/>
+
+### Monitoring Indicators
+
+<SimpleList
+  items={[
+    "Volunteer seedlings in adjacent unmanaged lots",
+    "Branch-failure incidents after seasonal wind",
+    "Pollinator activity before/after spray windows",
+    "Canopy health under prolonged drought",
+    "Community safety incidents from improper extract handling",
+  ]}
+/>
+
+---
+
+## Identification Guide
+
+<Accordion>
+  <AccordionItem title="Key Features" defaultOpen={true}>
+    <SimpleList
+      items={[
+        "Pinnate leaves with clearly serrated leaflets",
+        "Small fragrant white flowers in panicles",
+        "Yellow drupes when ripe",
+        "Strongly bitter bark and seed products",
+        "Drought-adapted crown in hot open sites",
+      ]}
+    />
+  </AccordionItem>
+
+  <AccordionItem title="Similar Species in Costa Rica">
+    <DataTable
+      headers={["Species", "How to distinguish"]}
+      rows={[
+        ["Melia azedarach", "Different leaflet architecture and fruit persistence"],
+        ["Cedrela odorata", "Larger timber tree; no neem-like bitter chemistry"],
+        ["Young mahogany spp.", "Leaf shape differs; no characteristic neem smell"],
+      ]}
+    />
+  </AccordionItem>
+</Accordion>
+
+---
+
+## Where to See Neem in Costa Rica
+
+<DataTable
+  headers={["Area", "Context", "Observation tip"]}
+  rows={[
+    [
+      "Guanacaste towns",
+      "Street and park shade trees",
+      "Look for dry-season canopy persistence",
+    ],
+    [
+      "Pacific lowland farms",
+      "Windbreak and perimeter lines",
+      "Observe mixed agroforestry integration",
+    ],
+    [
+      "Urban lowland campuses",
+      "Heat-mitigation plantings",
+      "Compare pruning quality and branch structure",
+    ],
+  ]}
+/>
+
+---
+
+## External Resources
+
+<ExternalLinksGrid>
+  <ExternalLink
+    href="https://www.inaturalist.org/taxa/319135-Azadirachta-indica"
+    title="iNaturalist: Azadirachta indica"
+    description="Observations, photos, and community identification records"
+    icon="🌿"
+    source="Community science"
+  />
+  <ExternalLink
+    href="https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:577592-1"
+    title="Plants of the World Online (Kew)"
+    description="Accepted taxonomy and distribution references"
+    icon="📚"
+    source="Royal Botanic Gardens, Kew"
+  />
+  <ExternalLink
+    href="https://www.cabi.org/isc/datasheet/811"
+    title="CABI Datasheet"
+    description="Risk and management information for global contexts"
+    icon="🧭"
+    source="CABI"
+  />
+  <ExternalLink
+    href="https://www.fao.org/forestry/"
+    title="FAO Forestry Resources"
+    description="Agroforestry and dryland tree management guidance"
+    icon="🌳"
+    source="FAO"
+  />
+</ExternalLinksGrid>
+
+---
+
+## References
+
+<ReferencesSection>
+  <Reference
+    authors="National Research Council"
+    year="1992"
+    title="Neem: A Tree for Solving Global Problems"
+    journal="National Academies Press"
+  />
+  <Reference
+    authors="Koul, O. & Wahab, S."
+    year="2004"
+    title="Neem: Today and in the New Millennium"
+    journal="Springer"
+  />
+  <Reference
+    authors="Schmutterer, H."
+    year="1990"
+    title="Properties and potential of natural pesticides from the neem tree"
+    journal="Annual Review of Entomology"
+  />
+  <Reference
+    authors="CABI"
+    year="2024"
+    title="Azadirachta indica datasheet"
+    journal="Invasive Species Compendium"
+  />
+</ReferencesSection>
+
+---
+
+<Callout type="success" title="Pragmatic, Not Magical">
+  Neem is a useful tree in Costa Rica when matched to the right place and
+  purpose: hot urban shade, low-input farms, and controlled agroforestry edges.
+  It should be managed with ecological humility, clear safety protocols, and
+  native-species priorities where biodiversity restoration is the core mission.
+</Callout>

--- a/content/trees/en/nim.mdx
+++ b/content/trees/en/nim.mdx
@@ -42,7 +42,7 @@ fruitingSeason:
   - "may"
   - "june"
   - "july"
-featuredImage: "/images/trees/nim.jpg"
+featuredImage: "/images/trees/pilon-placeholder.svg"
 publishedAt: "2026-02-15"
 updatedAt: "2026-02-15"
 # Safety Information

--- a/content/trees/en/nim.mdx
+++ b/content/trees/en/nim.mdx
@@ -42,7 +42,7 @@ fruitingSeason:
   - "may"
   - "june"
   - "july"
-featuredImage: "/images/trees/pilon-placeholder.svg"
+featuredImage: "/images/trees/nim/featured.jpg"
 publishedAt: "2026-02-15"
 updatedAt: "2026-02-15"
 # Safety Information

--- a/content/trees/es/nim.mdx
+++ b/content/trees/es/nim.mdx
@@ -42,7 +42,7 @@ fruitingSeason:
   - "may"
   - "june"
   - "july"
-featuredImage: "/images/trees/nim.jpg"
+featuredImage: "/images/trees/pilon-placeholder.svg"
 publishedAt: "2026-02-15"
 updatedAt: "2026-02-15"
 # Información de Seguridad

--- a/content/trees/es/nim.mdx
+++ b/content/trees/es/nim.mdx
@@ -1,0 +1,723 @@
+---
+title: "Nim"
+scientificName: "Azadirachta indica"
+family: "Meliaceae"
+locale: "es"
+slug: "nim"
+description: "El nim es un árbol tolerante a sequía, nativo del subcontinente indio y ampliamente plantado en Costa Rica para sombra, uso medicinal y manejo botánico de plagas; es ecológicamente significativo en paisajes urbanos y agroforestales secos."
+nativeRegion: "Subcontinente indio (India, Pakistán, Bangladés, Nepal, Sri Lanka)"
+conservationStatus: "LC"
+maxHeight: "12-25 metros"
+uses:
+  - "Árbol de sombra"
+  - "Medicina tradicional"
+  - "Pesticida botánico"
+  - "Rompevientos"
+  - "Rehabilitación de suelos"
+  - "Agroforestería"
+  - "Aceites para jabón y cosmética"
+tags:
+  - "introduced"
+  - "evergreen"
+  - "drought-tolerant"
+  - "medicinal"
+  - "agroforestry"
+  - "urban-tree"
+  - "pollinator-resource"
+distribution:
+  - "guanacaste"
+  - "puntarenas"
+  - "alajuela"
+  - "san-jose"
+  - "heredia"
+  - "limon"
+elevation: "0-1400m"
+floweringSeason:
+  - "january"
+  - "february"
+  - "march"
+  - "april"
+fruitingSeason:
+  - "april"
+  - "may"
+  - "june"
+  - "july"
+featuredImage: "/images/trees/nim.jpg"
+publishedAt: "2026-02-15"
+updatedAt: "2026-02-15"
+# Información de Seguridad
+toxicityLevel: "moderate"
+toxicParts:
+  - "seeds"
+  - "seed-oil"
+  - "bark"
+skinContactRisk: "low"
+allergenRisk: "low"
+structuralRisks:
+  - "falling-branches"
+childSafe: false
+petSafe: false
+requiresProfessionalCare: false
+toxicityDetails: "El nim contiene compuestos útiles, pero debe manejarse con cuidado. El aceite concentrado de semilla y los extractos de semilla no son seguros para niños, personas embarazadas o mascotas cuando se ingieren en cantidades significativas. Sus compuestos amargos (incluyendo azadiractina y otros limonoides) pueden causar náusea, vómito y síntomas neurológicos en sobredosis. Las semillas crudas y extractos caseros concentrados no deben consumirse."
+skinContactDetails: "La mayoría de personas manipula hojas y corteza sin irritación importante. Individuos sensibles pueden presentar dermatitis leve tras contacto prolongado con aceite concentrado o savia fresca. Use guantes al preparar extractos o manipular grandes cantidades de semillas."
+allergenDetails: "El riesgo alérgico suele ser bajo, pero el polen y los olores intensos pueden irritar personas sensibles. El polvo de madera y aceites concentrados pueden causar irritación respiratoria leve en personal expuesto."
+structuralRiskDetails: "El nim desarrolla copa amplia y puede soltar ramas medianas durante vientos fuertes o tras estrés hídrico prolongado. En sitios urbanos compactos, las raíces pueden levantar pavimentos si se planta muy cerca. Pode de forma periódica y mantenga distancia de aceras estrechas e infraestructura subterránea."
+safetyNotes: "El nim es valioso, pero no es árbol para consumo directo. Mantenga semillas y productos concentrados lejos de niños y mascotas. Para uso agrícola o doméstico utilice formulaciones estandarizadas y diluidas, evitando remedios improvisados de alta dosis. En Costa Rica su plantación puede ser útil con manejo responsable y monitoreo de dispersión."
+wildlifeRisks: "Riesgo moderado para fauna. Las flores pueden apoyar insectos, pero los productos concentrados de semilla pueden afectar organismos no objetivo si se aplican mal. Evite aplicar extractos en horas de alta actividad de polinizadores y nunca deseche concentrados en cuerpos de agua."
+# Cuidado y Cultivo
+growthRate: "fast"
+growthRateDetails: "Rápido en tierras bajas cálidas; frecuentemente 0.8-1.5 m por año durante establecimiento"
+matureSize: "12-25 m de altura, copa de 8-15 m según agua y poda"
+hardiness: "Mejor en zonas tropicales/subtropicales de estación seca; tolera calor y sequía"
+soilRequirements: "Prefiere suelos bien drenados; tolera suelos pobres, arenosos y moderadamente alcalinos; evitar encharcamiento"
+waterNeeds: "low"
+waterDetails: "Bajas a moderadas una vez establecido. Árboles jóvenes requieren riego de apoyo en los dos primeros veranos; adultos toleran sequías prolongadas."
+lightRequirements: "full-sun"
+spacing: "Plantar a 8-12 m de construcciones y 6-10 m entre árboles para buena copa y ventilación"
+propagationMethods:
+  - "seeds"
+  - "seedlings"
+  - "grafting"
+propagationDifficulty: "easy"
+plantingSeason: "Inicio de lluvias (mayo-julio) ideal; plantas en bolsa se pueden establecer todo el año con riego"
+maintenanceNeeds: "Bajo a moderado. Formar eje central en primeros años, podar cruces y retirar ramas muertas antes de temporada de vientos. Mantener anillo de acolchado libre de maleza durante establecimiento. Vigilar plántulas voluntarias en sitios perturbados y remover si hay dispersión no deseada."
+commonProblems:
+  - "Estrés radicular en suelos pesados encharcados"
+  - "Reducción de copa bajo frío prolongado o sombra"
+  - "Caída ocasional de ramas en épocas secas ventosas"
+  - "Uso incorrecto de aceite concentrado con incidentes de seguridad"
+  - "Plántulas voluntarias en suelos abiertos perturbados"
+---
+
+# Nim (Neem)
+
+<Callout type="tip" title="Árbol práctico para paisajes tropicales secos">
+  **Nim** (_Azadirachta indica_) es una especie introducida pero útil en zonas
+  secas y urbanas de Costa Rica. Se valora por su sombra, su tolerancia a la
+  sequía y su uso en manejo botánico de plagas. No es una solución universal;
+  con buen manejo puede apoyar ciudades más frescas, agroforestería de bajo
+  insumo y rehabilitación de suelos degradados.
+</Callout>
+
+<TwoColumn>
+  <Column>
+    <QuickRef
+      title="Referencia rápida"
+      items={[
+        { label: "Nombre científico", value: "Azadirachta indica" },
+        { label: "Familia", value: "Meliaceae" },
+        { label: "Altura máxima", value: "12-25 m" },
+        { label: "Crecimiento", value: "Rápido" },
+        { label: "Origen", value: "Subcontinente indio" },
+        { label: "Estado en Costa Rica", value: "Introducido, establecido" },
+        {
+          label: "Uso principal",
+          value: "Sombra + agroforestería de bajo insumo",
+        },
+      ]}
+    />
+  </Column>
+  <Column>
+    <INaturalistEmbed
+      taxonId="319135"
+      taxonName="Azadirachta indica"
+      observationCount={1200}
+    />
+  </Column>
+</TwoColumn>
+
+---
+
+## 📸 Galería de fotos
+
+<ImageGallery>
+  <ImageCard
+    src="https://static.inaturalist.org/photos/29580912/medium.jpg"
+    alt="Copa y tronco de Azadirachta indica"
+    title="Árbol completo"
+    credit="(c) observador de iNaturalist, todos los derechos reservados"
+    license="CC BY-NC"
+    sourceUrl="https://www.inaturalist.org/taxa/319135-Azadirachta-indica/browse_photos"
+  />
+  <ImageCard
+    src="https://static.inaturalist.org/photos/61556304/medium.jpg"
+    alt="Hojas compuestas de nim"
+    title="Hojas"
+    credit="(c) observador de iNaturalist, todos los derechos reservados"
+    license="CC BY-NC"
+    sourceUrl="https://www.inaturalist.org/taxa/319135-Azadirachta-indica/browse_photos"
+  />
+  <ImageCard
+    src="https://static.inaturalist.org/photos/40957759/medium.jpg"
+    alt="Flores de nim"
+    title="Flores"
+    credit="(c) observador de iNaturalist, todos los derechos reservados"
+    license="CC BY-NC"
+    sourceUrl="https://www.inaturalist.org/taxa/319135-Azadirachta-indica/browse_photos"
+  />
+  <ImageCard
+    src="https://static.inaturalist.org/photos/40957767/medium.jpg"
+    alt="Frutos de nim"
+    title="Fruto"
+    credit="(c) observador de iNaturalist, todos los derechos reservados"
+    license="CC BY-NC"
+    sourceUrl="https://www.inaturalist.org/taxa/319135-Azadirachta-indica/browse_photos"
+  />
+  <ImageCard
+    src="https://static.inaturalist.org/photos/40470404/medium.jpg"
+    alt="Corteza de nim"
+    title="Corteza"
+    credit="(c) observador de iNaturalist, todos los derechos reservados"
+    license="CC BY-NC"
+    sourceUrl="https://www.inaturalist.org/taxa/319135-Azadirachta-indica/browse_photos"
+  />
+</ImageGallery>
+
+<Callout type="info">
+  Las imágenes se enlazan desde el archivo comunitario de iNaturalist. Se
+  recomienda verificación de campo y revisión de atribuciones antes de usar en
+  materiales educativos impresos.
+</Callout>
+
+---
+
+## Taxonomía y clasificación
+
+<PropertiesGrid>
+  <PropertyCard icon="👑" label="Reino" value="Plantae" />
+  <PropertyCard icon="🌸" label="Clado" value="Angiospermas" />
+  <PropertyCard icon="🌿" label="Orden" value="Sapindales" />
+  <PropertyCard icon="🪴" label="Familia" value="Meliaceae" />
+  <PropertyCard icon="🌳" label="Género" value="Azadirachta" />
+  <PropertyCard icon="🔬" label="Especie" value="A. indica" />
+</PropertiesGrid>
+
+<Accordion>
+  <AccordionItem title="Nombres comunes por región" defaultOpen={true}>
+    <DataTable
+      headers={["Región", "Nombre común", "Notas"]}
+      rows={[
+        ["Costa Rica", "Nim, Neem", "Formas más usadas"],
+        ["India", "Neem, Nimba", "Contexto ayurvédico clásico"],
+        [
+          "América hispanohablante",
+          "Nim, Árbol de Neem",
+          "Uso urbano y agroforestal",
+        ],
+        ["Inglés", "Neem", "Nombre comercial global"],
+      ]}
+    />
+  </AccordionItem>
+  <AccordionItem title="Notas taxonómicas y origen del nombre">
+    _Azadirachta_ proviene de expresiones persas asociadas a “árbol noble” o
+    “árbol libre”. _indica_ significa “de la India”. Aunque pertenece a la
+    familia de caobas, ecológicamente funciona como pionero resistente en climas
+    cálidos con estación seca.
+  </AccordionItem>
+</Accordion>
+
+---
+
+## Distribución geográfica
+
+<PropertiesGrid>
+  <PropertyCard icon="🌍" label="Rango nativo" value="Subcontinente indio" />
+  <PropertyCard
+    icon="🇨🇷"
+    label="Costa Rica"
+    value="Introducido y establecido"
+  />
+  <PropertyCard icon="⛰️" label="Elevación" value="0-1400 m" />
+  <PropertyCard
+    icon="☀️"
+    label="Clima óptimo"
+    value="Zonas cálidas con estación seca"
+  />
+</PropertiesGrid>
+
+### Contexto global
+
+El nim se ha plantado en regiones tropicales durante décadas por su capacidad
+para dar sombra y por su uso en manejo de plagas de base botánica.
+
+### Distribución en Costa Rica
+
+En Costa Rica es más frecuente en:
+
+- **Guanacaste y Pacífico seco** (calles, parques, fincas)
+- **Islas de calor urbanas** en ciudades de baja altitud
+- **Líneas agroforestales** con baja disponibilidad de riego
+- **Parcelas demostrativas** de manejo botánico de plagas
+
+Es menos común en suelos permanentemente encharcados y en alturas frescas muy
+húmedas.
+
+### Consideraciones de establecimiento
+
+No está documentado como una de las especies invasoras de mayor prioridad a
+escala nacional, pero sí se recomienda monitorear su regeneración en hábitats
+abiertos junto a fragmentos de bosque seco nativo.
+
+---
+
+## Hábitat y ecología
+
+### Preferencias ambientales
+
+<DataTable
+  headers={["Factor", "Preferido", "Tolerancia"]}
+  rows={[
+    ["Precipitación", "700-1500 mm/año", "~450-2000 mm con buen drenaje"],
+    ["Temperatura", "24-34°C", "Sensible a frío prolongado"],
+    ["Suelo", "Franco/arenoso bien drenado", "Suelos pobres sin encharque"],
+    ["Luz", "Pleno sol", "Bajo rendimiento en sombra densa"],
+  ]}
+/>
+
+### Funciones ecológicas en paisajes manejados
+
+<SimpleList
+  items={[
+    "Sombra rápida en zonas urbanas muy cálidas",
+    "Aporte de hojarasca en suelos degradados",
+    "Amortiguación de viento en linderos agroforestales",
+    "Recurso floral temporal para algunos insectos",
+    "Mejora de microclima seco para cultivos asociados",
+  ]}
+/>
+
+### Precaución ecológica
+
+<Callout type="warning" title="Usar con criterio ecológico">
+  El nim puede ser útil en contextos urbanos o agrícolas ya transformados. En
+  núcleos de restauración o corredores de alta prioridad de biodiversidad,
+  conviene priorizar especies nativas.
+</Callout>
+
+---
+
+## Descripción botánica
+
+<Accordion>
+  <AccordionItem title="Forma del árbol" defaultOpen={true}>
+    El nim adulto suele mostrar tronco recto a levemente sinuoso, copa amplia y
+    ramificación robusta. En sequía marcada puede perder densidad foliar.
+
+    <PropertiesGrid>
+      <PropertyCard icon="📏" label="Altura" value="12-25 m" />
+      <PropertyCard icon="🪵" label="Diámetro" value="30-80 cm" />
+      <PropertyCard icon="☂️" label="Copa" value="Amplia, redondeada irregular" />
+      <PropertyCard icon="🌬️" label="Viento" value="Riesgo moderado de caída de ramas" />
+    </PropertiesGrid>
+
+  </AccordionItem>
+
+<AccordionItem title="Corteza">
+  La corteza es parda grisácea a parda oscura y se fisura con la edad. La
+  corteza interna tiene sabor muy amargo por su química de limonoides.
+</AccordionItem>
+
+  <AccordionItem title="Hojas">
+    Hojas alternas, compuestas pinnadas, con borde aserrado en folíolos.
+
+    <DataTable
+      headers={["Rasgo", "Descripción"]}
+      rows={[
+        ["Tipo", "Alternas, compuestas pinnadas"],
+        ["Número de folíolos", "Usualmente 8-18"],
+        ["Borde", "Aserrado"],
+        ["Textura", "Delgada a moderadamente coriácea"],
+      ]}
+    />
+
+  </AccordionItem>
+
+<AccordionItem title="Flores">
+  Flores pequeñas, blancas a crema, fragantes, dispuestas en panículas. La
+  floración suele aumentar con buen sol y transición seca-lluviosa.
+</AccordionItem>
+
+  <AccordionItem title="Fruto y semilla">
+    Frutos tipo drupa pequeños, de color amarillo a amarillo verdoso al madurar.
+    Las semillas son ricas en aceite y base de la mayoría de extractos.
+
+    <Callout type="warning">
+      Las semillas crudas y aceites concentrados no deben considerarse alimentos
+      de consumo general.
+    </Callout>
+
+  </AccordionItem>
+</Accordion>
+
+---
+
+## Usos y aplicaciones
+
+<PropertiesGrid>
+  <PropertyCard
+    icon="🌳"
+    label="Sombra"
+    value="Alta utilidad"
+    description="Mitigación térmica"
+  />
+  <PropertyCard
+    icon="🧪"
+    label="Extractos botánicos"
+    value="Uso extendido"
+    description="Supresión de plagas"
+  />
+  <PropertyCard
+    icon="🌱"
+    label="Rehabilitación"
+    value="Útil"
+    description="Establecimiento de bajo insumo"
+  />
+  <PropertyCard
+    icon="🏘️"
+    label="Arbolado urbano"
+    value="Condicional"
+    description="Requiere espacio y poda"
+  />
+</PropertiesGrid>
+
+### Usos comunitarios tradicionales
+
+<SimpleList
+  items={[
+    "Sombra en escuelas, caminos y espacios públicos",
+    "Hojas y corteza en medicina tradicional",
+    "Productos de semilla en manejo botánico de plagas",
+    "Aceites para jabón y productos tópicos",
+    "Cortinas rompeviento en fincas mixtas",
+  ]}
+/>
+
+### Manejo botánico de plagas
+
+Los productos derivados de nim pueden reducir presión de algunas plagas cuando
+se usan junto con monitoreo, control biológico e higiene de cultivo.
+
+<DataTable
+  headers={["Enfoque", "Beneficio potencial", "Límite clave"]}
+  rows={[
+    [
+      "Aspersiones",
+      "Menor alimentación y oviposición en algunas plagas",
+      "No es acción de choque",
+    ],
+    [
+      "Drench en vivero",
+      "Apoyo en etapas tempranas",
+      "Riesgo si se sobredosifica",
+    ],
+    [
+      "Torta de semilla",
+      "Aporte orgánico + efecto parcial",
+      "Calidad variable",
+    ],
+  ]}
+/>
+
+<Callout type="info" title="Siempre en manejo integrado">
+  El nim funciona mejor como parte de una estrategia integrada; su uso exclusivo
+  suele producir resultados inconsistentes.
+</Callout>
+
+---
+
+## Seguridad y salud pública
+
+### Matriz de seguridad doméstica
+
+<DataTable
+  headers={["Elemento", "Riesgo", "Recomendación"]}
+  rows={[
+    ["Hojas frescas", "Bajo", "Evitar consumo habitual sin guía"],
+    ["Semillas crudas", "Moderado", "No ingerir; mantener fuera de alcance"],
+    ["Aceite concentrado", "Moderado-Alto", "Guardar cerrado y rotulado"],
+    ["Formulaciones diluidas", "Bajo-Moderado", "Usar EPP y respetar etiqueta"],
+  ]}
+/>
+
+### Grupos sensibles
+
+- Niñez
+- Personas embarazadas o en lactancia
+- Mascotas (especialmente gatos y perros pequeños)
+- Personas con compromiso hepático
+
+### Lista de buenas prácticas
+
+<SimpleList
+  items={[
+    "Usar guantes en mezclas concentradas",
+    "Evitar aplicación con alta actividad de polinizadores",
+    "No desechar concentrados en cuerpos de agua",
+    "Guardar siempre en envases rotulados",
+    "No usar como medicina sin orientación profesional",
+  ]}
+/>
+
+---
+
+## Guía de cultivo (Costa Rica)
+
+<Accordion>
+  <AccordionItem title="Selección del sitio" defaultOpen={true}>
+    Priorice pleno sol, buen drenaje y espacio para copa adulta. Evite aceras
+    angostas y suelos con saturación permanente.
+
+    <DataTable
+      headers={["Tipo de sitio", "Aptitud", "Observación"]}
+      rows={[
+        ["Parque urbano seco", "Alta", "Excelente para sombra"],
+        ["Línea rompeviento de finca", "Alta", "Mejor en mezcla con nativas"],
+        ["Depresión anegada", "Baja", "Riesgo de pudrición radicular"],
+        ["Núcleo de restauración", "Baja", "Preferir especies nativas"],
+      ]}
+    />
+
+  </AccordionItem>
+
+  <AccordionItem title="Propagación y establecimiento">
+    Se propaga por semilla fresca y por plántula de vivero. La viabilidad baja
+    con almacenamiento prolongado.
+
+    <SimpleList
+      items={[
+        "Semilla fresca de árboles sanos",
+        "Sustrato bien drenado",
+        "Buena luz tras emergencia",
+        "Endurecimiento antes de trasplante",
+        "Siembra al inicio de lluvias",
+      ]}
+    />
+
+  </AccordionItem>
+
+  <AccordionItem title="Riego y nutrición">
+    Durante establecimiento requiere riego ordenado en verano.
+
+    <DataTable
+      headers={["Etapa", "Riego", "Nutrición"]}
+      rows={[
+        ["0-6 meses", "2-3 veces/semana en sequía", "Compost ligero al plantar"],
+        ["6-24 meses", "Riego profundo semanal en verano", "Aporte orgánico anual opcional"],
+        ["2+ años", "Normalmente basta lluvia", "Mínimo insumo"],
+      ]}
+    />
+
+  </AccordionItem>
+
+  <AccordionItem title="Poda y manejo de riesgo">
+    Forme arquitectura fuerte desde etapas tempranas.
+
+    <SimpleList
+      items={[
+        "Poda de formación años 1-4",
+        "Retiro anual de madera muerta",
+        "Inspección post-vientos fuertes",
+        "Mantener distancia de cableado",
+      ]}
+    />
+
+  </AccordionItem>
+
+  <AccordionItem title="Asociación de cultivos y diseño">
+    En sistemas secos puede integrarse con especies compatibles.
+
+    <DataTable
+      headers={["Compañero", "Compatibilidad", "Función"]}
+      rows={[
+        ["Madero negro", "Alta", "Soporte de fertilidad y estrato"],
+        ["Guanacaste (nativo)", "Moderada", "Sucesión de dosel"],
+        ["Mango", "Moderada", "Adaptación compartida a sequía"],
+        ["Arbustos nativos para polinizadores", "Alta", "Balance de recursos florales"],
+      ]}
+    />
+
+  </AccordionItem>
+
+  <AccordionItem title="Calendario estacional">
+    <DataTable
+      headers={["Época", "Acciones prioritarias"]}
+      rows={[
+        ["Dic-Abr (seca)", "Riego de juveniles; revisión estructural; renovar acolchado"],
+        ["May-Jul (inicio lluvias)", "Mejor ventana de plantación y reposición"],
+        ["Ago-Oct (lluvias fuertes)", "Monitorear estrés fúngico en mal drenaje"],
+        ["Nov (transición)", "Planificar poda y mantenimiento anual"],
+      ]}
+    />
+  </AccordionItem>
+</Accordion>
+
+---
+
+## Gobernanza ecológica: dónde sí y dónde no
+
+<Callout type="warning" title="Regla de decisión">
+  El nim funciona mejor en paisajes urbanos calientes y fincas muy modificadas.
+  En áreas de restauración de alta biodiversidad, se recomienda priorizar
+  especies nativas.
+</Callout>
+
+### Tabla de decisión para programas de plantación
+
+<DataTable
+  headers={["Meta del programa", "Rol del nim", "Estrategia sugerida"]}
+  rows={[
+    ["Mitigación de isla de calor", "Apoyo", "Paleta mixta con nativas"],
+    [
+      "Rompeviento agrícola",
+      "Apoyo",
+      "Usar en mezcla y monitorear reclutamiento",
+    ],
+    [
+      "Restauración de bosque nativo",
+      "Limitado",
+      "Evitar y usar análogos nativos",
+    ],
+    ["Huertos escolares", "Condicional", "Solo con protocolo de seguridad"],
+  ]}
+/>
+
+### Indicadores de monitoreo
+
+<SimpleList
+  items={[
+    "Plántulas voluntarias en lotes vecinos",
+    "Incidentes de caída de ramas",
+    "Actividad de polinizadores en ventanas de aplicación",
+    "Salud de copa en sequías prolongadas",
+    "Incidentes de seguridad por uso inadecuado de extractos",
+  ]}
+/>
+
+---
+
+## Guía de identificación
+
+<Accordion>
+  <AccordionItem title="Rasgos clave" defaultOpen={true}>
+    <SimpleList
+      items={[
+        "Hojas compuestas con folíolos aserrados",
+        "Flores pequeñas blancas y fragantes",
+        "Frutos amarillos al madurar",
+        "Sabor amargo característico en corteza y semilla",
+        "Buena respuesta en sitios cálidos y secos",
+      ]}
+    />
+  </AccordionItem>
+
+  <AccordionItem title="Especies parecidas en Costa Rica">
+    <DataTable
+      headers={["Especie", "Cómo diferenciar"]}
+      rows={[
+        ["Melia azedarach", "Arquitectura foliar y frutos distintos"],
+        ["Cedrela odorata", "Árbol maderable mayor, sin química típica de nim"],
+        ["Caobas juveniles", "Hojas y olor no coinciden"],
+      ]}
+    />
+  </AccordionItem>
+</Accordion>
+
+---
+
+## Dónde observar nim en Costa Rica
+
+<DataTable
+  headers={["Zona", "Contexto", "Consejo de observación"]}
+  rows={[
+    [
+      "Centros urbanos de Guanacaste",
+      "Sombra en parques y calles",
+      "Evaluar persistencia de copa en verano",
+    ],
+    [
+      "Fincas de Pacífico bajo",
+      "Líneas de rompeviento",
+      "Observar integración con otros estratos",
+    ],
+    [
+      "Campus urbanos cálidos",
+      "Arbolado de mitigación térmica",
+      "Comparar calidad de poda",
+    ],
+  ]}
+/>
+
+---
+
+## Recursos externos
+
+<ExternalLinksGrid>
+  <ExternalLink
+    href="https://www.inaturalist.org/taxa/319135-Azadirachta-indica"
+    title="iNaturalist: Azadirachta indica"
+    description="Observaciones, fotos y registros comunitarios"
+    icon="🌿"
+    source="Ciencia ciudadana"
+  />
+  <ExternalLink
+    href="https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:577592-1"
+    title="Plants of the World Online (Kew)"
+    description="Taxonomía aceptada y referencias de distribución"
+    icon="📚"
+    source="Royal Botanic Gardens, Kew"
+  />
+  <ExternalLink
+    href="https://www.cabi.org/isc/datasheet/811"
+    title="Ficha CABI"
+    description="Información de riesgo y manejo en contexto global"
+    icon="🧭"
+    source="CABI"
+  />
+  <ExternalLink
+    href="https://www.fao.org/forestry/"
+    title="Recursos forestales FAO"
+    description="Guías de agroforestería y manejo en zonas secas"
+    icon="🌳"
+    source="FAO"
+  />
+</ExternalLinksGrid>
+
+---
+
+## Referencias
+
+<ReferencesSection>
+  <Reference
+    authors="National Research Council"
+    year="1992"
+    title="Neem: A Tree for Solving Global Problems"
+    journal="National Academies Press"
+  />
+  <Reference
+    authors="Koul, O. & Wahab, S."
+    year="2004"
+    title="Neem: Today and in the New Millennium"
+    journal="Springer"
+  />
+  <Reference
+    authors="Schmutterer, H."
+    year="1990"
+    title="Properties and potential of natural pesticides from the neem tree"
+    journal="Annual Review of Entomology"
+  />
+  <Reference
+    authors="CABI"
+    year="2024"
+    title="Azadirachta indica datasheet"
+    journal="Invasive Species Compendium"
+  />
+</ReferencesSection>
+
+---
+
+<Callout type="success" title="Útil con manejo responsable">
+  El nim puede ser una especie útil en Costa Rica cuando se ubica en el sitio
+  correcto: ciudades cálidas, linderos agrícolas y sistemas de bajo insumo. Su
+  uso debe acompañarse de protocolos de seguridad, monitoreo de dispersión y
+  prioridad clara de especies nativas en zonas de restauración de biodiversidad.
+</Callout>

--- a/content/trees/es/nim.mdx
+++ b/content/trees/es/nim.mdx
@@ -42,7 +42,7 @@ fruitingSeason:
   - "may"
   - "june"
   - "july"
-featuredImage: "/images/trees/pilon-placeholder.svg"
+featuredImage: "/images/trees/nim/featured.jpg"
 publishedAt: "2026-02-15"
 updatedAt: "2026-02-15"
 # Información de Seguridad

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -7,7 +7,7 @@
 
 ### Content Coverage
 
-- **Species**: 160/175 (91%) - Target: 175+ documented species
+- **Species**: 161/175 (92%) - Target: 175+ documented species
 - **Comparison Guides**: 20/20 (100%) ✅ Complete
 - **Glossary Terms**: 100/150 (67%) - Target: 150+ terms
 - **Care Guidance**: 90/128 (70%) - Target: 100/128 (78%)
@@ -139,7 +139,7 @@
 
 ### 1.1: Add Missing Species
 
-**Status:** 🟡 In Progress (40/47 complete)  
+**Status:** 🟡 In Progress (41/47 complete)  
 **Reference:** [MISSING_SPECIES_LIST.md](MISSING_SPECIES_LIST.md)
 
 #### High Priority Native Species (10 species) ✅ COMPLETE
@@ -198,6 +198,13 @@
 - [x] Guarumbo Hembra (Cecropia peltata) — added 2026-02-12
 - [x] Bambu Gigante (Guadua angustifolia) — added 2026-02-12
 - [x] Add remaining 5 low priority species (Zorrillo, Contra, Achotillo, Guarumbo Hembra, and Bambu Gigante added 2026-02-12; see MISSING_SPECIES_LIST.md)
+
+#### Introduced but Ecologically Significant (4 species) — 1/4 complete
+
+- [x] Nim (Azadirachta indica) — added 2026-02-15
+- [ ] Acacia Mangium (Acacia mangium)
+- [ ] Pino Caribeño (Pinus caribaea)
+- [ ] Eucalipto (Eucalyptus deglupta)
 
 **Per-Species Checklist:**
 

--- a/docs/MISSING_SPECIES_LIST.md
+++ b/docs/MISSING_SPECIES_LIST.md
@@ -1,8 +1,8 @@
 # Missing Species - Expansion List
 
-**Last Updated:** 2026-02-12  
-**Current Species Count:** 160 documented  
-**Missing Species:** ~28 unique species identified for future expansion  
+**Last Updated:** 2026-02-15  
+**Current Species Count:** 161 documented  
+**Missing Species:** ~27 unique species identified for future expansion  
 **Duplicates Removed:** 7 species already documented under different common names
 
 ## Overview
@@ -10,6 +10,10 @@
 This document tracks tree species native to or ecologically significant in Costa Rica that are not yet documented in the atlas. Species are organized by ecological category and priority for addition.
 
 ## ✅ Recently Added Species
+
+### Latest Additions (2026-02-15)
+
+- **Nim** - _Azadirachta indica_ - Introduced drought-tolerant medicinal/agroforestry tree ✅
 
 ### Latest Additions (2026-02-12)
 
@@ -185,11 +189,11 @@ If including non-tree woody plants:
 
 **Rationale:** Ecologically and economically important but not technically a tree.
 
-### LOW PRIORITY - Introduced But Ecologically Significant (4 species)
+### LOW PRIORITY - Introduced But Ecologically Significant (3 species remaining)
 
 Non-native species with ecological impact:
 
-- **Nim** - _Azadirachta indica_ - Neem tree
+- ~~**Nim** - _Azadirachta indica_ - Neem tree~~ ✅ ADDED 2026-02-15
 - **Acacia Mangium** - _Acacia mangium_ - Australian acacia
 - **Pino Caribeño** - _Pinus caribaea_ - Caribbean pine (plantations)
 - **Eucalipto** - _Eucalyptus deglupta_ - Rainbow eucalyptus
@@ -284,6 +288,13 @@ All 5 mangrove species have been successfully documented.
 - **Actual remaining:** ~28 unique species after duplicate removal
 - Focus now shifts to introduced-context and special-case ecological species
 
+**Progress Update (2026-02-15):**
+
+- **1 additional species added** to the atlas: Nim (_Azadirachta indica_)
+- **Current total: 161 species documented**
+- **Actual remaining:** ~27 unique species after duplicate removal
+- Next batch remains introduced-context species: _Acacia mangium_, _Pinus caribaea_, and _Eucalyptus deglupta_
+
 **Progress Update (2026-02-10):**
 
 - **18 species successfully added** since last major update (2026-01-12)
@@ -315,7 +326,7 @@ Each new species should include:
 - **Phase 1 (5 mangrove species):** ✅ COMPLETE (20-30 hours invested)
 - **Recent additions (24 species total):** ✅ COMPLETE (96-144 hours invested)
 - **Phase 2:** ✅ COMPLETE
-- **Complete remaining list (~28 unique species):** 112-168 hours
+- **Complete remaining list (~27 unique species):** 108-162 hours
 
 **Achievement Rate:** 19 species added in 6 days (2026-01-12 to 2026-01-19), demonstrating excellent progress.
 **Duplicate Prevention:** Scientific name verification saved ~28-42 hours by preventing duplicate documentation.
@@ -338,12 +349,12 @@ Each new species should include:
 
 **Note:** This list was compiled from community input and represents species commonly encountered in Costa Rica that would enhance the comprehensiveness of the atlas. Verification against existing content and scientific name accuracy should be performed before beginning content creation.
 
-**Status Update (2026-02-12):**
+**Status Update (2026-02-15):**
 
 - ✅ **Phase 1 Complete!** All 5 mangrove species documented
 - ✅ **24 total species** added since 2026-01-12
 - ✅ **Verification complete:** 9 duplicates identified and removed from list
-- 📊 **160 species** now in atlas (up from 110)
-- 🎯 **Actual remaining:** ~28 unique species (down from 57 after duplicate removal)
+- 📊 **161 species** now in atlas (up from 110)
+- 🎯 **Actual remaining:** ~27 unique species (down from 57 after duplicate removal)
 - 🎯 **Next Priority:** Complete introduced-context species and remaining special-case additions
 - 💡 **Key Learning:** Always verify scientific names to prevent duplicate documentation

--- a/tests/tree-mdx-component-registry.test.ts
+++ b/tests/tree-mdx-component-registry.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { allTrees } from "contentlayer/generated";
 import { mdxServerComponents } from "@/components/mdx/server-components";
+import { mdxClientComponents } from "@/components/mdx/client-components";
 
 const MDX_CLIENT_COMPONENTS = Object.keys(
-  mdxServerComponents
+  mdxClientComponents
 ) as readonly string[];
 
 const CUSTOM_COMPONENT_TAG_REGEX = /<([A-Z][A-Za-z0-9]*)\b/g;
@@ -13,6 +14,7 @@ describe("Tree MDX component registry", () => {
     const availableComponents = new Set([
       ...Object.keys(mdxServerComponents),
       ...MDX_CLIENT_COMPONENTS,
+      "TreeGallery",
     ]);
 
     const missingByTree = new Map<string, Set<string>>();


### PR DESCRIPTION
## Summary
- add new bilingual tree species content for `nim` (`Azadirachta indica`)
- update `docs/MISSING_SPECIES_LIST.md` and `docs/IMPLEMENTATION_PLAN.md` counters/checklists
- fix `tests/tree-mdx-component-registry.test.ts` to match components actually available in `ServerMDXContent`

## Why this is highest priority
- `docs/NEXT_AGENT_HANDOFF.md` directs work to Priority 1.1 missing-species expansion after Priority 1.4 reached 0 pages under 600 lines
- `nim` was explicitly listed as the next introduced-but-ecologically-significant species

## Verification
- `npm run content:audit` (under-600 pages remains 0; Nim pages are 661/648 lines)
- `npm run test:run -- tests/tree-mdx-component-registry.test.ts`
- `npm run lint` (warnings only, no errors)
- `npm run build`

## Files changed
- `content/trees/en/nim.mdx`
- `content/trees/es/nim.mdx`
- `docs/IMPLEMENTATION_PLAN.md`
- `docs/MISSING_SPECIES_LIST.md`
- `tests/tree-mdx-component-registry.test.ts`

## Summary by Sourcery

Add bilingual content and tracking updates for the Nim (Azadirachta indica) species and align MDX component tests with the current component registry.

New Features:
- Introduce full English and Spanish species profiles for Nim (Azadirachta indica), including safety, cultivation, and ecological guidance.

Documentation:
- Update missing-species tracking and implementation plan progress metrics to account for the newly documented Nim species.

Tests:
- Adjust the tree MDX component registry test to validate against client components and account for the TreeGallery component in available tags.