### PR TITLE
perf: enable edge caching by removing layout nonce dependency

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -80,6 +80,90 @@ const nextConfig: NextConfig = {
         },
       ],
     },
+    // Edge caching for static public pages
+    // These pages are pre-rendered at build and don't use per-request data.
+    // Middleware still applies fresh CSP headers on every request.
+    {
+      source: "/:locale(en|es)/trees",
+      headers: [
+        {
+          key: "Cache-Control",
+          value: "public, s-maxage=86400, stale-while-revalidate=604800",
+        },
+      ],
+    },
+    {
+      source: "/:locale(en|es)/glossary",
+      headers: [
+        {
+          key: "Cache-Control",
+          value: "public, s-maxage=86400, stale-while-revalidate=604800",
+        },
+      ],
+    },
+    {
+      source: "/:locale(en|es)/about",
+      headers: [
+        {
+          key: "Cache-Control",
+          value: "public, s-maxage=86400, stale-while-revalidate=604800",
+        },
+      ],
+    },
+    {
+      source: "/:locale(en|es)/conservation",
+      headers: [
+        {
+          key: "Cache-Control",
+          value: "public, s-maxage=86400, stale-while-revalidate=604800",
+        },
+      ],
+    },
+    {
+      source: "/:locale(en|es)/education",
+      headers: [
+        {
+          key: "Cache-Control",
+          value: "public, s-maxage=86400, stale-while-revalidate=604800",
+        },
+      ],
+    },
+    {
+      source: "/:locale(en|es)/safety",
+      headers: [
+        {
+          key: "Cache-Control",
+          value: "public, s-maxage=86400, stale-while-revalidate=604800",
+        },
+      ],
+    },
+    {
+      source: "/:locale(en|es)/seasonal",
+      headers: [
+        {
+          key: "Cache-Control",
+          value: "public, s-maxage=86400, stale-while-revalidate=604800",
+        },
+      ],
+    },
+    {
+      source: "/:locale(en|es)/map",
+      headers: [
+        {
+          key: "Cache-Control",
+          value: "public, s-maxage=86400, stale-while-revalidate=604800",
+        },
+      ],
+    },
+    {
+      source: "/:locale(en|es)/identify",
+      headers: [
+        {
+          key: "Cache-Control",
+          value: "public, s-maxage=86400, stale-while-revalidate=604800",
+        },
+      ],
+    },
   ],
 
   // Experimental optimizations

--- a/public/theme-init.js
+++ b/public/theme-init.js
@@ -1,0 +1,39 @@
+/**
+ * Theme initialization script - prevents flash of incorrect theme (FOUC).
+ *
+ * MUST load synchronously in <head> (no async/defer) so it runs before
+ * first paint. Reads the persisted theme from localStorage and applies
+ * the correct class/attribute to <html> immediately.
+ *
+ * This is an external file (not inline) so it works with CSP 'self'
+ * and is compatible with edge caching (no nonce required).
+ */
+(function () {
+  try {
+    var stored = localStorage.getItem("cr-tree-atlas");
+    var theme = "light";
+
+    if (stored) {
+      var parsed = JSON.parse(stored);
+      var savedTheme = (parsed.state && parsed.state.theme) || "system";
+
+      if (savedTheme === "system") {
+        theme = window.matchMedia("(prefers-color-scheme: dark)").matches
+          ? "dark"
+          : "light";
+      } else {
+        theme = savedTheme;
+      }
+    } else {
+      theme = window.matchMedia("(prefers-color-scheme: dark)").matches
+        ? "dark"
+        : "light";
+    }
+
+    document.documentElement.classList.add(theme);
+    document.documentElement.setAttribute("data-theme", theme);
+    document.documentElement.style.colorScheme = theme;
+  } catch (e) {
+    document.documentElement.classList.add("light");
+  }
+})();

