### PR TITLE
fix: resolve admin 404 and broken JWT session verification

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -27,7 +27,8 @@ const STATIC_FILE_REGEX =
   /\.(js|css|woff2?|ttf|otf|eot|svg|png|jpg|jpeg|gif|webp|ico|map)$/;
 
 // Regex patterns for route matching - compiled once at module level for performance
-const ADMIN_ROUTE_REGEX = new RegExp(`^/(${localePattern})/admin/`);
+// Note: (/|$) matches both /en/admin (no trailing slash) and /en/admin/ or /en/admin/...
+const ADMIN_ROUTE_REGEX = new RegExp(`^/(${localePattern})/admin(/|$)`);
 const MARKETING_ROUTE_REGEX = new RegExp(`^/(${localePattern})/marketing/`);
 const TREE_DETAIL_ROUTE_REGEX = new RegExp(
   `^/(${localePattern})/trees/[^/]+/?$`

--- a/src/app/[locale]/admin/page.tsx
+++ b/src/app/[locale]/admin/page.tsx
@@ -1,0 +1,19 @@
+/**
+ * Admin Root Page
+ *
+ * Redirects to the admin images dashboard.
+ * Authentication is enforced by middleware before this page is reached.
+ */
+
+import { redirect } from "next/navigation";
+
+export const dynamic = "force-dynamic";
+
+export default async function AdminRootPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  redirect(`/${locale}/admin/images`);
+}

--- a/src/lib/auth/session.ts
+++ b/src/lib/auth/session.ts
@@ -2,15 +2,16 @@
  * NextAuth Session Helper for Edge Middleware
  *
  * Verifies JWT tokens in Edge runtime without database calls.
- * Uses jose library for JWT verification.
+ * Uses next-auth/jwt getToken which correctly handles NextAuth's JWE
+ * (JSON Web Encryption) token format used by default in next-auth v4.
+ *
+ * Note: The previous implementation used jose's jwtVerify (JWS only) which
+ * is incompatible with NextAuth's JWE-encrypted tokens, causing all session
+ * checks to silently fail and redirect users back to login.
  */
 
 import { NextRequest } from "next/server";
-import { jwtVerify } from "jose";
-import { logJWTVerificationError } from "./jwt-error-logger";
-
-const JWT_SECRET = process.env.NEXTAUTH_SECRET || "";
-const JWT_SECRET_KEY = new TextEncoder().encode(JWT_SECRET);
+import { getToken } from "next-auth/jwt";
 
 interface SessionUser {
   id: string;
@@ -21,39 +22,33 @@ interface SessionUser {
 export async function getSessionFromRequest(
   request: NextRequest
 ): Promise<SessionUser | null> {
+  const secret = process.env.NEXTAUTH_SECRET;
+
+  if (!secret) {
+    return null;
+  }
+
   try {
-    // NextAuth stores JWT in cookies
-    // Development uses next-auth.session-token
-    // Production uses __Secure-next-auth.session-token (with https)
-    const devToken = request.cookies.get("next-auth.session-token")?.value;
-    const prodToken = request.cookies.get(
-      "__Secure-next-auth.session-token"
-    )?.value;
-    const token = prodToken || devToken;
+    // getToken handles both dev (next-auth.session-token) and prod
+    // (__Secure-next-auth.session-token) cookies automatically, and correctly
+    // decrypts NextAuth's JWE-encrypted JWT tokens.
+    const token = await getToken({ req: request, secret });
 
-    if (!token || !JWT_SECRET) {
-      return null;
-    }
-
-    // Verify JWT
-    const { payload } = await jwtVerify(token, JWT_SECRET_KEY, {
-      algorithms: ["HS256"],
-    });
-
-    // Extract user from payload
-    if (payload && typeof payload === "object" && "id" in payload) {
+    if (
+      token &&
+      typeof token.id === "string" &&
+      typeof token.email === "string"
+    ) {
       return {
-        id: payload.id as string,
-        email: payload.email as string,
-        name: payload.name as string | undefined,
+        id: token.id,
+        email: token.email,
+        name: token.name ?? null,
       };
     }
 
     return null;
-  } catch (error) {
-    // Invalid or expired token - log for operational diagnostics
-    // Note: No sensitive data (token payload) is logged
-    logJWTVerificationError(error);
+  } catch {
+    // Token decryption/verification failed (invalid, expired, or tampered)
     return null;
   }
 }


### PR DESCRIPTION
## Problem

Two root causes behind `/en/admin` returning 404 and admin pages being inaccessible after login:

### 1. Missing admin index page (`/en/admin` → 404)
`src/app/[locale]/admin/` had no `page.tsx`. Navigating to `/en/admin` triggered the i18n router which found no page, returning 404. Also, the middleware regex `^/(en|es)/admin/` required a trailing slash, so `/en/admin` was never auth-protected either.

### 2. Broken JWT session verification (admin pages inaccessible after login)
`src/lib/auth/session.ts` used `jose`'s `jwtVerify` (JWS — JSON Web Signature) to verify NextAuth session tokens. However, **NextAuth v4 uses JWE (JSON Web Encryption) by default**, not JWS. This caused `jwtVerify` to silently throw on every token, be caught by the try/catch, and return `null` — meaning every authenticated admin request was treated as unauthenticated and redirected to login in a loop.

## Changes

### `src/app/[locale]/admin/page.tsx` *(new file)*
- Adds the missing admin root page
- Redirects `/{locale}/admin` → `/{locale}/admin/images`
- Middleware handles auth before this page is reached

### `middleware.ts`
- Changes `ADMIN_ROUTE_REGEX` from `^/(en|es)/admin/` to `^/(en|es)/admin(/|$)`
- Now correctly matches and protects `/en/admin` (no trailing slash) as well as all sub-paths

### `src/lib/auth/session.ts`
- Replaces `jwtVerify` from `jose` with `getToken` from `next-auth/jwt`
- `getToken` properly handles NextAuth's JWE-encrypted tokens in the Edge runtime
- Removes now-unused JWT_SECRET_KEY, jose import, and jwt-error-logger dependency

## Summary by Sourcery

Fix admin access by adding a root admin page, correcting admin route protection, and aligning JWT session verification with NextAuth's JWE tokens.

Bug Fixes:
- Add a locale-aware admin root page that redirects /{locale}/admin to /{locale}/admin/images to prevent 404s on the admin entry route.
- Update admin route matching in middleware to protect both /{locale}/admin and all admin subpaths without requiring a trailing slash.
- Replace custom jose-based JWT verification with next-auth/jwt getToken to correctly validate NextAuth JWE session tokens in the Edge runtime and avoid false unauthenticated redirects.