### PR TITLE
fix: Scientific accuracy audit + SEO/DX improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A bilingual (English/Spanish) open-source web application showcasing the magnifi
 ### Bilingual Content
 
 - Full English and Spanish support with locale-based routing
-- **160 tree species** with comprehensive bilingual profiles (320 documents)
+- **175 tree species** with comprehensive bilingual profiles (350 documents)
 - MDX content system for rich tree profiles with React components
 
 ### Education Tools

--- a/content/comparisons/en/cocobolo-vs-cristobal.mdx
+++ b/content/comparisons/en/cocobolo-vs-cristobal.mdx
@@ -3,7 +3,7 @@ title: "Cocobolo vs. Cristóbal: Premium Rosewood Distinction"
 locale: "en"
 slug: "cocobolo-vs-cristobal"
 species: ["cocobolo", "cristobal"]
-keyDifference: "Cocobolo is critically endangered small tree (15-25 m) with orange-red heartwood and CITES protection, while Cristóbal is near-threatened canopy tree (25-40 m) with purple heartwood and wider distribution—both valuable but fundamentally different conservation and size profiles."
+keyDifference: "Cocobolo is a globally Vulnerable (IUCN), severely depleted small tree (15-25 m) with orange-red heartwood and CITES protection, while Cristóbal is near-threatened canopy tree (25-40 m) with purple heartwood and wider distribution—both valuable but fundamentally different conservation and size profiles."
 description: "Compare Cocobolo and Cristóbal premium rosewood species in Costa Rica, understanding their critical differences in size, wood color, conservation status, and identification features."
 featuredImages:
   - "/images/trees/cocobolo.jpg"

--- a/content/comparisons/en/mango-vs-espavel.mdx
+++ b/content/comparisons/en/mango-vs-espavel.mdx
@@ -161,7 +161,7 @@ While both mango and espavel belong to the Anacardiaceae (cashew) family, they o
 - **Nut**: Kidney-shaped, 2-3 cm, attached at BASE of apple
 - Apple is edible but not commonly eaten
 - **Nut is edible** ONLY when properly roasted
-- Raw nuts contain urushiol (toxic!)
+- Raw nuts contain anacardic acid and cardol (caustic, skin-irritating compounds related to urushiol)
 - Important wildlife food source
 
 ### 4. Leaves
@@ -207,26 +207,31 @@ While both mango and espavel belong to the Anacardiaceae (cashew) family, they o
 
 ---
 
-## Urushiol Warning - Both Trees Have It!
+## Anacardiaceae Irritant Warning - Both Trees Have It!
 
-<Callout type="warning" title="Family Safety Concern: Urushiol">
-  Both trees are in the Anacardiaceae family and contain **urushiol** - the same
-  compound found in poison ivy. However, the risks differ significantly between
-  the two species.
+<Callout
+  type="warning"
+  title="Family Safety Concern: Skin-Irritating Compounds"
+>
+  Both trees are in the Anacardiaceae family and contain **irritant phenolic
+  compounds** — structurally related to urushiol (the compound in poison ivy).
+  Mango sap contains mangol and cardol; Espavel nuts and sap contain **anacardic
+  acid and cardol**. These compounds cause contact dermatitis similar to poison
+  ivy in sensitive individuals.
 </Callout>
 
-### Mango Urushiol Exposure
+### Mango Irritant Exposure
 
 - **Location:** Highest in peel and sap
 - **Fruit flesh:** Generally safe to eat
-- **Sap contact:** Can cause skin rash in sensitive people
+- **Sap contact:** Contains mangol and cardol; can cause skin rash in sensitive people
 - **"Mango mouth":** Rash from eating unpeeled fruit
 - **Risk level:** Moderate - most people tolerate mangoes
 
-### Espavel Urushiol Exposure
+### Espavel Irritant Exposure
 
-- **Raw nut shell:** Contains urushiol (like cashew)
-- **Sap/bark:** Contains irritating compounds
+- **Raw nut shell:** Contains anacardic acid and cardol (caustic, like raw cashew shell)
+- **Sap/bark:** Contains irritating phenolic compounds
 - **Roasting required:** Nuts must be roasted to destroy toxins
 - **Cashew apple:** Generally safe
 - **Risk level:** Moderate to high if handling raw nuts
@@ -420,7 +425,7 @@ While both mango and espavel belong to the Anacardiaceae (cashew) family, they o
 
 ## Conclusion
 
-While mango and espavel share membership in the Anacardiaceae family and both contain urushiol compounds, they are remarkably different trees occupying completely different niches:
+While mango and espavel share membership in the Anacardiaceae family and both contain irritant phenolic compounds (structurally related to urushiol), they are remarkably different trees occupying completely different niches:
 
 **Choose Mango if you're looking at:**
 

--- a/content/comparisons/es/cocobolo-vs-cristobal.mdx
+++ b/content/comparisons/es/cocobolo-vs-cristobal.mdx
@@ -3,7 +3,7 @@ title: "Cocobolo vs. Cristóbal: Distinción entre Maderas Preciosas"
 locale: "es"
 slug: "cocobolo-vs-cristobal"
 species: ["cocobolo", "cristobal"]
-keyDifference: "El Cocobolo es un árbol pequeño críticamente amenazado (15-25 m) con duramen rojo-naranja y protección CITES, mientras que el Cristóbal es un árbol de dosel casi amenazado (25-40 m) con duramen púrpura y distribución más amplia—ambos valiosos pero con perfiles fundamentalmente diferentes de conservación y tamaño."
+keyDifference: "El Cocobolo es un árbol pequeño globalmente Vulnerable (UICN) y severamente diezmado (15-25 m) con duramen rojo-naranja y protección CITES, mientras que el Cristóbal es un árbol de dosel casi amenazado (25-40 m) con duramen púrpura y distribución más amplia—ambos valiosos pero con perfiles fundamentalmente diferentes de conservación y tamaño."
 description: "Compare las especies de palo de rosa premium Cocobolo y Cristóbal en Costa Rica, comprendiendo sus diferencias críticas en tamaño, color de madera, estado de conservación y características de identificación."
 featuredImages:
   - "/images/trees/cocobolo.jpg"

