### PR TITLE
fix: provide page-specific i18n namespaces for client components

### DIFF
--- a/docs/NEXT_AGENT_HANDOFF.md
+++ b/docs/NEXT_AGENT_HANDOFF.md
@@ -1,6 +1,6 @@
 # Next Agent Handoff
 
-Last updated: 2026-02-21
+Last updated: 2026-02-22
 
 ## Latest Run Summary
 

--- a/docs/NEXT_AGENT_HANDOFF.md
+++ b/docs/NEXT_AGENT_HANDOFF.md
@@ -1,31 +1,22 @@
 # Next Agent Handoff
 
-Last updated: 2026-02-22
+Last updated: 2026-02-21
 
 ## Latest Run Summary
 
-- **Branch**: `feature/lighthouse-performance-optimization` (PR #440 to main, open)
+- **Branch**: `fix/missing-client-translation-namespaces` (PR to main, pending)
 - **Tasks completed**:
-  1. **Lighthouse performance optimization (P2)**: Targeted the three key bottlenecks — JS bundle size, LCP (hero image), and client-side payload.
-     - Removed no-op `StoreProvider` "use client" boundary from root layout (dead client boundary on every page).
-     - Removed global `QueryProvider` from root layout — React Query (~40-60KB) was loaded on EVERY page but only used by one component (`BiodiversityInfo`) on tree detail pages. Made BiodiversityInfo self-contained with its own provider.
-     - Filtered `NextIntlClientProvider` messages to only ship client-needed namespaces (~7.5KB vs ~36KB): `nav`, `theme`, `language`, `safety`, `glossary`, `api`.
-     - Re-encoded hero AVIF images (were 399KB, larger than WebP 293KB). Now: desktop 155KB, tablet 155KB, mobile-lg 79KB, mobile 48KB (47-64% smaller).
-     - Fixed hero preload/picture format mismatch (was preloading WebP but serving AVIF first).
-     - Removed `priority` from header logo to avoid LCP contention with hero image.
-     - Moved SpeedInsights inside `<body>` for valid HTML.
-     - Deleted dead code: `StoreProvider.tsx`, cleaned provider exports.
+  1. **Fix missing client translation namespaces**: After the root layout was optimized to ship only global client namespaces (`nav`, `theme`, `language`, `safety`, `glossary`, `api`), three pages with client components using page-specific namespaces lost their translations.
+     - `contribute/photo/page.tsx` — wraps `PhotoUploadClient` with scoped `NextIntlClientProvider` supplying `contribute` namespace.
+     - `identify/page.tsx` — wraps `IdentifyClient` with scoped `NextIntlClientProvider` supplying `identify` namespace.
+     - `images/vote/page.tsx` — wraps `VotingClient` with scoped `NextIntlClientProvider` supplying `imageVoting` namespace.
+  2. **Full audit**: Confirmed all 13 `useTranslations` call sites are covered — 6 global namespaces in root layout, 3 page-scoped providers (fixed here), 4 server components using `useTranslations` server-side (no provider needed).
 - **Key files changed**:
-  - `src/app/[locale]/layout.tsx` — removed StoreProvider, QueryProvider, filtered messages, fixed SpeedInsights placement
-  - `src/app/[locale]/page.tsx` — fixed hero preload to AVIF format
-  - `src/components/Header.tsx` — removed priority from logo image
-  - `src/components/data/BiodiversityInfo.tsx` — self-contained QueryClientProvider
-  - `src/components/providers/StoreProvider.tsx` — deleted (no-op)
-  - `src/components/providers/index.ts` — cleaned exports
-  - `src/components/index.ts` — cleaned exports
-  - 6 AVIF hero images — re-encoded with proper compression
+  - `src/app/[locale]/contribute/photo/page.tsx` — scoped NextIntlClientProvider for `contribute`
+  - `src/app/[locale]/identify/page.tsx` — scoped NextIntlClientProvider for `identify`
+  - `src/app/[locale]/images/vote/page.tsx` — scoped NextIntlClientProvider for `imageVoting`
   - `docs/NEXT_AGENT_HANDOFF.md` — this file
-- **Verification**: Lint 0 errors (268 pre-existing warnings), build successful, 175 EN + 175 ES species confirmed.
+- **Verification**: Lint 0 errors (268 pre-existing warnings), build successful.
 
 ## Highest-Priority Remaining Work
 
@@ -62,7 +53,8 @@ Repository
 Mission
 - Performance (P2): JS bundle reduced (~70-90KB removed from every page), hero AVIF
   re-encoded (47-64% smaller), preload/picture mismatch fixed, logo priority contention
-  resolved. Lighthouse score improvement pending post-deploy measurement (baseline 48/100,
+  resolved. Missing page-scoped i18n namespaces fixed (contribute, identify, imageVoting).
+  Lighthouse score improvement pending post-deploy measurement (baseline 48/100,
   target 90/100). ~51 client components retain genuine client-side interactivity.
 - Species content: 175/175 (100%) — 175+ target achieved. Can continue expanding.
 - Next recommended tasks (pick one or more):

--- a/src/app/[locale]/contribute/photo/page.tsx
+++ b/src/app/[locale]/contribute/photo/page.tsx
@@ -1,6 +1,12 @@
-import { setRequestLocale, getTranslations } from "next-intl/server";
+import { NextIntlClientProvider } from "next-intl";
+import {
+  setRequestLocale,
+  getMessages,
+  getTranslations,
+} from "next-intl/server";
 import { allTrees } from "contentlayer/generated";
 import type { Metadata } from "next";
+import type { AbstractIntlMessages } from "next-intl";
 import PhotoUploadClient from "./PhotoUploadClient";
 
 export const dynamic = "force-dynamic";
@@ -41,5 +47,14 @@ export default async function ContributePhotoPage({ params }: Props) {
     }))
     .sort((a, b) => a.title.localeCompare(b.title));
 
