### PR TITLE
fix: reduce unnecessary Vercel preview builds

### DIFF
--- a/scripts/vercel-ignore-build.sh
+++ b/scripts/vercel-ignore-build.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+echo "🧠 Evaluating whether this commit needs a Vercel build..."
+
+CURRENT_SHA="${VERCEL_GIT_COMMIT_SHA:-}"
+PREVIOUS_SHA="${VERCEL_GIT_PREVIOUS_SHA:-}"
+
+if [[ -z "$CURRENT_SHA" || -z "$PREVIOUS_SHA" ]]; then
+  echo "ℹ️ Missing Vercel git SHAs (first deploy or unavailable metadata)."
+  echo "➡️ Building to be safe."
+  exit 1
+fi
+
+if ! git cat-file -e "$CURRENT_SHA"^{commit} 2>/dev/null; then
+  echo "ℹ️ Current SHA not available in checkout."
+  echo "➡️ Building to be safe."
+  exit 1
+fi
+
+if ! git cat-file -e "$PREVIOUS_SHA"^{commit} 2>/dev/null; then
+  echo "ℹ️ Previous SHA not available in checkout."
+  echo "➡️ Building to be safe."
+  exit 1
+fi
+
+CHANGED_FILES="$(git diff --name-only "$PREVIOUS_SHA" "$CURRENT_SHA")"
+
+if [[ -z "$CHANGED_FILES" ]]; then
+  echo "ℹ️ No changed files detected between SHAs."
+  echo "➡️ Building to be safe."
+  exit 1
+fi
+
+echo "Changed files:"
+echo "$CHANGED_FILES"
+
+SHOULD_BUILD=false
+
+while IFS= read -r file; do
+  [[ -z "$file" ]] && continue
+
+  case "$file" in
+    src/*|content/*|public/*|messages/*|i18n/*|middleware.ts|next.config.ts|vercel.json|contentlayer.config.ts|package.json|package-lock.json|tsconfig.json|postcss.config.mjs|eslint.config.mjs|vitest.config.ts|vitest.setup.ts|prisma/*)
+      SHOULD_BUILD=true
+      break
+      ;;
+    *)
+      ;;
+  esac
+done <<< "$CHANGED_FILES"
+
+if [[ "$SHOULD_BUILD" == true ]]; then
+  echo "✅ App-impacting changes detected."
+  echo "➡️ Proceeding with build."
+  exit 1
+fi
+
+echo "⏭️ Only non-app-impacting changes detected (e.g., docs/meta)."
+echo "➡️ Skipping this preview build."
+exit 0

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "nextjs",
+  "ignoreCommand": "bash scripts/vercel-ignore-build.sh",
   "buildCommand": "npm run build",
   "installCommand": "npm install",
   "env": {


### PR DESCRIPTION
## Summary
- add Vercel ignored-build gate via `ignoreCommand`
- add `scripts/vercel-ignore-build.sh` to skip preview builds when only non-app files changed
- default to building when commit metadata is missing (fail-safe)

## Testing
- shell syntax check passed for `scripts/vercel-ignore-build.sh`
- local smoke test confirmed docs-only diff returns skip (exit 0)

## Summary by Sourcery

Configure Vercel preview deployments to skip builds for commits that do not affect application code while defaulting to build when commit metadata is unavailable.

Build:
- Add Vercel ignoreCommand configuration to gate preview builds based on a custom script.

Deployment:
- Introduce a vercel-ignore-build shell script that inspects changed files and skips non–app-impacting preview builds with safe fallbacks.