--- a/content/comparisons/es/mango-vs-espavel.mdx
+++ b/content/comparisons/es/mango-vs-espavel.mdx
@@ -162,7 +162,7 @@ Aunque tanto el mango como el espavel pertenecen a la familia Anacardiaceae (mar
 - **Nuez**: En forma de riñón, 2-3 cm, adherida en la BASE de la manzana
 - Manzana es comestible pero no comúnmente consumida
 - **Nuez es comestible** SOLO cuando está debidamente tostada
-- ¡Nueces crudas contienen urushiol (tóxico)!
+- ¡Nueces crudas contienen ácido anacárdico y cardol (compuestos cáusticos e irritantes de la piel, relacionados con el urushiol)!
 - Fuente importante de alimento para fauna silvestre
 
 ### 4. Hojas
@@ -208,26 +208,32 @@ Aunque tanto el mango como el espavel pertenecen a la familia Anacardiaceae (mar
 
 ---
 
-## Advertencia de Urushiol - ¡Ambos Árboles lo Tienen!
+## Advertencia de Irritantes de Anacardiaceae - ¡Ambos Árboles los Tienen!
 
-<Callout type="warning" title="Preocupación de Seguridad Familiar: Urushiol">
-  Ambos árboles están en la familia Anacardiaceae y contienen **urushiol** - el
-  mismo compuesto encontrado en la hiedra venenosa. Sin embargo, los riesgos
-  difieren significativamente entre las dos especies.
+<Callout
+  type="warning"
+  title="Preocupación de Seguridad Familiar: Compuestos Irritantes de la Piel"
+>
+  Ambos árboles están en la familia Anacardiaceae y contienen **compuestos
+  fenólicos irritantes** — estructuralmente relacionados con el urushiol (el
+  compuesto de la hiedra venenosa). La savia del mango contiene mangol y cardol;
+  las nueces y savia del espavel contienen **ácido anacárdico y cardol**. Estos
+  compuestos causan dermatitis de contacto similar a la hiedra venenosa en
+  personas sensibles.
 </Callout>
 
-### Exposición al Urushiol del Mango
+### Exposición a Irritantes del Mango
 
 - **Ubicación:** Más alto en cáscara y savia
 - **Carne del fruto:** Generalmente segura para comer
-- **Contacto con savia:** Puede causar sarpullido en piel en personas sensibles
+- **Contacto con savia:** Contiene mangol y cardol; puede causar sarpullido en piel en personas sensibles
 - **"Boca de mango":** Sarpullido por comer fruta sin pelar
 - **Nivel de riesgo:** Moderado - la mayoría de personas toleran los mangos
 
-### Exposición al Urushiol del Espavel
+### Exposición a Irritantes del Espavel
 
-- **Cáscara de nuez cruda:** Contiene urushiol (como el marañón)
-- **Savia/corteza:** Contiene compuestos irritantes
+- **Cáscara de nuez cruda:** Contiene ácido anacárdico y cardol (cáusticos, como cáscara de marañón crudo)
+- **Savia/corteza:** Contiene compuestos fenólicos irritantes
 - **Tostado requerido:** Las nueces deben tostarse para destruir toxinas
 - **Manzana de marañón:** Generalmente segura
 - **Nivel de riesgo:** Moderado a alto si se manipulan nueces crudas
@@ -421,7 +427,7 @@ Aunque tanto el mango como el espavel pertenecen a la familia Anacardiaceae (mar
 
 ## Conclusión
 
-Aunque el mango y el espavel comparten membresía en la familia Anacardiaceae y ambos contienen compuestos de urushiol, son árboles notablemente diferentes que ocupan nichos completamente diferentes:
+Aunque el mango y el espavel comparten membresía en la familia Anacardiaceae y ambos contienen compuestos fenólicos irritantes (estructuralmente relacionados con el urushiol), son árboles notablemente diferentes que ocupan nichos completamente diferentes:
 
 **Elija Mango si está mirando:**
 

--- a/content/glossary/en/cauliflory.mdx
+++ b/content/glossary/en/cauliflory.mdx
@@ -7,7 +7,7 @@ technicalDefinition: "A botanical phenomenon in which flowers are borne directly
 category: "reproduction"
 pronunciation: "kaw-lih-FLOR-ee"
 etymology: "From Latin 'caulis' (stem, stalk) + 'flos' (flower), meaning flowers borne on the stem."
-exampleSpecies: ["cacao", "guapinol", "ira-rosa"]
+exampleSpecies: ["cacao", "jicaro", "ira-rosa"]
 relatedTerms: ["pollination", "inflorescence", "stamen", "pistil"]
 publishedAt: "2026-02-20"
 ---

--- a/content/glossary/en/mycorrhiza.mdx
+++ b/content/glossary/en/mycorrhiza.mdx
@@ -7,7 +7,7 @@ technicalDefinition: "A mutualistic symbiosis between plant roots and fungi in w
 category: "ecology"
 pronunciation: "my-koh-RY-zuh"
 etymology: "From Greek 'mykes' (fungus) + 'rhiza' (root), coined by German botanist Albert Bernhard Frank in 1885."
-exampleSpecies: ["pino", "roble", "almendro"]
+exampleSpecies: ["pino-caribeno", "roble-encino", "almendro"]
 relatedTerms: ["symbiosis", "nitrogen-fixation", "fungi", "root-system"]
 publishedAt: "2026-01-11"
 ---

--- a/content/glossary/es/cauliflory.mdx
+++ b/content/glossary/es/cauliflory.mdx
@@ -7,7 +7,7 @@ technicalDefinition: "Fenómeno por el cual las flores se producen directamente 
 category: "reproduction"
 pronunciation: "cau-li-FLO-ria"
 etymology: "Del latín 'caulis' (tallo, tronco) + 'flos/floris' (flor), significando flores que nacen del tallo."
-exampleSpecies: ["cacao", "jicaro", "guapinol"]
+exampleSpecies: ["cacao", "jicaro", "ira-rosa"]
 relatedTerms: ["pollination", "inflorescence", "entomophily", "understory"]
 publishedAt: "2026-02-20"
 ---
@@ -40,9 +40,9 @@ El ejemplo clásico — las mazorcas de cacao crecen directamente del tronco y l
 
 Produce frutos grandes y esféricos directamente en las ramas principales — los cascarones se usan como recipientes artesanales.
 
-### Guapinol (_Hymenaea courbaril_)
+### Ira Rosa (_Brownea macrophylla_)
 
-Flores que aparecen en las ramas gruesas, produciendo las vainas duras con pulpa aromática.
+Espectaculares racimos de flores rojas brotan del tronco y ramas viejas, atrayendo colibríes.
 
 ## Caulifloria vs. Ramifloria
 

--- a/content/glossary/es/mycorrhiza.mdx
+++ b/content/glossary/es/mycorrhiza.mdx
@@ -7,7 +7,7 @@ technicalDefinition: "Una simbiosis mutualista entre raíces de plantas y hongos
 category: "ecology"
 pronunciation: "mi-co-RRI-za"
 etymology: "Del griego 'mykes' (hongo) + 'rhiza' (raíz), acuñado por el botánico alemán Albert Bernhard Frank en 1885."
-exampleSpecies: ["pino", "roble", "almendro"]
+exampleSpecies: ["pino-caribeno", "roble-encino", "almendro"]
 relatedTerms: ["symbiosis", "nitrogen-fixation", "fungi", "root-system"]
 publishedAt: "2026-01-11"
 ---

--- a/content/trees/en/cocobolo.mdx
+++ b/content/trees/en/cocobolo.mdx
@@ -4,9 +4,9 @@ scientificName: "Dalbergia retusa"
 family: "Fabaceae"
 locale: "en"
 slug: "cocobolo"
-description: "The Cocobolo is one of the world's most valuable and beautiful hardwoods, a stunning rosewood species with spectacular orange, red, and black grain patterns that has been prized by craftsmen for centuries—and is now critically endangered from overexploitation."
+description: "The Cocobolo is one of the world's most valuable and beautiful hardwoods, a stunning rosewood species with spectacular orange, red, and black grain patterns that has been prized by craftsmen for centuries—and is now globally Vulnerable (IUCN) and severely depleted in Costa Rica from overexploitation."
 nativeRegion: "Mexico to Panama"
-conservationStatus: "CR"
+conservationStatus: "VU"
 maxHeight: "15-25 meters (50-80 feet)"
 uses:
   - "Premium woodworking"
@@ -22,7 +22,7 @@ tags:
   - "endangered"
   - "dry-forest"
   - "slow-growing"
-  - "critically-endangered"
+  - "vulnerable"
 distribution:
   - "guanacaste"
   - "puntarenas"
@@ -89,9 +89,9 @@ commonProblems:
   species in crisis. Its stunning wood, with swirling patterns of orange, red,
   yellow, and black, has commanded prices of **$100-300 per board foot** and has
   been sought by craftsmen for centuries. This demand has driven the species to
-  **Critically Endangered status** with heavy logging continuing. CITES
-  protection now regulates international trade, but enforcement remains
-  challenging.
+  **Vulnerable status globally (IUCN)** with severe national-level depletion in
+  Costa Rica and heavy logging continuing. CITES protection now regulates
+  international trade, but enforcement remains challenging.
 </Callout>
 
 <TwoColumn>
@@ -104,7 +104,10 @@ commonProblems:
     { label: "Family", value: "Fabaceae (Legume Family)" },
     { label: "Max Height", value: "15-25 m (50-80 ft)" },
     { label: "Wood Density", value: "1.0-1.2 g/cm³ (sinks in water)" },
-    { label: "Conservation", value: "Critically Endangered (IUCN)" },
+    {
+      label: "Conservation",
+      value: "Vulnerable (IUCN); severely depleted in CR",
+    },
     { label: "Trade", value: "CITES Appendix II" },
   ]}
 />

--- a/content/trees/en/guayacan-real.mdx
+++ b/content/trees/en/guayacan-real.mdx
@@ -17,7 +17,7 @@ uses:
   - "Conservation plantings"
 tags:
   - "native"
-  - "deciduous"
+  - "semi-evergreen"
   - "flowering"
   - "timber"
   - "medicinal"
@@ -27,7 +27,7 @@ tags:
 distribution:
   - "guanacaste"
   - "puntarenas"
-elevation: "0-600m"
+elevation: "0-300m"
 floweringSeason:
   - "march"
   - "april"
@@ -511,7 +511,7 @@ The Guayacán Real is a small to medium-sized evergreen tree with a short, often
     <DataTable
       headers={["Species", "Key Difference"]}
       rows={[
-        ["_Guaiacum officinale_", "More leaflet pairs (8-14), larger flowers"],
+        ["_Guaiacum officinale_", "More leaflet pairs (4-7), larger flowers"],
         ["_Lonchocarpus_ species", "Different leaf arrangement, different flowers"],
         ["Other dry forest trees", "Lack compound leaves with specific arrangement"],
       ]}

--- a/content/trees/en/magnolia.mdx
+++ b/content/trees/en/magnolia.mdx
@@ -61,10 +61,10 @@ safetyNotes: "SAFE for landscapes, gardens, and public spaces. The tree itself p
   The **Magnolia poasana**, known locally as Candelilla, is one of Costa Rica's
   most beautiful highland trees. Named after **Poás Volcano**, this species
   belongs to one of the most ancient flowering plant families on Earth.
-  Magnolias appeared over 95 million years ago, before bees evolved, and were
-  pollinated by beetles. Today, this **Near Threatened** species is restricted
-  to the cloud forests of Costa Rica's volcanic ranges, a living link to the
-  deep past.
+  Magnolias appeared over 95 million years ago, before the diversification of
+  modern bee lineages, and were pollinated by beetles. Today, this **Near
+  Threatened** species is restricted to the cloud forests of Costa Rica's
+  volcanic ranges, a living link to the deep past.
 </Callout>
 
 <TwoColumn>
@@ -105,7 +105,7 @@ safetyNotes: "SAFE for landscapes, gardens, and public spaces. The tree itself p
 
 - **Origin**: Appeared in the Early Cretaceous (95+ million years ago)
 - **Dinosaur contemporaries**: Flourished when dinosaurs roamed
-- **Pre-bee pollination**: Evolved before bees—pollinated by beetles
+- **Pre-bee pollination**: Evolved before the diversification of modern bees—pollinated by beetles
 - **Primitive features**: Spiral flower parts, undifferentiated tepals
 - **Living fossils**: Little changed over tens of millions of years
 
@@ -442,8 +442,12 @@ This ancient partnership continues in Costa Rica's cloud forests today.
 <DataTable
   headers={["Animal", "Role", "Notes"]}
   rows={[
-    ["Quetzals", "Primary disperser", "Attracted to red arils"],
-    ["Mountain Robins", "Disperser", "Common cloud forest bird"],
+    ["Quetzals", "Occasional disperser", "Attracted to red arils"],
+    [
+      "Mountain Robins",
+      "Primary disperser",
+      "Common cloud forest bird; most consistent frugivore",
+    ],
     ["Bell Birds", "Disperser", "Important frugivore"],
     ["Small mammals", "Ground disperser", "May cache seeds"],
   ]}

--- a/content/trees/en/mangle-rojo.mdx
+++ b/content/trees/en/mangle-rojo.mdx
@@ -240,11 +240,11 @@ The prop roots are the tree's most distinctive feature:
   <PropertyCard
     icon="💧"
     label="Adaptation"
-    value="Salt-excreting glands on underside"
+    value="Waxy cuticle; salt excluded at roots"
   />
 </PropertiesGrid>
 
-Leaves are **thick and succulent**, adapted to conserve water in saline environments. The waxy cuticle reduces water loss. Small salt-excreting glands on the leaf underside help the tree manage salt intake.
+Leaves are **thick and succulent**, adapted to conserve water in saline environments. The waxy cuticle reduces water loss. Unlike Black Mangrove (_Avicennia germinans_), which has salt-excreting glands on its leaves, Red Mangrove manages salinity primarily through **ultrafiltration at the roots**, excluding up to 97% of salt before it enters the xylem.
 
 ### Flowers
 
@@ -420,10 +420,10 @@ Red Mangrove forests support exceptional biodiversity:
 
 Red Mangrove employs multiple strategies to cope with high salinity:
 
-1. **Salt exclusion**: Roots filter out up to 90% of salt from seawater
-2. **Salt excretion**: Specialized glands on leaves excrete excess salt
-3. **Salt accumulation**: Old leaves accumulate salt, then drop (deciduous in salt, not temperature)
-4. **Osmotic adjustment**: High internal solute concentrations balance external salinity
+1. **Salt exclusion (primary mechanism)**: Root ultrafiltration membranes exclude up to 97% of salt from seawater — this is the defining adaptation of _Rhizophora_ and distinguishes it from _Avicennia_ (which uses leaf salt glands instead)
+2. **Salt accumulation**: Old leaves accumulate residual salt that passes the root filter, then are shed — functioning as a secondary salt removal pathway
+3. **Osmotic adjustment**: High internal solute concentrations balance external salinity
+4. **Waxy cuticle**: Reduces water loss and prevents salt spray absorption through leaf surfaces
 
 </AccordionItem>
 

--- a/content/trees/en/nim.mdx
+++ b/content/trees/en/nim.mdx
@@ -256,7 +256,8 @@ highlands.
 ### Establishment and Monitoring Considerations
 
 Neem is not currently documented as a top-tier invasive threat in Costa Rica at
-a national scale, but local monitoring is still advisable where disturbed,
+a national scale, but it is listed in the **Global Invasive Species Database (GISD)**
+as an invasive species in various tropical regions. Local monitoring is still advisable where disturbed,
 open habitats surround native dry-forest fragments.
 
 ---

--- a/content/trees/en/pejibaye.mdx
+++ b/content/trees/en/pejibaye.mdx
@@ -287,8 +287,8 @@ Pejibaye is a clump-forming palm that produces multiple stems from the base. Its
   Pejibaye season (April-September, peaking May-July) is eagerly anticipated in
   Costa Rica. Street vendors sell boiled pejibaye by the bag, often with
   mayonnaise for dipping—a beloved local tradition. The fruits must be cooked
-  before eating as they contain calcium oxalate crystals that irritate the
-  throat when raw.
+  before eating as they contain trypsin inhibitors and calcium oxalate crystals
+  that cause throat irritation and digestive distress when raw.
 </Callout>
 
 <TwoColumn>
@@ -464,10 +464,10 @@ Pejibaye is a clump-forming palm that produces multiple stems from the base. Its
       "Nocturnal pollinator/disperser",
     ],
     [
-      "Rhinoceros Beetle",
+      "Palm Flower Weevils",
       "Primary pollinator",
       "Jan-May",
-      "Essential for fruit set",
+      "Essential for fruit set (_Phyllotrox_, _Andranthobius_ spp.)",
     ],
     [
       "White-faced Capuchin",
@@ -642,10 +642,10 @@ avoid splitting.
 </AccordionItem>
 <AccordionItem title="🍳 Can't Eat It Raw">
 
-Raw pejibaye contains calcium oxalate crystals that cause intense throat
-irritation. These compounds are destroyed by cooking, which is why the fruits
-are always boiled before eating. The cooking time (30-60 minutes) also makes
-the starchy flesh digestible and brings out the distinctive chestnut-like
+Raw pejibaye contains trypsin inhibitors and calcium oxalate crystals that cause intense throat
+irritation and block protein digestion. Cooking destroys the trypsin inhibitors, gelatinizes the starch
+(making the flesh digestible), and reduces the oxalate crystals, which is why the fruits
+are always boiled before eating. The cooking time (30-60 minutes) also brings out the distinctive chestnut-like
 flavor.
 
 </AccordionItem>

--- a/content/trees/en/yellow-oleander.mdx
+++ b/content/trees/en/yellow-oleander.mdx
@@ -13,7 +13,7 @@ uses:
   - "Traditional medicine (dangerous)"
   - "Hedge plant"
 tags:
-  - "introduced"
+  - "native"
   - "evergreen"
   - "flowering"
   - "ornamental"

--- a/content/trees/es/cocobolo.mdx
+++ b/content/trees/es/cocobolo.mdx
@@ -4,9 +4,9 @@ scientificName: "Dalbergia retusa"
 family: "Fabaceae"
 locale: "es"
 slug: "cocobolo"
-description: "El Cocobolo es una de las maderas duras más valiosas y hermosas del mundo, una espectacular especie de palisandro con patrones de grano naranja, rojo y negro que ha sido apreciada por artesanos durante siglos—y ahora está en peligro crítico por sobreexplotación."
+description: "El Cocobolo es una de las maderas duras más valiosas y hermosas del mundo, una espectacular especie de palisandro con patrones de grano naranja, rojo y negro que ha sido apreciada por artesanos durante siglos—y ahora está Vulnerable globalmente (UICN) y severamente diezmada en Costa Rica por sobreexplotación."
 nativeRegion: "México a Panamá"
-conservationStatus: "CR"
+conservationStatus: "VU"
 maxHeight: "15-25 metros"
 uses:
   - "Ebanistería premium"
@@ -22,7 +22,7 @@ tags:
   - "endangered"
   - "dry-forest"
   - "slow-growing"
-  - "critically-endangered"
+  - "vulnerable"
 distribution:
   - "guanacaste"
   - "puntarenas"
@@ -89,9 +89,10 @@ commonProblems:
   centroamericanos—y una especie en crisis. Su impresionante madera, con
   patrones arremolinados de naranja, rojo, amarillo y negro, ha alcanzado
   precios de **$100-300 por pie tablar** y ha sido buscada por artesanos durante
-  siglos. Esta demanda ha llevado a la especie al **estado En Peligro Crítico**
-  con tala intensa que continúa. La protección CITES ahora regula el comercio
-  internacional, pero la aplicación sigue siendo desafiante.
+  siglos. Esta demanda ha llevado a la especie al estado **Vulnerable a nivel
+  global (UICN)** con severa disminución en Costa Rica y tala intensa que
+  continúa. La protección CITES ahora regula el comercio internacional, pero la
+  aplicación sigue siendo desafiante.
 </Callout>
 
 <TwoColumn>
@@ -104,7 +105,10 @@ commonProblems:
     { label: "Familia", value: "Fabaceae (Familia de las Leguminosas)" },
     { label: "Altura Máxima", value: "15-25 m" },
     { label: "Densidad de la Madera", value: "1.0-1.2 g/cm³ (se hunde)" },
-    { label: "Conservación", value: "En Peligro Crítico (UICN)" },
+    {
+      label: "Conservación",
+      value: "Vulnerable (UICN); severamente diezmado en CR",
+    },
     { label: "Comercio", value: "CITES Apéndice II" },
   ]}
 />