--- a/src/app/[locale]/admin/contributions/page.tsx
+++ b/src/app/[locale]/admin/contributions/page.tsx
@@ -4,6 +4,8 @@ import { redirect as nextRedirect } from "next/navigation";
 import { authOptions } from "@/app/api/auth/[...nextauth]/route";
 import { ContributionsListClient } from "./ContributionsListClient";
 
+export const dynamic = "force-dynamic";
+
 export const metadata: Metadata = {
   title: "Review Contributions | Admin",
   description: "Review and manage community contributions",

--- a/src/app/[locale]/admin/images/page.tsx
+++ b/src/app/[locale]/admin/images/page.tsx
@@ -4,6 +4,8 @@ import type { Metadata } from "next";
 import { Link } from "@i18n/navigation";
 import ImageReviewClient from "./ImageReviewClient";
 
+export const dynamic = "force-dynamic";
+
 type Props = {
   params: Promise<{ locale: string }>;
 };

--- a/src/app/[locale]/admin/images/proposals/[id]/page.tsx
+++ b/src/app/[locale]/admin/images/proposals/[id]/page.tsx
@@ -3,6 +3,8 @@ import type { Metadata } from "next";
 import { Link } from "@i18n/navigation";
 import ProposalDetailClient from "./ProposalDetailClient";
 
+export const dynamic = "force-dynamic";
+
 type Props = {
   params: Promise<{ locale: string; id: string }>;
 };

--- a/src/app/[locale]/admin/images/proposals/page.tsx
+++ b/src/app/[locale]/admin/images/proposals/page.tsx
@@ -3,6 +3,8 @@ import type { Metadata } from "next";
 import { Link } from "@i18n/navigation";
 import ProposalsListClient from "./ProposalsListClient";
 
+export const dynamic = "force-dynamic";
+
 type Props = {
   params: Promise<{ locale: string }>;
 };

--- a/src/app/[locale]/admin/performance/page.tsx
+++ b/src/app/[locale]/admin/performance/page.tsx
@@ -3,6 +3,8 @@ import { setRequestLocale } from "next-intl/server";
 import { Link } from "@i18n/navigation";
 import PerformanceDashboardClient from "./PerformanceDashboardClient";
 
+export const dynamic = "force-dynamic";
+
 type Props = {
   params: Promise<{ locale: string }>;
 };

--- a/src/app/[locale]/admin/users/page.tsx
+++ b/src/app/[locale]/admin/users/page.tsx
@@ -14,6 +14,8 @@ import { authOptions } from "@/app/api/auth/[...nextauth]/route";
 import prisma from "@/lib/prisma";
 import { UserManagementClient } from "./UserManagementClient";
 
+export const dynamic = "force-dynamic";
+
 export const metadata = {
   title: "User Management | Admin",
   description: "Manage your account, security settings, and view audit logs",

--- a/src/app/[locale]/contribute/page.tsx
+++ b/src/app/[locale]/contribute/page.tsx
@@ -3,6 +3,8 @@ import { getTranslations } from "next-intl/server";
 import { ContributeClient } from "./ContributeClient";
 import { allTrees, type Tree } from "contentlayer/generated";
 
+export const dynamic = "force-dynamic";
+
 interface PageProps {
   params: Promise<{ locale: string }>;
 }

--- a/src/app/[locale]/contribute/photo/page.tsx
+++ b/src/app/[locale]/contribute/photo/page.tsx
@@ -3,6 +3,8 @@ import { allTrees } from "contentlayer/generated";
 import type { Metadata } from "next";
 import PhotoUploadClient from "./PhotoUploadClient";
 
+export const dynamic = "force-dynamic";
+
 type Props = {
   params: Promise<{ locale: string }>;
 };

--- a/src/app/[locale]/images/vote/page.tsx
+++ b/src/app/[locale]/images/vote/page.tsx
@@ -3,6 +3,8 @@ import { allTrees } from "contentlayer/generated";
 import type { Metadata } from "next";
 import VotingClient from "./VotingClient";
 
+export const dynamic = "force-dynamic";
+
 type Props = {
   params: Promise<{ locale: string }>;
 };

--- a/src/components/ImageLightbox.tsx
+++ b/src/components/ImageLightbox.tsx
@@ -1,0 +1,248 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { SafeImage } from "@/components/SafeImage";
+import { useScrollLock } from "@/hooks/useScrollLock";
+
+export interface LightboxImage {
+  src: string;
+  alt: string;
+  title?: string;
+  credit?: string;
+  license?: string;
+}
+
+interface ImageLightboxProps {
+  images: LightboxImage[];
+  initialIndex?: number;
+  onClose: () => void;
+}
+
+export function ImageLightbox({
+  images,
+  initialIndex = 0,
+  onClose,
+}: ImageLightboxProps) {
+  const [currentIndex, setCurrentIndex] = useState(initialIndex);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const currentImage = images[currentIndex];
+
+  const goToPrevious = useCallback(() => {
+    setIsLoading(true);
+    setCurrentIndex((prev) => (prev === 0 ? images.length - 1 : prev - 1));
+  }, [images.length]);
+
+  const goToNext = useCallback(() => {
+    setIsLoading(true);
+    setCurrentIndex((prev) => (prev === images.length - 1 ? 0 : prev + 1));
+  }, [images.length]);
+
+  // Lock scroll while lightbox is open
+  useScrollLock(true);
+
+  // Keyboard navigation
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      switch (e.key) {
+        case "Escape":
+          onClose();
+          break;
+        case "ArrowLeft":
+          goToPrevious();
+          break;
+        case "ArrowRight":
+          goToNext();
+          break;
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [onClose, goToPrevious, goToNext]);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/90 backdrop-blur-sm"
+      onClick={onClose}
+    >
+      {/* Close button */}
+      <button
+        onClick={onClose}
+        className="absolute top-4 right-4 z-10 p-2 text-white/80 hover:text-white transition-colors"
+        aria-label="Close lightbox"
+      >
+        <CloseIcon className="w-8 h-8" />
+      </button>
+
+      {/* Navigation arrows */}
+      {images.length > 1 && (
+        <>
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              goToPrevious();
+            }}
+            className="absolute left-4 top-1/2 -translate-y-1/2 z-10 p-3 rounded-full bg-white/10 text-white/80 hover:bg-white/20 hover:text-white transition-all"
+            aria-label="Previous image"
+          >
+            <ChevronLeftIcon className="w-6 h-6" />
+          </button>
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              goToNext();
+            }}
+            className="absolute right-4 top-1/2 -translate-y-1/2 z-10 p-3 rounded-full bg-white/10 text-white/80 hover:bg-white/20 hover:text-white transition-all"
+            aria-label="Next image"
+          >
+            <ChevronRightIcon className="w-6 h-6" />
+          </button>
+        </>
+      )}
+
+      {/* Image container */}
+      <div
+        className="relative max-w-[90vw] max-h-[85vh] flex flex-col items-center"
+        onClick={(e) => {
+          e.stopPropagation();
+        }}
+      >
+        {/* Loading spinner */}
+        {isLoading && (
+          <div className="absolute inset-0 flex items-center justify-center">
+            <div className="w-10 h-10 border-4 border-white/20 border-t-white rounded-full animate-spin" />
+          </div>
+        )}
+
+        {/* Image */}
+        <div className="relative max-w-full max-h-[75vh]">
+          <SafeImage
+            src={currentImage.src}
+            alt={currentImage.alt}
+            width={1200}
+            height={800}
+            className={`max-h-[75vh] w-auto object-contain transition-opacity duration-300 ${
+              isLoading ? "opacity-0" : "opacity-100"
+            }`}
+            onLoad={() => {
+              setIsLoading(false);
+            }}
+            quality={85}
+            priority
+            fallback="placeholder"
+          />
+        </div>
+
+        {/* Caption */}
+        <div className="mt-4 text-center text-white max-w-2xl px-4">
+          {currentImage.title && (
+            <h3 className="text-lg font-semibold mb-1">{currentImage.title}</h3>
+          )}
+          {currentImage.credit && (
+            <p className="text-sm text-white/70">
+              📷 {currentImage.credit}
+              {currentImage.license && (
+                <span className="ml-2 text-white/50">
+                  ({currentImage.license})
+                </span>
+              )}
+            </p>
+          )}
+        </div>
+
+        {/* Image counter */}
+        {images.length > 1 && (
+          <div className="mt-4 text-white/60 text-sm">
+            {currentIndex + 1} / {images.length}
+          </div>
+        )}
+
+        {/* Thumbnail strip for multiple images */}
+        {images.length > 1 && images.length <= 10 && (
+          <div className="mt-4 flex gap-2 overflow-x-auto max-w-full px-4 pb-2">
+            {images.map((image, index) => (
+              <button
+                key={index}
+                onClick={() => {
+                  setIsLoading(true);
+                  setCurrentIndex(index);
+                }}
+                className={`flex-shrink-0 w-16 h-16 rounded-lg overflow-hidden border-2 transition-all ${
+                  index === currentIndex
+                    ? "border-white scale-110"
+                    : "border-transparent opacity-60 hover:opacity-100"
+                }`}
+              >
+                <SafeImage
+                  src={image.src}
+                  alt={image.alt}
+                  width={64}
+                  height={64}
+                  className="w-full h-full object-cover"
+                  quality={60}
+                  fallback="placeholder"
+                />
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// Icon components
+function CloseIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
+      <path d="M18 6L6 18" />
+      <path d="M6 6l12 12" />
+    </svg>
+  );
+}
+
+function ChevronLeftIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
+      <path d="m15 18-6-6 6-6" />
+    </svg>
+  );
+}
+
+function ChevronRightIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
+      <path d="m9 18 6-6-6-6" />
+    </svg>
+  );
+}

