### PR TITLE
fix: add force-dynamic to contribute/photo page to prevent prerender error

### DIFF
--- a/src/app/[locale]/contribute/photo/page.tsx
+++ b/src/app/[locale]/contribute/photo/page.tsx
@@ -3,6 +3,8 @@ import { allTrees } from "contentlayer/generated";
 import type { Metadata } from "next";
 import PhotoUploadClient from "./PhotoUploadClient";
 
+export const dynamic = "force-dynamic";
+
 type Props = {
   params: Promise<{ locale: string }>;
 };


### PR DESCRIPTION
## 📋 Description

The production build was failing because the `/en/contribute/photo` page was being statically prerendered during build. The `PhotoUploadClient` component uses `useSession()` from next-auth, which returns `undefined` during static generation (no session context), causing a `TypeError: Cannot destructure property 'data'`.

Added `export const dynamic = "force-dynamic"` to opt the page out of static generation, matching the pattern already used by all other auth-dependent pages.

## 🎯 Related Issue

Production build failure on Vercel.

## 🔄 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## ✅ Checklist

### General

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors
- [x] The build (`npm run build`) succeeds

### For Code Changes

- [x] I have run `npm run lint` and fixed any issues
- [x] I have run `npm run format` to format my code

## 📝 Additional Notes

This export was already documented as required in `docs/PERFORMANCE_OPTIMIZATION.md` (line 398) but was missing from the actual code. All other auth-dependent pages (`admin/contributions`, `admin/images`, `admin/users`, etc.) already have this export.

## Summary by Sourcery

Bug Fixes:
- Prevent production build failures by opting the /contribute/photo page out of static prerendering when using next-auth session data.