@@ -404,12 +408,13 @@ El Cocobolo es nativo de los bosques secos del Pacífico de Costa Rica, desde Gu
 ### Una Especie en Crisis
 
 <Callout type="warning" title="Estado UICN y CITES">
-  **Lista Roja UICN**: En Peligro Crítico (población decreciente) **CITES**:
-  Apéndice II (todas las especies de _Dalbergia_) Desde 2017, TODAS las especies
-  de _Dalbergia_ han sido incluidas en el Apéndice II de CITES, lo que significa
-  que el comercio internacional requiere permisos y documentación. Esto fue en
-  respuesta a la tala catastrófica de especies de palisandro en todo el mundo,
-  con la demanda asiática impulsando una crisis de tala en todos los trópicos.
+  **Lista Roja UICN**: Vulnerable (VU) a nivel global; severamente diezmado en
+  Costa Rica **CITES**: Apéndice II (todas las especies de _Dalbergia_) Desde
+  2017, TODAS las especies de _Dalbergia_ han sido incluidas en el Apéndice II
+  de CITES, lo que significa que el comercio internacional requiere permisos y
+  documentación. Esto fue en respuesta a la tala catastrófica de especies de
+  palisandro en todo el mundo, con la demanda asiática impulsando una crisis de
+  tala en todos los trópicos.
 </Callout>
 
 ### Evaluación de Amenazas