--- a/src/components/TreeGallery.tsx
+++ b/src/components/TreeGallery.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState } from "react";
 import { SafeImage } from "@/components/SafeImage";
 import { BLUR_DATA_URL } from "@/lib/image";
-import { ResponsiveVirtualizedGrid } from "./ResponsiveVirtualizedGrid";
-import { useScrollLock } from "@/hooks/useScrollLock";
 import { ComponentErrorBoundary } from "./ComponentErrorBoundary";
+import { ImageLightbox } from "./ImageLightbox";
+import type { LightboxImage } from "./ImageLightbox";
 
 export interface GalleryImage {
   src: string;
@@ -15,187 +15,8 @@ export interface GalleryImage {
   license?: string;
 }
 
-interface ImageLightboxProps {
-  images: GalleryImage[];
-  initialIndex?: number;
-  onClose: () => void;
-}
-
-export function ImageLightbox({
-  images,
-  initialIndex = 0,
-  onClose,
-}: ImageLightboxProps) {
-  const [currentIndex, setCurrentIndex] = useState(initialIndex);
-  const [isLoading, setIsLoading] = useState(true);
-
-  const currentImage = images[currentIndex];
-
-  const goToPrevious = useCallback(() => {
-    setIsLoading(true);
-    setCurrentIndex((prev) => (prev === 0 ? images.length - 1 : prev - 1));
-  }, [images.length]);
-
-  const goToNext = useCallback(() => {
-    setIsLoading(true);
-    setCurrentIndex((prev) => (prev === images.length - 1 ? 0 : prev + 1));
-  }, [images.length]);
-
-  // Lock scroll while lightbox is open
-  useScrollLock(true);
-
-  // Keyboard navigation
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      switch (e.key) {
-        case "Escape":
-          onClose();
-          break;
-        case "ArrowLeft":
-          goToPrevious();
-          break;
-        case "ArrowRight":
-          goToNext();
-          break;
-      }
-    };
-
-    document.addEventListener("keydown", handleKeyDown);
-    return () => {
-      document.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [onClose, goToPrevious, goToNext]);
-
-  return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/90 backdrop-blur-sm"
-      onClick={onClose}
-    >
-      {/* Close button */}
-      <button
-        onClick={onClose}
-        className="absolute top-4 right-4 z-10 p-2 text-white/80 hover:text-white transition-colors"
-        aria-label="Close lightbox"
-      >
-        <CloseIcon className="w-8 h-8" />
-      </button>
-
-      {/* Navigation arrows */}
-      {images.length > 1 && (
-        <>
-          <button
-            onClick={(e) => {
-              e.stopPropagation();
-              goToPrevious();
-            }}
-            className="absolute left-4 top-1/2 -translate-y-1/2 z-10 p-3 rounded-full bg-white/10 text-white/80 hover:bg-white/20 hover:text-white transition-all"
-            aria-label="Previous image"
-          >
-            <ChevronLeftIcon className="w-6 h-6" />
-          </button>
-          <button
-            onClick={(e) => {
-              e.stopPropagation();
-              goToNext();
-            }}
-            className="absolute right-4 top-1/2 -translate-y-1/2 z-10 p-3 rounded-full bg-white/10 text-white/80 hover:bg-white/20 hover:text-white transition-all"
-            aria-label="Next image"
-          >
-            <ChevronRightIcon className="w-6 h-6" />
-          </button>
-        </>
-      )}
-
-      {/* Image container */}
-      <div
-        className="relative max-w-[90vw] max-h-[85vh] flex flex-col items-center"
-        onClick={(e) => {
-          e.stopPropagation();
-        }}
-      >
-        {/* Loading spinner */}
-        {isLoading && (
-          <div className="absolute inset-0 flex items-center justify-center">
-            <div className="w-10 h-10 border-4 border-white/20 border-t-white rounded-full animate-spin" />
-          </div>
-        )}
-
-        {/* Image */}
-        <div className="relative max-w-full max-h-[75vh]">
-          <SafeImage
-            src={currentImage.src}
-            alt={currentImage.alt}
-            width={1200}
-            height={800}
-            className={`max-h-[75vh] w-auto object-contain transition-opacity duration-300 ${
-              isLoading ? "opacity-0" : "opacity-100"
-            }`}
-            onLoad={() => {
-              setIsLoading(false);
-            }}
-            quality={85}
-            priority
-            fallback="placeholder"
-          />
-        </div>
-
-        {/* Caption */}
-        <div className="mt-4 text-center text-white max-w-2xl px-4">
-          {currentImage.title && (
-            <h3 className="text-lg font-semibold mb-1">{currentImage.title}</h3>
-          )}
-          {currentImage.credit && (
-            <p className="text-sm text-white/70">
-              📷 {currentImage.credit}
-              {currentImage.license && (
-                <span className="ml-2 text-white/50">
-                  ({currentImage.license})
-                </span>
-              )}
-            </p>
-          )}
-        </div>
-
-        {/* Image counter */}
-        {images.length > 1 && (
-          <div className="mt-4 text-white/60 text-sm">
-            {currentIndex + 1} / {images.length}
-          </div>
-        )}
-
-        {/* Thumbnail strip for multiple images */}
-        {images.length > 1 && images.length <= 10 && (
-          <div className="mt-4 flex gap-2 overflow-x-auto max-w-full px-4 pb-2">
-            {images.map((image, index) => (
-              <button
-                key={index}
-                onClick={() => {
-                  setIsLoading(true);
-                  setCurrentIndex(index);
-                }}
-                className={`flex-shrink-0 w-16 h-16 rounded-lg overflow-hidden border-2 transition-all ${
-                  index === currentIndex
-                    ? "border-white scale-110"
-                    : "border-transparent opacity-60 hover:opacity-100"
-                }`}
-              >
-                <SafeImage
-                  src={image.src}
-                  alt={image.alt}
-                  width={64}
-                  height={64}
-                  className="w-full h-full object-cover"
-                  quality={60}
-                  fallback="placeholder"
-                />
-              </button>
-            ))}
-          </div>
-        )}
-      </div>
-    </div>
-  );
-}
+// Re-export ImageLightbox for backward compatibility
+export { ImageLightbox };
 
 interface TreeGalleryProps {
   images: GalleryImage[];
@@ -214,9 +35,6 @@ export function TreeGallery({ images, title }: TreeGalleryProps) {
     setLightboxIndex(index);
     setLightboxOpen(true);
   };
-
-  // Use virtualization for large galleries (20+ images)
-  const useVirtualization = images.length >= 20;
 
   return (
     <ComponentErrorBoundary componentName="Tree Gallery">
@@ -278,10 +96,10 @@ export function TreeGallery({ images, title }: TreeGalleryProps) {
           </div>
         )}
 
-        {/* Lightbox */}
+        {/* Lightbox - only rendered when open (lazy JS execution) */}
         {lightboxOpen && (
           <ImageLightbox
-            images={images}
+            images={images as LightboxImage[]}
             initialIndex={lightboxIndex}
             onClose={() => {
               setLightboxOpen(false);
@@ -290,59 +108,6 @@ export function TreeGallery({ images, title }: TreeGalleryProps) {
         )}
       </div>
     </ComponentErrorBoundary>
-  );
-}
-
-// Icon components
-function CloseIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-    >
-      <path d="M18 6L6 18" />
-      <path d="M6 6l12 12" />
-    </svg>
-  );
-}
-
-function ChevronLeftIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-    >
-      <path d="m15 18-6-6 6-6" />
-    </svg>
-  );
-}
-
-function ChevronRightIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-    >
-      <path d="m9 18 6-6-6-6" />
-    </svg>
   );
 }
 

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -20,6 +20,7 @@ export { LanguageSwitcher } from "./LanguageSwitcher";
 // Tree display (used in tree pages and comparison)
 export { TreeTags } from "./TreeTags";
 export { TreeGallery } from "./TreeGallery";
