### PR TITLE
fix: resolve CSP blocking all inline scripts

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -134,12 +134,9 @@ export default async function LocaleLayout({ children, params }: Props) {
   const messages = await getMessages();
   const tNav = await getTranslations("nav");
 
-  // Nonce removed: the layout no longer calls headers(), making all child
-  // pages eligible for static generation and Vercel edge caching.
-  // Theme bootstrap is an inline script allowed via its SHA-256 hash in the
-  // CSP (see src/lib/security/csp.ts).  The CSP uses 'self' + explicit
-  // host allowlisting instead of 'strict-dynamic', so Next.js framework
-  // scripts load normally without nonce attributes.
+  // CSP uses 'unsafe-inline' for script-src (no nonce needed) to support
+  // Next.js RSC hydration scripts while keeping pages statically generated.
+  // The theme bootstrap runs as inline script — allowed by 'unsafe-inline'.
   // Analytics scripts use next/script with strategy="lazyOnload".
   // JSON-LD <script type="application/ld+json"> is a data block
   // (non-executable) and does not require a nonce in modern browsers.
@@ -150,8 +147,7 @@ export default async function LocaleLayout({ children, params }: Props) {
         {/*
           Theme bootstrap - MUST run synchronously before first paint to
           prevent flash of incorrect theme (FOUC).
-          No nonce needed: the script content is static and its SHA-256 hash
-          is whitelisted in the CSP, satisfying 'strict-dynamic'.
+          Allowed by 'unsafe-inline' in the CSP script-src directive.
           Security: THEME_SCRIPT is a compile-time constant — no user input.
         */}
         {/* eslint-disable-next-line react/no-danger */}

--- a/src/lib/security/csp.ts
+++ b/src/lib/security/csp.ts
@@ -23,19 +23,6 @@ const COMMON_IMG_SOURCES = [
 ] as const;
 
 /**
- * SHA-256 hash of the inline theme bootstrap script (THEME_SCRIPT from
- * src/lib/theme/theme-script.ts).  Used to whitelist the inline <script>
- * in the CSP without requiring a nonce — which in turn lets the layout avoid
- * calling headers() so pages can be statically generated and edge-cached.
- *
- * Recompute when THEME_SCRIPT changes:
- *   node -e "const { THEME_SCRIPT } = require('./src/lib/theme/theme-script'); \
- *     console.log('sha256-' + require('crypto').createHash('sha256').update(THEME_SCRIPT, 'utf8').digest('base64'));"
- */
-const THEME_SCRIPT_HASH =
-  "'sha256-0xv81yB5NADv8PB1GJ/KUCaSky5FyqNwJ9+UQq/FzwM='";
-
-/**
  * Generate a cryptographic nonce for CSP using Web Crypto API
  * Compatible with Edge Runtime
  *
@@ -88,27 +75,26 @@ export function generateNonce(): string {
 
 /**
  * Build Content Security Policy header value
- * Strict policy: NO unsafe-inline, NO unsafe-eval
  *
- * This is the most secure CSP used for pages without dynamic content rendering.
- * It does NOT include unsafe-eval, making it incompatible with:
- * - Google Tag Manager (use buildRelaxedCSP)
- * - MDX content rendering (use buildMDXCSP)
+ * Uses 'unsafe-inline' for script-src to support Next.js App Router inline
+ * hydration scripts (RSC payload). This is intentional: the layout does not
+ * call headers() so pages remain eligible for static generation / edge caching.
+ * Per CSP spec, 'unsafe-inline' is ignored when any nonce or hash source is
+ * present — so we intentionally omit both.
  *
- * @param nonce - Optional nonce for script-src directive
  * @returns CSP header value string
  */
-export function buildCSP(nonce?: string): string {
+export function buildCSP(): string {
   const isDev = process.env.NODE_ENV === "development";
 
   const directives = {
     "default-src": ["'self'"],
     "script-src": [
       "'self'",
-      // Hash for the inline theme bootstrap script (no nonce needed)
-      THEME_SCRIPT_HASH,
-      // Nonce for inline scripts
-      ...(nonce ? [`'nonce-${nonce}'`] : []),
+      // Allow inline scripts (required for Next.js RSC hydration payload).
+      // NOTE: 'unsafe-inline' is ignored by browsers when any nonce or
+      // hash source is present, so we intentionally omit both here.
+      "'unsafe-inline'",
       // Privacy-friendly analytics (no eval needed)
       "https://plausible.io",
       "https://scripts.simpleanalyticscdn.com",
@@ -189,16 +175,17 @@ export function buildCSP(nonce?: string): string {
  * @param nonce - Optional nonce for script-src directive
  * @returns CSP header value string (strict, no unsafe-eval)
  */
-export function buildMDXCSP(nonce?: string): string {
+export function buildMDXCSP(): string {
   const isDev = process.env.NODE_ENV === "development";
 
   const directives = {
     "default-src": ["'self'"],
     "script-src": [
       "'self'",
-      // Hash for the inline theme bootstrap script (no nonce needed)
-      THEME_SCRIPT_HASH,
-      ...(nonce ? [`'nonce-${nonce}'`] : []),
+      // Allow inline scripts (required for Next.js RSC hydration payload).
+      // NOTE: 'unsafe-inline' is ignored by browsers when any nonce or
+      // hash source is present, so we intentionally omit both here.
+      "'unsafe-inline'",
       // Privacy-friendly analytics
       "https://plausible.io",
       "https://scripts.simpleanalyticscdn.com",
@@ -265,19 +252,17 @@ export function buildMDXCSP(nonce?: string): string {
  *
  * Should only be used on routes like /marketing/* or specific landing pages.
  *
- * @param nonce - Optional nonce for script-src directive
  * @returns Relaxed CSP header value string
  */
-export function buildRelaxedCSP(nonce?: string): string {
+export function buildRelaxedCSP(): string {
   const isDev = process.env.NODE_ENV === "development";
 
   const directives = {
     "default-src": ["'self'"],
     "script-src": [
       "'self'",
-      // Hash for the inline theme bootstrap script (no nonce needed)
-      THEME_SCRIPT_HASH,
-      ...(nonce ? [`'nonce-${nonce}'`] : []),
+      // Allow inline scripts (required for Next.js RSC hydration payload).
+      "'unsafe-inline'",
       "https://www.googletagmanager.com",
       "https://www.google-analytics.com",
       // GTM requires unsafe-eval :(

--- a/src/lib/security/csp.ts
+++ b/src/lib/security/csp.ts
@@ -170,7 +170,6 @@ export function buildCSP(): string {
  * - Route-based policy selection in middleware
  * - Future flexibility if MDX pages need different permissions
  *
- * @param nonce - Optional nonce for script-src directive
  * @returns CSP header value string (strict, no unsafe-eval)
  */
 export function buildMDXCSP(): string {


### PR DESCRIPTION
## Problem

No pages were loading — the browser console showed CSP violations for every inline script:

```
Executing inline script violates the following Content Security Policy directive
'script-src 'self' 'sha256-...' 'nonce-...' https://...'
```

## Root Cause

The CSP had a **contradictory configuration**:

1. **Middleware** generated a nonce and added `'nonce-xxx'` + a SHA-256 hash to `script-src`
2. **Layout** deliberately did NOT consume the nonce (to keep pages statically generated)
3. Per CSP spec, when **any** nonce or hash source is present in `script-src`, browsers **ignore** `'unsafe-inline'`
4. Next.js App Router emits inline RSC hydration scripts without nonce attributes → all blocked
5. The `THEME_SCRIPT_HASH` was also stale (didn't match current script content)

## Fix

- Remove nonce generation from middleware (nothing consumed it)
- Remove stale `THEME_SCRIPT_HASH` constant from CSP module
- Replace nonce/hash sources with `'unsafe-inline'` in all three CSP builders (`buildCSP`, `buildMDXCSP`, `buildRelaxedCSP`)
- Remove `X-Nonce` response header (unused)
- Update layout comments to reflect new strategy

## Security Tradeoff

`'unsafe-inline'` is less restrictive than nonce-based CSP, but it's the standard approach for statically generated Next.js sites where the layout can't call `headers()`. URL-based allowlisting (`'self'` + explicit analytics domains) still protects against loading scripts from untrusted external sources.

## Files Changed

- `middleware.ts` — Removed nonce generation and `X-Nonce` header
- `src/lib/security/csp.ts` — Simplified `script-src` across all CSP builders
- `src/app/[locale]/layout.tsx` — Updated comments

## Testing

- `npm run build` passes successfully
- All pages should now load without CSP violations

## Summary by Sourcery

Relax the Content Security Policy to allow required inline scripts while simplifying CSP construction and removing unused nonce handling.

Bug Fixes:
- Resolve CSP blocking of inline Next.js inline hydration scripts by permitting inline execution in script-src.

Enhancements:
- Simplify CSP builders to a nonce-free, hash-free configuration using 'unsafe-inline' for script-src across standard, MDX, and relaxed policies.
- Remove unused theme script hash constant and nonce generation logic from the security module and middleware.
- Update layout documentation comments to describe the new CSP strategy and inline script handling.