--- a/content/trees/es/guayacan-real.mdx
+++ b/content/trees/es/guayacan-real.mdx
@@ -17,7 +17,7 @@ uses:
   - "Plantaciones de conservación"
 tags:
   - "native"
-  - "deciduous"
+  - "semi-evergreen"
   - "flowering"
   - "timber"
   - "medicinal"
@@ -26,7 +26,7 @@ tags:
 distribution:
   - "guanacaste"
   - "puntarenas"
-elevation: "0-600m"
+elevation: "0-300m"
 floweringSeason:
   - "march"
   - "april"
@@ -512,7 +512,7 @@ El Guayacán Real es un árbol pequeño a mediano siempreverde con tronco corto,
     <DataTable
       headers={["Especie", "Diferencia Clave"]}
       rows={[
-        ["_Guaiacum officinale_", "Más pares de folíolos (8-14), flores más grandes"],
+        ["_Guaiacum officinale_", "Más pares de folíolos (4-7), flores más grandes"],
         ["Especies de _Lonchocarpus_", "Diferente arreglo de hojas, flores diferentes"],
         ["Otros árboles de bosque seco", "Carecen de hojas compuestas con arreglo específico"],
       ]}

--- a/content/trees/es/magnolia.mdx
+++ b/content/trees/es/magnolia.mdx
@@ -62,10 +62,10 @@ safetyNotes: "SEGURO para paisajismo, jardines y espacios públicos. El árbol e
   árboles más hermosos de las tierras altas de Costa Rica. Nombrada por el
   **Volcán Poás**, esta especie pertenece a una de las familias de plantas con
   flores más antiguas de la Tierra. Las magnolias aparecieron hace más de 95