+export { ImageLightbox } from "./ImageLightbox";
 export { TreeComparison } from "./TreeComparison";
 export { ConservationStatus } from "./ConservationStatus";
 export { SeasonalCalendar } from "./SeasonalCalendar";

--- a/src/components/mdx/server-components.tsx
+++ b/src/components/mdx/server-components.tsx
@@ -1912,17 +1912,30 @@ export function QuickDecisionFlow({
 
 // Compare In Tool Button
 interface CompareInToolButtonProps {
-  species: string[];
+  /** Accepts string[] from code or comma-separated string from MDX
+   *  (MDX security plugin strips JS expression attributes like arrays) */
+  species?: string[] | string;
   locale?: string;
   label?: string;
 }
 
 export function CompareInToolButton({
-  species,
+  species = [],
   locale = "en",
   label,
 }: CompareInToolButtonProps) {
-  const speciesParam = species.join(",");
+  // Handle both string (from MDX where array expressions are stripped) and array
+  const speciesList = Array.isArray(species)
+    ? species
+    : typeof species === "string"
+      ? species.split(",").map((s) => s.trim())
+      : [];
+
+  if (speciesList.length === 0) {
+    return null;
+  }
+
+  const speciesParam = speciesList.join(",");
   const href = `/${locale}/compare?species=${encodeURIComponent(speciesParam)}`;
   const buttonLabel =
     label ||


### PR DESCRIPTION
## 📋 Description

Enables Vercel edge caching for all 1465 static pages by removing the `headers()` call from the root layout that was forcing every page to be dynamically rendered on every request.

### Root Cause
The root layout called `headers()` from `next/headers` to read a CSP nonce for the inline theme script. In Next.js, any call to `headers()` opts the entire route tree into dynamic rendering, which meant:
- No static pages were ever cached at the Vercel CDN edge
- Every page visit triggered a full server render
- `generateStaticParams` was effectively useless

### Architecture Changes

**External theme script** — Replaced the inline `<script nonce={nonce} dangerouslySetInnerHTML={{__html: THEME_SCRIPT}}>` with an external `<script src="/theme-init.js" />`. The CSP `'self'` directive already allows scripts from the same origin, so no nonce is needed.

**Cache headers** — Fixed middleware cache headers from `no-cache, no-store, must-revalidate` to `public, s-maxage=86400, stale-while-revalidate=604800` for MDX content pages. Added matching headers in `next.config.ts` for 9 public routes.

**Auth page isolation** — Added `export const dynamic = 'force-dynamic'` to 9 auth-dependent pages (admin/*, contribute/*, images/vote) that require runtime session access and cannot be statically rendered.

**Component split** — Extracted `ImageLightbox` from `TreeGallery` into its own client component, reducing JS bundle for pages that only need the grid.

**Bug fix** — Fixed `CompareInToolButton` crash where `species.join()` failed because MDX security plugin strips array expressions. Now accepts `string | string[]` with null guard.

## 🎯 Related Issue

Performance optimization — edge caching strategy from docs/PERFORMANCE_OPTIMIZATION.md

## 🔄 Type of Change

- [x] ⚡ Performance improvement
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ♻️ Refactoring (no functional changes)

## ✅ Checklist

### General

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] The build (`npm run build`) succeeds

### For Code Changes

- [x] I have run `npm run lint` and fixed any issues (0 errors, 265 pre-existing warnings)
- [x] I have run `npm run format` to format my code

## 🧪 How Has This Been Tested?

- `npm run build` — 1465/1465 static pages generated successfully
- `npm run lint` — 0 errors
- Verified auth pages render as `ƒ (Dynamic)` and content pages as `● (SSG)` in build output

## 📝 Additional Notes

### Files Changed (17 files)
- **middleware.ts** — Cache-Control headers for MDX pages
- **next.config.ts** — Added cache headers for public routes  
- **public/theme-init.js** — NEW: External theme initialization script
- **src/app/[locale]/layout.tsx** — Removed headers() call, use external theme script
- **src/components/ImageLightbox.tsx** — NEW: Extracted lightbox client component
- **src/components/TreeGallery.tsx** — Simplified, delegates to ImageLightbox
- **src/components/mdx/server-components.tsx** — CompareInToolButton bug fix
- **9 page.tsx files** — Added `force-dynamic` to auth-dependent pages

### Expected Impact
- **Before**: 0 pages edge-cached (all dynamic due to layout `headers()` call)
- **After**: 1465 pages edge-cached with 24h TTL + 7d stale-while-revalidate
- Significant TTFB reduction expected for repeat visitors

## Summary by Sourcery

Enable edge caching and static generation for public pages by removing the layout nonce dependency and updating caching configuration.

New Features:
- Add an external theme initialization script served from /public/theme-init.js to replace the inline theme script.
- Introduce a standalone ImageLightbox client component and export it for reuse across the app.

Bug Fixes:
- Fix CompareInToolButton to handle both string and string[] species props, preventing crashes when MDX strips array expressions.

Enhancements:
- Refactor TreeGallery to delegate lightbox functionality to the new ImageLightbox component, reducing JS loaded on pages that only need the gallery grid.
- Clarify CSP handling in middleware and keep MDX-specific CSP separate for future policy flexibility.

Build:
- Configure Cache-Control headers in next.config.ts for key static public routes to leverage CDN edge caching.

Chores:
- Mark admin, contribute, and image voting pages as force-dynamic so auth-dependent pages continue to render with per-request data after enabling static generation for other routes.
- Relax middleware cache headers for MDX pages to allow edge caching while still issuing fresh CSP headers on every request.