-  return <PhotoUploadClient trees={trees} />;
+  // Provide contribute namespace to the client component.
+  const messages = await getMessages();
+  const castMessages = messages as Record<string, AbstractIntlMessages>;
+  const clientMessages = { contribute: castMessages.contribute };
+
+  return (
+    <NextIntlClientProvider messages={clientMessages}>
+      <PhotoUploadClient trees={trees} />
+    </NextIntlClientProvider>
+  );
 }

--- a/src/app/[locale]/identify/page.tsx
+++ b/src/app/[locale]/identify/page.tsx
@@ -1,6 +1,8 @@
-import { setRequestLocale } from "next-intl/server";
+import { NextIntlClientProvider } from "next-intl";
+import { setRequestLocale, getMessages } from "next-intl/server";
 import { SafeJsonLd } from "@/components/SafeJsonLd";
 import type { Metadata } from "next";
+import type { AbstractIntlMessages } from "next-intl";
 import IdentifyClient from "./IdentifyClient";
 
 interface IdentifyPageProps {
@@ -61,10 +63,15 @@ export default async function IdentifyPage({ params }: IdentifyPageProps) {
     },
   };
 
+  // Provide identify namespace to the client component.
+  const messages = await getMessages();
+  const castMessages = messages as Record<string, AbstractIntlMessages>;
+  const clientMessages = { identify: castMessages.identify };
+
   return (
-    <>
+    <NextIntlClientProvider messages={clientMessages}>
       <SafeJsonLd data={structuredData} />
       <IdentifyClient />
-    </>
+    </NextIntlClientProvider>
   );
 }

--- a/src/app/[locale]/images/vote/page.tsx
+++ b/src/app/[locale]/images/vote/page.tsx
@@ -1,6 +1,12 @@
-import { setRequestLocale, getTranslations } from "next-intl/server";
+import { NextIntlClientProvider } from "next-intl";
+import {
+  setRequestLocale,
+  getMessages,
+  getTranslations,
+} from "next-intl/server";
 import { allTrees } from "contentlayer/generated";
 import type { Metadata } from "next";
+import type { AbstractIntlMessages } from "next-intl";
 import VotingClient from "./VotingClient";
 
 type Props = {
@@ -30,6 +36,13 @@ export default async function ImageVotePage({ params }: Props) {
   const { locale } = await params;
   setRequestLocale(locale);
 
+  // Provide imageVoting namespace to the client component.
+  // The root layout only ships global namespaces; page-specific
+  // namespaces are provided here to avoid bloating all pages.
+  const messages = await getMessages();
+  const castMessages = messages as Record<string, AbstractIntlMessages>;
+  const clientMessages = { imageVoting: castMessages.imageVoting };
+
   // Get trees with images for voting
   const treesWithImages = allTrees
     .filter((t) => t.locale === locale && t.featuredImage)
@@ -44,5 +57,9 @@ export default async function ImageVotePage({ params }: Props) {
     }))
     .filter((t) => !t.hasPlaceholder); // Exclude placeholders from voting
 
-  return <VotingClient trees={treesWithImages} />;
+  return (
+    <NextIntlClientProvider messages={clientMessages}>
+      <VotingClient trees={treesWithImages} />
+    </NextIntlClientProvider>
+  );
 }


### PR DESCRIPTION
## Summary

After PR #440 optimized the root layout to only ship 6 global client namespaces (`nav`, `theme`, `language`, `safety`, `glossary`, `api`) — reducing the client-side translation payload from ~36KB to ~7.5KB — three pages with their own client components lost access to their page-specific namespaces.

## Changes

Each affected server page now wraps its client component with a scoped `NextIntlClientProvider` that supplies only the needed namespace:

| Page | Client Component | Namespace |
|------|-----------------|-----------|
| `contribute/photo/page.tsx` | `PhotoUploadClient` | `contribute` |
| `identify/page.tsx` | `IdentifyClient` | `identify` |
| `images/vote/page.tsx` | `VotingClient` | `imageVoting` |

## Audit Results

Full audit of all 13 `useTranslations` call sites confirmed complete coverage:
- **6 global namespaces** in root layout (unchanged)
- **3 page-scoped providers** (fixed in this PR)
- **4 server components** using `useTranslations` server-side (no client provider needed)

## Verification

- Lint: 0 errors (268 pre-existing warnings)
- Build: successful
- Both `en` and `es` locales have all 3 namespaces confirmed present

## Summary by Sourcery

Scope page-specific i18n namespaces to affected client components to restore missing translations without increasing global payload.

Bug Fixes:
- Restore page-specific client translations for contribute photo upload by providing the `contribute` namespace via a scoped NextIntlClientProvider.
- Restore page-specific client translations for the identify page by providing the `identify` namespace via a scoped NextIntlClientProvider.
- Restore page-specific client translations for the image voting page by providing the `imageVoting` namespace via a scoped NextIntlClientProvider.

Enhancements:
- Update handoff documentation to reflect the new branch, work completed, key files changed, and verification status, including the fixed page-scoped i18n namespaces.

Documentation:
- Refresh NEXT_AGENT_HANDOFF documentation with the latest run summary and mission notes related to i18n fixes.