-  millones de años, antes de que evolucionaran las abejas, y fueron polinizadas
-  por escarabajos. Hoy, esta especie **Casi Amenazada** está restringida a los
-  bosques nubosos de las cordilleras volcánicas de Costa Rica, un vínculo
-  viviente con el pasado profundo.
+  millones de años, antes de la diversificación de los linajes modernos de
+  abejas, y fueron polinizadas por escarabajos. Hoy, esta especie **Casi
+  Amenazada** está restringida a los bosques nubosos de las cordilleras
+  volcánicas de Costa Rica, un vínculo viviente con el pasado profundo.
 </Callout>
 
 <TwoColumn>
@@ -160,7 +160,7 @@ safetyNotes: "SEGURO para paisajismo, jardines y espacios públicos. El árbol e
 
 - **Origen**: Aparecieron en el Cretácico Temprano (hace 95+ millones de años)
 - **Contemporáneas de dinosaurios**: Florecieron cuando los dinosaurios vagaban
-- **Polinización pre-abejas**: Evolucionaron antes de las abejas—polinizadas por escarabajos
+- **Polinización pre-abejas**: Evolucionaron antes de la diversificación de abejas modernas—polinizadas por escarabajos
 - **Características primitivas**: Partes florales en espiral, tépalos indiferenciados
 - **Fósiles vivientes**: Poco cambiadas en decenas de millones de años
 
@@ -446,8 +446,12 @@ Esta asociación antigua continúa en los bosques nubosos de Costa Rica hoy.
 <DataTable
   headers={["Animal", "Rol", "Notas"]}
   rows={[
-    ["Quetzales", "Dispersor primario", "Atraídos a arilos rojos"],
-    ["Yigüirros de Montaña", "Dispersor", "Ave común del bosque nuboso"],
+    ["Quetzales", "Dispersor ocasional", "Atraídos a arilos rojos"],
+    [
+      "Yigüirros de Montaña",
+      "Dispersor primario",
+      "Ave común del bosque nuboso; frugívoro más consistente",
+    ],
     ["Pájaros Campana", "Dispersor", "Frugívoro importante"],
     ["Pequeños mamíferos", "Dispersor terrestre", "Pueden enterrar semillas"],
   ]}

--- a/content/trees/es/mangle-rojo.mdx
+++ b/content/trees/es/mangle-rojo.mdx
@@ -245,11 +245,11 @@ Las raíces zanco son la característica más distintiva del árbol:
   <PropertyCard
     icon="💧"
     label="Adaptación"
-    value="Glándulas excretoras de sal en el envés"
+    value="Cutícula cerosa; sal excluida en raíces"
   />
 </PropertiesGrid>
 
-Las hojas son **gruesas y suculentas**, adaptadas para conservar agua en ambientes salinos. La cutícula cerosa reduce la pérdida de agua. Pequeñas glándulas excretoras de sal en el envés de la hoja ayudan al árbol a manejar la ingesta de sal.
+Las hojas son **gruesas y suculentas**, adaptadas para conservar agua en ambientes salinos. La cutícula cerosa reduce la pérdida de agua. A diferencia del Mangle Negro (_Avicennia germinans_), que posee glándulas excretoras de sal en sus hojas, el Mangle Rojo maneja la salinidad principalmente mediante **ultrafiltración en las raíces**, excluyendo hasta el 97% de la sal antes de que entre al xilema.
 
 ### Flores
 
@@ -429,10 +429,10 @@ Los bosques de Mangle Rojo soportan biodiversidad excepcional:
 
 El Mangle Rojo emplea múltiples estrategias para lidiar con alta salinidad:
 
-1. **Exclusión de sal**: Las raíces filtran hasta 90% de la sal del agua de mar
-2. **Excreción de sal**: Glándulas especializadas en hojas excretan exceso de sal
-3. **Acumulación de sal**: Hojas viejas acumulan sal, luego caen (caducifolio en sal, no temperatura)
-4. **Ajuste osmótico**: Altas concentraciones internas de solutos balancean salinidad externa
+1. **Exclusión de sal (mecanismo primario)**: Membranas de ultrafiltración en las raíces excluyen hasta el 97% de la sal del agua de mar — esta es la adaptación definitoria de _Rhizophora_ y la distingue de _Avicennia_ (que usa glándulas salinas foliares)
+2. **Acumulación de sal**: Hojas viejas acumulan la sal residual que pasa el filtro radicular, luego caen — funcionando como vía secundaria de eliminación de sal
+3. **Ajuste osmótico**: Altas concentraciones internas de solutos balancean la salinidad externa
+4. **Cutícula cerosa**: Reduce la pérdida de agua y previene la absorción de sal por aspersión a través de las superficies foliares
 
 </AccordionItem>
 

--- a/content/trees/es/nim.mdx
+++ b/content/trees/es/nim.mdx
@@ -255,7 +255,8 @@ húmedas.
 ### Consideraciones de establecimiento
 
 No está documentado como una de las especies invasoras de mayor prioridad a
-escala nacional, pero sí se recomienda monitorear su regeneración en hábitats
+escala nacional, pero está listado en la **Base de Datos Global de Especies Invasoras (GISD)**
+como especie invasora en varias regiones tropicales. Aún así se recomienda monitorear su regeneración en hábitats
 abiertos junto a fragmentos de bosque seco nativo.
 
 ---

--- a/content/trees/es/pejibaye.mdx
+++ b/content/trees/es/pejibaye.mdx
@@ -285,8 +285,9 @@ El Pejibaye es una palma que forma macollas y produce múltiples tallos desde la
   La temporada de pejibaye (abril-septiembre, pico en mayo-julio) es esperada
   con ansias en Costa Rica. Los vendedores callejeros venden pejibaye hervido
   por bolsa, a menudo con mayonesa para untar—una querida tradición local. Los
-  frutos deben cocinarse antes de comer ya que contienen cristales de oxalato de
-  calcio que irritan la garganta cuando están crudos.
+  frutos deben cocinarse antes de comer ya que contienen inhibidores de tripsina
+  y cristales de oxalato de calcio que causan irritación de garganta y malestar
+  digestivo cuando están crudos.
 </Callout>
 
 <TwoColumn>
@@ -433,10 +434,10 @@ El Pejibaye es una palma que forma macollas y produce múltiples tallos desde la
       "Polinizador/dispersor nocturno",
     ],
     [
-      "Escarabajo Rinoceronte",
+      "Gorgojos de Flores de Palma",
       "Polinizador primario",
       "Ene-May",
-      "Esencial para fructificación",
+      "Esencial para fructificación (_Phyllotrox_, _Andranthobius_ spp.)",
     ],
     [
       "Mono Carablanca",
@@ -641,11 +642,11 @@ taladrar para evitar que se raje.
 </AccordionItem>
 <AccordionItem title="🍳 No se Puede Comer Crudo">
 
-El pejibaye crudo contiene cristales de oxalato de calcio que causan intensa
-irritación de garganta. Estos compuestos se destruyen al cocinar, por lo que
+El pejibaye crudo contiene inhibidores de tripsina y cristales de oxalato de calcio que causan intensa
+irritación de garganta y bloquean la digestión proteica. La cocción destruye los inhibidores de tripsina,
+gelatiniza el almidón (haciendo la pulpa digerible) y reduce los cristales de oxalato, por lo que
 los frutos siempre se hierven antes de comer. El tiempo de cocción (30-60
-minutos) también hace la pulpa almidonada digerible y saca el distintivo
-sabor a castaña.
+minutos) también saca el distintivo sabor a castaña.
 
 </AccordionItem>
 <AccordionItem title="🌱 Sueños sin Espinas">

--- a/content/trees/es/yellow-oleander.mdx
+++ b/content/trees/es/yellow-oleander.mdx
@@ -13,7 +13,7 @@ uses:
   - "Medicina tradicional (peligroso)"
   - "Planta de seto"
 tags:
-  - "introduced"
+  - "native"
   - "evergreen"
   - "flowering"
   - "ornamental"

--- a/contentlayer.config.ts
+++ b/contentlayer.config.ts
@@ -50,8 +50,9 @@ export const Tree = defineDocumentType(() => ({
       required: false,
     },
     conservationStatus: {
-      type: "string",
-      description: "IUCN conservation status if known",
+      type: "enum",
+      options: ["LC", "NT", "VU", "EN", "CR", "EW", "EX", "DD", "NE"],
+      description: "IUCN conservation status code",
       required: false,
     },
     maxHeight: {

--- a/docs/CONTENT_STANDARDIZATION_GUIDE.md
+++ b/docs/CONTENT_STANDARDIZATION_GUIDE.md
@@ -6,11 +6,11 @@
 
 ## Executive Summary
 
-**Current State Analysis** (January 2026):
+**Current State Analysis** (February 2026):
 
-- **Total tree pages**: 128 species (256 bilingual documents)
-- **Comparison guides**: 16 bilingual guides
-- **Glossary terms**: 100 terms documented
+- **Total tree pages**: 175 species (350 bilingual documents)
+- **Comparison guides**: 20 bilingual guides
+- **Glossary terms**: 150 terms documented
 - **Page length distribution** (based on December 2025 audit of 107 pages):
   - 700+ lines (strong): 8 pages
   - 600-700 lines: 43 pages
@@ -259,7 +259,7 @@ For **palms**:
 
 **Coverage data** (December 2025 audit of 107 pages):
 
-> ⚠️ **Audit Status**: Data below reflects 107 trees. Current count is 128 species. Re-audit recommended for accurate percentages.
+> ⚠️ **Audit Status**: Data below reflects 107 trees. Current count is 175 species. Re-audit recommended for accurate percentages.
 
 | Section                        | Pages with Section | Target             |
 | ------------------------------ | ------------------ | ------------------ |

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,11 +42,11 @@ Roadmap and testing documentation:
 
 ### Content Metrics
 
-- ✅ **154 species** documented with bilingual content (EN+ES)
-- ✅ **100% safety coverage** - All 154 trees have complete 13-field safety data
-- ✅ **100 glossary terms** with inline tooltips
-- ✅ **60 species** with comprehensive care & cultivation guidance (47%)
-- ✅ **16 comparison guides** (80% of 20 target)
+- ✅ **175 species** documented with bilingual content (EN+ES)
+- ✅ **100% safety coverage** - All 175 trees have complete 13-field safety data
+- ✅ **150 glossary terms** with inline tooltips
+- ✅ **175 species** with comprehensive care & cultivation guidance
+- ✅ **20 comparison guides** (100% of 20 target)
 
 ### Technical Achievement
 
@@ -59,8 +59,8 @@ Roadmap and testing documentation:
 ### Status
 
 - 🚀 **v1.0 Production Ready** - Core features complete
-- 🔄 **Active Development** - Priority 0 work in progress (admin auth, image review, safety verification)
-- 📚 **Content Expansion** - 40 unique species remaining to document
+- 🔄 **Active Development** - Performance optimization and scientific accuracy audit in progress
+- ✅ **Content Complete** - 175/175 species documented
 
 ## 📦 Archive
 

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,99 +1,76 @@
 import { MetadataRoute } from "next";
-import { allTrees } from "contentlayer/generated";
+import {
+  allTrees,
+  allGlossaryTerms,
+  allSpeciesComparisons,
+} from "contentlayer/generated";
 
 const BASE_URL = "https://costaricatreeatlas.com";
+const locales = ["en", "es"] as const;
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const now = new Date().toISOString();
 
-  // Static pages for both locales
+  // Helper to generate entries for both locales
+  const bilingualPages = (
+    path: string,
+    options: {
+      changeFrequency: MetadataRoute.Sitemap[number]["changeFrequency"];
+      priority: number;
+    }
+  ): MetadataRoute.Sitemap =>
+    locales.map((locale) => ({
+      url: `${BASE_URL}/${locale}${path}`,
+      lastModified: now,
+      changeFrequency: options.changeFrequency,
+      priority: options.priority,
+    }));
+
+  // Static section pages for both locales
   const staticPages: MetadataRoute.Sitemap = [
-    // English static pages
-    {
-      url: `${BASE_URL}/en`,
-      lastModified: now,
-      changeFrequency: "weekly",
-      priority: 1.0,
-    },
-    {
-      url: `${BASE_URL}/en/trees`,
-      lastModified: now,
-      changeFrequency: "weekly",
-      priority: 0.9,
-    },
-    {
-      url: `${BASE_URL}/en/identify`,
-      lastModified: now,
-      changeFrequency: "monthly",
-      priority: 0.8,
-    },
-    {
-      url: `${BASE_URL}/en/compare`,
-      lastModified: now,
+    ...bilingualPages("", { changeFrequency: "weekly", priority: 1.0 }),
+    ...bilingualPages("/trees", { changeFrequency: "weekly", priority: 0.9 }),
+    ...bilingualPages("/compare", {
       changeFrequency: "monthly",
       priority: 0.7,
-    },
-    {
-      url: `${BASE_URL}/en/education`,
-      lastModified: now,
+    }),
+    ...bilingualPages("/education", {
       changeFrequency: "monthly",
       priority: 0.8,
-    },
-    {
-      url: `${BASE_URL}/en/seasonal`,
-      lastModified: now,
+    }),
+    ...bilingualPages("/seasonal", {
       changeFrequency: "monthly",
       priority: 0.7,
-    },
-    {
-      url: `${BASE_URL}/en/about`,
-      lastModified: now,
+    }),
+    ...bilingualPages("/about", { changeFrequency: "monthly", priority: 0.6 }),
+    ...bilingualPages("/glossary", {
+      changeFrequency: "monthly",
+      priority: 0.7,
+    }),
+    ...bilingualPages("/safety", { changeFrequency: "monthly", priority: 0.7 }),
+    ...bilingualPages("/conservation", {
+      changeFrequency: "monthly",
+      priority: 0.7,
+    }),
+    ...bilingualPages("/map", { changeFrequency: "monthly", priority: 0.7 }),
+    ...bilingualPages("/field-guide", {
       changeFrequency: "monthly",
       priority: 0.6,
-    },
-    // Spanish static pages
-    {
-      url: `${BASE_URL}/es`,
-      lastModified: now,
-      changeFrequency: "weekly",
-      priority: 1.0,
-    },
-    {
-      url: `${BASE_URL}/es/trees`,
-      lastModified: now,
-      changeFrequency: "weekly",
-      priority: 0.9,
-    },
-    {
-      url: `${BASE_URL}/es/identify`,
-      lastModified: now,
+    }),
+    ...bilingualPages("/wizard", { changeFrequency: "monthly", priority: 0.6 }),
+    ...bilingualPages("/quiz", { changeFrequency: "monthly", priority: 0.5 }),
+    ...bilingualPages("/diagnose", {
       changeFrequency: "monthly",
-      priority: 0.8,
-    },
-    {
-      url: `${BASE_URL}/es/compare`,
-      lastModified: now,
+      priority: 0.5,
+    }),
+    ...bilingualPages("/contribute", {
       changeFrequency: "monthly",
-      priority: 0.7,
-    },
-    {
-      url: `${BASE_URL}/es/education`,
-      lastModified: now,
+      priority: 0.5,
+    }),
+    ...bilingualPages("/use-cases", {
       changeFrequency: "monthly",
-      priority: 0.8,
-    },
-    {
-      url: `${BASE_URL}/es/seasonal`,
-      lastModified: now,
-      changeFrequency: "monthly",
-      priority: 0.7,
-    },
-    {
-      url: `${BASE_URL}/es/about`,
-      lastModified: now,
-      changeFrequency: "monthly",
-      priority: 0.6,
-    },
+      priority: 0.5,
+    }),
   ];
 
   // Dynamic tree pages
@@ -104,5 +81,23 @@ export default function sitemap(): MetadataRoute.Sitemap {
     priority: 0.8,
   }));
 
-  return [...staticPages, ...treePages];
+  // Dynamic glossary term pages
+  const glossaryPages: MetadataRoute.Sitemap = allGlossaryTerms.map((term) => ({
+    url: `${BASE_URL}/${term.locale}/glossary/${term.slug}`,
+    lastModified: term.publishedAt || now,
+    changeFrequency: "monthly",
+    priority: 0.6,
+  }));
+
+  // Dynamic comparison pages
+  const comparisonPages: MetadataRoute.Sitemap = allSpeciesComparisons.map(
+    (comparison) => ({
+      url: `${BASE_URL}/${comparison.locale}/compare/${comparison.slug}`,
+      lastModified: comparison.publishedAt || now,
+      changeFrequency: "monthly",
+      priority: 0.7,
+    })
+  );
+
+  return [...staticPages, ...treePages, ...glossaryPages, ...comparisonPages];
 }

--- a/src/components/SeasonalCalendar.tsx
+++ b/src/components/SeasonalCalendar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useMemo, useCallback } from "react";
-import Link from "next/link";
+import { Link } from "@i18n/navigation";
 import { SafeImage } from "@/components/SafeImage";
 import {
   getEventsForMonth,
@@ -734,7 +734,7 @@ function EventCard({
               {event.relatedTrees.map((treeSlug) => (
                 <Link
                   key={treeSlug}
-                  href={`/${locale}/trees/${treeSlug}`}
+                  href={`/trees/${treeSlug}`}
                   className="text-xs px-2 py-0.5 rounded-full bg-green-200 dark:bg-green-900/50 text-green-800 dark:text-green-300 hover:bg-green-300 dark:hover:bg-green-800/50 transition-colors"
                 >
                   🌳 {treeSlug}
@@ -787,7 +787,7 @@ function TreeListItem({
 
   return (
     <Link
-      href={`/${locale}/trees/${tree.slug}`}
+      href={`/trees/${tree.slug}`}
       className="flex items-center gap-3 p-2 rounded-lg hover:bg-white/50 dark:hover:bg-white/10 transition-colors"
     >
       <div className="w-10 h-10 relative rounded-lg overflow-hidden flex-shrink-0">

--- a/src/lib/store/index.ts
+++ b/src/lib/store/index.ts
@@ -289,35 +289,3 @@ export function useFavorite(slug: string) {
   const toggleFavorite = useStore((state) => state.toggleFavorite);
   return { isFavorite, toggle: () => toggleFavorite(slug) };
 }
-
-/**
- * @deprecated Use the ThemeSync component instead
- * This hook is kept for backward compatibility but is no longer used internally
- */
-export function useThemeSync() {
-  const theme = useStore((state) => state.theme);
-  const setResolvedTheme = useStore((state) => state.setResolvedTheme);
-
-  // This should be called in a useEffect in the root layout
-  const syncTheme = () => {
-    const root = document.documentElement;
-    let resolved: ResolvedTheme;
-
-    if (theme === "system") {
-      resolved = window.matchMedia("(prefers-color-scheme: dark)").matches
-        ? "dark"
-        : "light";
-    } else {
-      resolved = theme;
-    }
-
-    setResolvedTheme(resolved);
-
-    root.classList.remove("light", "dark");
-    root.classList.add(resolved);
-
-    return resolved;
-  };
-
-  return { theme, syncTheme };
-}


### PR DESCRIPTION
## Summary

Comprehensive scientific accuracy audit across species content, plus SEO and developer experience improvements. All fixes applied to both EN and ES locales simultaneously.

## Scientific Corrections (10 species/terms fixed)

### Critical Fixes
- **Mangle Rojo**: Replaced incorrect "salt-excreting glands on leaves" with accurate salt-exclusion at root ultrafiltration mechanism. *Rhizophora mangle* is a salt **excluder**, not a salt gland species (that's *Avicennia*).
- **Cocobolo**: Corrected IUCN status from CR (Critically Endangered) to VU (Vulnerable) — the actual global assessment. Added context: "Vulnerable globally; severely depleted in Costa Rica."
- **Pejibaye**: Replaced "Rhinoceros Beetle" as primary pollinator with accurate "Palm Flower Weevils (*Phyllotrox*, *Andranthobius* spp.)". Fixed cooking chemistry from "calcium oxalate only" to "trypsin inhibitors AND calcium oxalate crystals".

### Moderate Fixes
- **Guayacán Real**: Changed tag from "deciduous" to "semi-evergreen", fixed elevation from 0-600m to 0-300m, corrected *G. officinale* leaflet comparison from "8-14 pairs" to "4-7 pairs".
- **Mango vs Espavel comparison**: Replaced "urushiol" throughout with accurate "anacardic acid and cardol" (urushiol is *Toxicodendron*, not *Mangifera/Anacardium*).
- **Magnolia**: Changed "before bees evolved" to "before the diversification of modern bee lineages" (bees are ~100mya, roughly contemporaneous). Swapped Quetzals from "Primary" to "Occasional" disperser and Mountain Robins to "Primary".
- **Neem**: Added Global Invasive Species Database (GISD) listing context.

### Minor Fixes
- **Cauliflory glossary**: Replaced Guapinol (flowers on branch terminals, NOT trunk) with Jícaro (EN) / Ira Rosa (ES).
- **Mycorrhiza glossary**: Fixed slug reference from non-existent `pino` to correct `pino-caribeno`.
- **Yellow Oleander**: Changed tag from "introduced" to "native" (*Thevetia peruviana* is native to tropical Americas).

## Schema & Infrastructure

- **contentlayer.config.ts**: Changed `conservationStatus` from free string to validated enum with IUCN standard codes: LC, NT, VU, EN, CR, EW, EX, DD, NE
- **sitemap.ts**: Expanded from ~14 static URLs to 350+ including all glossary terms, comparison guides, and section pages
- **SeasonalCalendar.tsx**: Fixed `Link` import from `next/link` to `@i18n/navigation` (locale auto-prefixing)
- **store/index.ts**: Removed deprecated `useThemeSync` hook (zero consumers)
- **docs**: Updated stale species counts from 128-160 to actual 175

## Files Changed (29)
- 23 content files (MDX) across trees, comparisons, glossary
- 3 source files (sitemap, SeasonalCalendar, store)
- 3 documentation files (README, docs/README, CONTENT_STANDARDIZATION_GUIDE)

## Verification
- ✅ `npm run build` passes (all 350+ static pages generated)
- ✅ ESLint: zero new errors (only pre-existing warnings)
- ✅ Both EN and ES locales updated in parallel

## Summary by Sourcery

Update species content for scientific accuracy, strengthen conservation status metadata, and expand SEO coverage via a richer sitemap and locale-aware links.

New Features:
- Generate sitemap entries for all glossary terms, comparison guides, and additional static sections across both locales.

Bug Fixes:
- Correct multiple species biology, chemistry, and conservation details in EN/ES tree and comparison content, including mangrove salt adaptation, pejibaye edibility and pollinators, Anacardiaceae irritant chemistry, and Magnolia ecology.
- Fix Yellow Oleander nativeness tag and glossary example species references for cauliflory and mycorrhiza.

Enhancements:
- Tighten IUCN alignment by changing tree conservationStatus to a validated enum and updating Cocobolo status copy and related comparison guides.
- Clarify invasive status context for Neem using GISD references and adjust Guayacán Real phenology and range details.
- Remove an unused theme synchronization hook from the global store and switch seasonal calendar links to use locale-aware routing utilities.

Build:
- Broaden sitemap generation to cover bilingual static sections and all dynamic trees, glossary terms, and species comparisons for improved crawl coverage.

Documentation:
- Refresh content metrics and project status in README and docs to reflect 175 species, expanded glossary, and completed comparison guides.