### PR TITLE
feat(api): P6.3 Public API — comparisons, glossary, OpenAPI spec

### DIFF
--- a/docs/NEXT_AGENT_HANDOFF.md
+++ b/docs/NEXT_AGENT_HANDOFF.md
@@ -1,27 +1,27 @@
 # Next Agent Handoff
 
-Last updated: 2026-02-26
+Last updated: 2026-02-27
 
-## Latest Run Summary (2026-02-26 — Run 10)
+## Latest Run Summary (2026-02-27 — Run 11)
 
-- **Branch**: `feature/cloudinary-integration` → [PR #494](https://github.com/sandgraal/Costa-Rica-Tree-Atlas/pull/494) (merged)
-- **Sub-PR**: [PR #495](https://github.com/sandgraal/Costa-Rica-Tree-Atlas/pull/495) (merged) — singleton guard + comprehensive tests
-- **Also merged**: [PR #493](https://github.com/sandgraal/Costa-Rica-Tree-Atlas/pull/493) (Codacy removal), [PR #496](https://github.com/sandgraal/Costa-Rica-Tree-Atlas/pull/496) (minimatch bump)
+- **Branch**: `feature/p6-community-features-and-fixes` → push pending (network down)
 - **Tasks completed**:
-  1. **B4 Resolved: Cloudinary integration** — Created `src/lib/cloudinary.ts` (239 lines): singleton `getCloudinary()`, `uploadTreeImage()` with automatic folder structure (`costa-rica-tree-atlas/trees/{slug}`), format/quality optimization, CDN URL generation. Refactored `src/app/api/images/upload/route.ts` from local filesystem to Cloudinary. Added `res.cloudinary.com` to `next.config.ts` remote patterns. Added env var validation (CLOUDINARY_CLOUD_NAME, API_KEY, API_SECRET).
-  2. **Cloudinary test coverage** — Created `tests/lib/cloudinary.test.ts` (439 lines, 23 tests): singleton guard, upload success/error, configuration validation, folder structure, format options.
-  3. **Codacy removal** — Deleted `.codacy/` directory, removed `codacy.instructions.md`, cleaned gitignore and security comments.
-  4. **Dependency update**: minimatch 3.1.2 → 3.1.5 (security patch).
-  5. **Verified**: 502/502 tests pass, 0 lint errors, build clean.
+  1. **P6.3: Public API — Comparisons endpoints** — Created `/api/v1/comparisons` (list with filtering by species, difficulty, tag, search, pagination) and `/api/v1/comparisons/[slug]` (detail with embedded species data). 19 new tests.
+  2. **P6.3: Public API — Glossary endpoints** — Created `/api/v1/glossary` (list with filtering by category, search, pagination) and `/api/v1/glossary/[slug]` (detail with embedded related terms and example species). 15 new tests.
+  3. **P6.3: Public API — OpenAPI specification** — Created `/api/v1/openapi.json` with full OpenAPI 3.1 spec documenting all 7 v1 endpoints (trees, trees/[slug], families, comparisons, comparisons/[slug], glossary, glossary/[slug]). 5 new tests.
+  4. **Shared rate limiter extraction** — Created `src/lib/api-rate-limit.ts` replacing duplicated inline rate-limiting code in trees, trees/[slug], and families routes. Adds periodic cleanup for memory leak prevention. All new endpoints use shared limiter.
+  5. **API types expansion** — Added `ComparisonAPIResponse`, `ComparisonFilterOptions`, `GlossaryAPIResponse`, `GlossaryFilterOptions` to `src/types/api.ts`.
+  6. **Fix: @sentry/nextjs Turbopack build warnings** — Used runtime string concatenation (`["@sentry", "nextjs"].join("/")`) in `src/lib/error-tracking.ts` and `src/instrumentation.ts` to prevent Turbopack static analysis from resolving the optional module.
+  7. **Verified**: 541/541 tests pass (39 new), 0 lint errors.
 
 ## Previous Run Summary (2026-02-26 — Run 9)
 
-- **Branch**: `content/glossary-standardization-and-enum-normalization` → [PR #491](https://github.com/sandgraal/Costa-Rica-Tree-Atlas/pull/491) (merged)
+- **Branch**: `content/glossary-standardization-and-enum-normalization` → PR pending
 - **Tasks completed**:
-  1. **Content Standardization: Enum normalization** — Normalized 111 non-standard enum values across 53 tree files (EN + ES). Created `scripts/normalize-enum-values.mjs`.
-  2. **Content Standardization: Glossary exampleSpecies** — Fixed 121 references (common names → valid tree slugs). Created `scripts/fix-glossary-references.mjs`.
-  3. **Content Standardization: Glossary relatedTerms** — Removed 391 invalid references across 209 glossary files.
-  4. **Bug fix**: Fixed flaky ReDoS timing test (threshold 1ms → 5ms).
+  1. **Content Standardization: Enum normalization** — Normalized 111 non-standard enum values across 53 tree files (EN + ES). Fields fixed: waterNeeds (27), lightRequirements (21), growthRate (22), propagationDifficulty (26), toxicityLevel (5), skinContactRisk (5), allergenRisk (5). Spanish translations ("moderado" → "moderate", "pleno-sol" → "full-sun") and English compound values ("very-fast" → "fast", "moderate-to-high" → "high") mapped to schema-valid enums. Created `scripts/normalize-enum-values.mjs`.
+  2. **Content Standardization: Glossary exampleSpecies** — Fixed 121 glossary exampleSpecies references (common names → valid tree slugs). Removed 64 invalid entries (non-atlas species like beans, corn, dandelion). Mappings: "mahogany" → "caoba", "teak" → "teca", "cecropia" → "guarumo", "kapok" → "ceiba", etc. Created `scripts/fix-glossary-references.mjs`.
+  3. **Content Standardization: Glossary relatedTerms** — Removed 391 invalid relatedTerms references that pointed to non-existent glossary slugs. Affected 209 glossary files (EN + ES).
+  4. **Bug fix**: Fixed flaky ReDoS timing test (threshold 1ms → 5ms, was intermittently failing).
   5. **Verified**: 479/479 tests pass, 0 lint errors, build clean.
 
 ## Previous Run Summary (2026-06-10 — Run 8)
@@ -109,46 +109,46 @@ Last updated: 2026-02-26
 
 ## Current Project State
 
-- **Tests**: 502/502 passing (30 test files)
+- **Tests**: 541/541 passing (34 test files)
 - **Content**: 175 trees × 2 locales, 20 comparisons × 2, 150 glossary × 2
 - **Content quality**: All enum values normalized to schema, glossary references validated
 - **Galleries**: 174/175 trees with iNaturalist photo galleries
 - **External links**: 175/175 trees with GBIF + IUCN links
 - **All pages**: 600+ lines, bilingual parity achieved
 - **Database**: Neon PostgreSQL deployed, Prisma 7, admin user active, indexes optimized
-- **Cloud storage**: Cloudinary integrated — upload route, CDN delivery, env validation
 - **Performance**: Lighthouse 85/100 (Perf), 100 (SEO), 100 (BP). LCP 4.0s is network-bound. A11y expected 100 after contrast fix deployed.
 - **Component sizes**: All 3 large clients split — TreeMapClient 1,027, ScavengerHuntClient 575, TreeJournalClient 672 lines
 - **SEO**: All P3 tasks complete (P3.1–P3.5). OG images, JSON-LD, sitemap, and meta descriptions all optimized.
-- **Error tracking**: Sentry-ready (zero deps, graceful fallback)
+- **Error tracking**: Sentry-ready (zero deps, graceful fallback), Turbopack build warnings fixed
+- **Public API (P6.3)**: 7 v1 endpoints — trees (list/detail), families, comparisons (list/detail), glossary (list/detail), OpenAPI 3.1 spec. Shared rate limiter, pagination, HAL-style links.
 
 ## Highest-Priority Remaining Work
 
 From `docs/IMPLEMENTATION_PLAN.md` (updated 2026-02-26):
 
-| Priority | Task                                  | Status      | Notes                                                                |
-| -------- | ------------------------------------- | ----------- | -------------------------------------------------------------------- |
-| P2.1     | Photo gallery sections                | ✅ Complete | 174/175 (orey lacks iNaturalist photos)                              |
-| P2.2     | Applications/Uses body sections       | ✅ Complete | Already present in 173/175 under various headings                    |
-| P2.3     | Seasonal phenology body sections      | ✅ Complete | Already present in all 174 with seasonal frontmatter                 |
-| P2.4     | GBIF/IUCN external links              | ✅ Complete | 175/175 now have both GBIF and IUCN links                            |
-| P3.1     | OG images for comparison detail pages | ✅ Complete | Created opengraph-image.tsx + twitter-image.tsx                      |
-| P3.2     | OG images for tree detail pages       | ✅ Complete | Already existed from a previous run                                  |
-| P3.3     | JSON-LD for tree detail pages         | ✅ Complete | Taxon schema, conservation status, distribution, multi-image         |
-| P3.4     | Sitemap enhancements                  | ✅ Complete | All pages, lastmod, comparisons, glossary already included           |
-| P3.5     | Meta description optimization         | ✅ Complete | 16 descriptions optimized across 14 files, ES i18n bugs fixed        |
-| P4.2     | SSR refactor 2 education pages        | ✅ Complete | ScavengerHuntClient, TreeJournalClient — all 6 education pages done  |
-| P4.3     | Split large client components         | ✅ Complete | TreeMapClient 26%, ScavengerHuntClient 52%, TreeJournalClient 37%    |
-| P4.4     | Database query optimization           | ✅ Complete | 3 indexes added (Account.userId, image_proposals, contributions)     |
-| P4.6     | LCP image optimization                | ✅ Complete | Images recompressed 37%, priority props added                        |
-| P4.7     | A11y contrast fixes (4 issues)        | ✅ Complete | Dark mode primary/secondary lightened, skip-link override added      |
-| P5.1     | API route test coverage               | ✅ Complete | 107 new tests across 9 files, 431/431 total passing                  |
-| P5.2     | Error tracking (Sentry)               | ✅ Complete | Sentry-ready, 18 API routes updated, zero new deps                   |
-| P5.3     | Content validation tests              | ✅ Complete | 48 tests — schema, parity, images, cross-refs. 479/479 total.        |
-| P5.4     | Content standardization               | ✅ Complete | 111 enum fixes, 121 exampleSpecies mapped, 391 relatedTerms cleaned  |
-| B4       | Cloud image storage (Cloudinary)      | ✅ Complete | SDK integrated, upload route refactored, CDN delivery, env validated |
+| Priority | Task                                  | Status      | Notes                                                               |
+| -------- | ------------------------------------- | ----------- | ------------------------------------------------------------------- |
+| P2.1     | Photo gallery sections                | ✅ Complete | 174/175 (orey lacks iNaturalist photos)                             |
+| P2.2     | Applications/Uses body sections       | ✅ Complete | Already present in 173/175 under various headings                   |
+| P2.3     | Seasonal phenology body sections      | ✅ Complete | Already present in all 174 with seasonal frontmatter                |
+| P2.4     | GBIF/IUCN external links              | ✅ Complete | 175/175 now have both GBIF and IUCN links                           |
+| P3.1     | OG images for comparison detail pages | ✅ Complete | Created opengraph-image.tsx + twitter-image.tsx                     |
+| P3.2     | OG images for tree detail pages       | ✅ Complete | Already existed from a previous run                                 |
+| P3.3     | JSON-LD for tree detail pages         | ✅ Complete | Taxon schema, conservation status, distribution, multi-image        |
+| P3.4     | Sitemap enhancements                  | ✅ Complete | All pages, lastmod, comparisons, glossary already included          |
+| P3.5     | Meta description optimization         | ✅ Complete | 16 descriptions optimized across 14 files, ES i18n bugs fixed       |
+| P4.2     | SSR refactor 2 education pages        | ✅ Complete | ScavengerHuntClient, TreeJournalClient — all 6 education pages done |
+| P4.3     | Split large client components         | ✅ Complete | TreeMapClient 26%, ScavengerHuntClient 52%, TreeJournalClient 37%   |
+| P4.4     | Database query optimization           | ✅ Complete | 3 indexes added (Account.userId, image_proposals, contributions)    |
+| P4.6     | LCP image optimization                | ✅ Complete | Images recompressed 37%, priority props added                       |
+| P4.7     | A11y contrast fixes (4 issues)        | ✅ Complete | Dark mode primary/secondary lightened, skip-link override added     |
+| P5.1     | API route test coverage               | ✅ Complete | 107 new tests across 9 files, 431/431 total passing                 |
+| P5.2     | Error tracking (Sentry)               | ✅ Complete | Sentry-ready, 18 API routes updated, zero new deps                  |
+| P5.3     | Content validation tests              | ✅ Complete | 48 tests — schema, parity, images, cross-refs. 479/479 total.       |
+| P5.4     | Content standardization               | ✅ Complete | 111 enum fixes, 121 exampleSpecies mapped, 391 relatedTerms cleaned |
+| P6.3     | Public API for researchers            | ✅ Complete | 7 endpoints, OpenAPI spec, shared rate limiter, 39 tests            |
 
-**Recommended next task**: P6.1 (User photo uploads — B4 resolved, Cloudinary ready), P6.3 (Public API), or P4.5 (CSP optimization — manual sprint).
+**Recommended next task**: P6.1 (User photo uploads — infrastructure exists, needs final testing), P4.5 (CSP optimization — manual sprint), or polish remaining items.
 
 ## Established Patterns
 
@@ -216,13 +216,12 @@ Mission
 - Performance (P4): Lighthouse 85/100. LCP optimized (images recompressed 37%, priority props added). DB indexes added ✅. A11y contrast ✅. SSR refactor ✅ ALL 6 education pages done. Component splits ✅ ALL 3 done.
 - Testing (P5): API route tests ✅ (107 tests). Content validation tests ✅ (48 tests, 479 total). Error tracking ✅ (Sentry-ready, 18 API routes updated, zero new deps). Content standardization ✅ (111 enum fixes, 121 exampleSpecies mapped, 391 relatedTerms cleaned).
 - Recommended execution order (pick one or more):
-  1. P6.1: User photo uploads — Cloudinary integrated (B4 ✅), build upload UI + proposal workflow
-  2. P6.3: Public API for researchers — RESTful endpoints, rate limiting, OpenAPI docs
-  3. P4.5: CSP optimization — refactor 30+ components with inline styles to Tailwind/CSS modules (manual sprint)
+  1. P4.5: CSP optimization — refactor 30+ components with inline styles to Tailwind/CSS modules (manual sprint, 1-2 weeks)
+  2. P6.1: User photo uploads — infrastructure exists (upload UI, API, Cloudinary integration), needs final testing and deployment validation
+  3. Push pending branch `feature/p6-community-features-and-fixes` and open PR (network was down during Run 11)
   4. Apply DB migration to production (manual step — `npx prisma migrate deploy`)
   5. Install @sentry/nextjs and configure DSN in Vercel env vars (manual step)
-  6. Add Cloudinary API keys to Vercel env vars (manual step)
-  7. Any remaining polish from IMPLEMENTATION_PLAN.md
+  6. Any remaining polish from IMPLEMENTATION_PLAN.md
 
 Required workflow
 1. Read and follow:

--- a/src/app/api/v1/comparisons/[slug]/route.ts
+++ b/src/app/api/v1/comparisons/[slug]/route.ts
@@ -1,0 +1,141 @@
+/**
+ * Public API — Get Single Comparison
+ *
+ * GET /api/v1/comparisons/[slug] — detailed comparison with species links.
+ *
+ * Part of P6.3: Public API for researchers.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { allSpeciesComparisons, allTrees } from "contentlayer/generated";
+import { captureApiError } from "@/lib/error-tracking";
+import {
+  rateLimitOrNull,
+  getClientId,
+  checkRateLimit,
+  addRateLimitHeaders,
+} from "@/lib/api-rate-limit";
+
+interface RouteParams {
+  params: Promise<{ slug: string }>;
+}
+
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  const blocked = rateLimitOrNull(request);
+  if (blocked) return blocked;
+
+  try {
+    const { slug } = await params;
+    const { searchParams } = new URL(request.url);
+    const baseUrl = `${request.nextUrl.protocol}//${request.nextUrl.host}`;
+    const locale = searchParams.get("locale") || "en";
+
+    const comparison = allSpeciesComparisons.find(
+      (c) => c.slug === slug && c.locale === locale
+    );
+
+    if (!comparison) {
+      // Check if it exists in another locale
+      const any = allSpeciesComparisons.find((c) => c.slug === slug);
+      if (any) {
+        const clientId = getClientId(request);
+        const rl = checkRateLimit(clientId);
+        const headers = new Headers();
+        addRateLimitHeaders(headers, rl);
+        return NextResponse.json(
+          {
+            error: {
+              code: "LOCALE_NOT_FOUND",
+              message: `Comparison "${slug}" not found in locale "${locale}". Available in: ${allSpeciesComparisons
+                .filter((c) => c.slug === slug)
+                .map((c) => c.locale)
+                .join(", ")}`,
+            },
+            _links: {
+              documentation: "/api/docs",
+              alternatives: allSpeciesComparisons
+                .filter((c) => c.slug === slug)
+                .map(
+                  (c) =>
+                    `${baseUrl}/api/v1/comparisons/${slug}?locale=${c.locale}`
+                ),
+            },
+          },
+          { status: 404, headers }
+        );
+      }
+
+      const clientId = getClientId(request);
+      const rl = checkRateLimit(clientId);
+      const headers = new Headers();
+      addRateLimitHeaders(headers, rl);
+      return NextResponse.json(
+        {
+          error: {
+            code: "NOT_FOUND",
+            message: `Comparison "${slug}" not found`,
+          },
+          _links: {
+            documentation: "/api/docs",
+            comparisons: `${baseUrl}/api/v1/comparisons`,
+          },
+        },
+        { status: 404, headers }
+      );
+    }
+
+    // Enrich with species details
+    const speciesDetails = comparison.species.map((s) => {
+      const tree = allTrees.find((t) => t.slug === s && t.locale === locale);
+      return {
+        slug: s,
+        title: tree?.title ?? s,
+        scientificName: tree?.scientificName,
+        family: tree?.family,
+        _links: {
+          self: `${baseUrl}/api/v1/trees/${s}?locale=${locale}`,
+          html: `${baseUrl}/${locale}/trees/${s}`,
+        },
+      };
+    });
+
+    const data = {
+      slug: comparison.slug,
+      locale: comparison.locale,
+      title: comparison.title,
+      species: comparison.species,
+      keyDifference: comparison.keyDifference,
+      description: comparison.description,
+      difficulty: comparison.difficulty,
+      confusionRating: comparison.confusionRating,
+      comparisonTags: comparison.comparisonTags,
+      seasonalNote: comparison.seasonalNote,
+      publishedAt: comparison.publishedAt,
+      _links: {
+        self: `${baseUrl}/api/v1/comparisons/${comparison.slug}?locale=${locale}`,
+        html: `${baseUrl}/${locale}/compare/${comparison.slug}`,
+      },
+      _embedded: { species: speciesDetails },
+    };
+
+    const clientId = getClientId(request);
+    const rl = checkRateLimit(clientId);
+    const headers = new Headers();
+    addRateLimitHeaders(headers, rl);
+    headers.set("Cache-Control", "public, max-age=300, s-maxage=600");
+
+    return NextResponse.json({ data }, { headers });
+  } catch (error) {
+    captureApiError(error, "/api/v1/comparisons/[slug]", "GET");
+    return NextResponse.json(
+      {
+        error: {
+          code: "INTERNAL_ERROR",
+          message: "An unexpected error occurred",
+        },
+        _links: { documentation: "/api/docs" },
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/v1/comparisons/route.ts
+++ b/src/app/api/v1/comparisons/route.ts
@@ -1,0 +1,201 @@
+/**
+ * Public API — List Comparisons
+ *
+ * GET /api/v1/comparisons — paginated list with filtering by species,
+ *     difficulty, tag, and free-text search.
+ *
+ * Part of P6.3: Public API for researchers.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import {
+  allSpeciesComparisons,
+  type SpeciesComparison,
+} from "contentlayer/generated";
+import { captureApiError } from "@/lib/error-tracking";
+import {
+  rateLimitOrNull,
+  getClientId,
+  checkRateLimit,
+  addRateLimitHeaders,
+} from "@/lib/api-rate-limit";
+import type {
+  ComparisonAPIResponse,
+  ComparisonFilterOptions,
+  PaginatedResponse,
+} from "@/types/api";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function transformComparison(
+  c: SpeciesComparison,
+  baseUrl: string
+): ComparisonAPIResponse {
+  return {
+    slug: c.slug,
+    locale: c.locale,
+    title: c.title,
+    species: c.species,
+    keyDifference: c.keyDifference,
+    description: c.description,
+    difficulty: c.difficulty,
+    confusionRating: c.confusionRating,
+    comparisonTags: c.comparisonTags,
+    seasonalNote: c.seasonalNote,
+    publishedAt: c.publishedAt,
+    _links: {
+      self: `${baseUrl}/api/v1/comparisons/${c.slug}?locale=${c.locale}`,
+      html: `${baseUrl}/${c.locale}/compare/${c.slug}`,
+      species: c.species.map((s) => ({
+        slug: s,
+        url: `${baseUrl}/api/v1/trees/${s}?locale=${c.locale}`,
+      })),
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Route
+// ---------------------------------------------------------------------------
+
+export async function GET(request: NextRequest) {
+  // Rate limit
+  const blocked = rateLimitOrNull(request);
+  if (blocked) return blocked;
+
+  try {
+    const { searchParams } = new URL(request.url);
+    const baseUrl = `${request.nextUrl.protocol}//${request.nextUrl.host}`;
+
+    // Parse filters
+    const filters: ComparisonFilterOptions = {
+      locale: (searchParams.get("locale") as "en" | "es") || undefined,
+      species: searchParams.get("species") || undefined,
+      difficulty: searchParams.get("difficulty") || undefined,
+      tag: searchParams.get("tag") || undefined,
+      search: searchParams.get("search") || undefined,
+      page: parseInt(searchParams.get("page") || "1", 10),
+      pageSize: Math.min(
+        Math.max(parseInt(searchParams.get("pageSize") || "20", 10), 1),
+        100
+      ),
+      sort:
+        (searchParams.get("sort") as ComparisonFilterOptions["sort"]) ||
+        "title",
+      order: (searchParams.get("order") as "asc" | "desc") || "asc",
+    };
+
+    let comparisons = [...allSpeciesComparisons];
+
+    // Locale
+    if (filters.locale) {
+      comparisons = comparisons.filter((c) => c.locale === filters.locale);
+    }
+
+    // Species filter — show comparisons involving a given tree slug
+    if (filters.species) {
+      const slug = filters.species.toLowerCase();
+      comparisons = comparisons.filter((c) =>
+        c.species.some((s) => s.toLowerCase() === slug)
+      );
+    }
+
+    // Difficulty filter
+    if (filters.difficulty) {
+      const diff = filters.difficulty.toLowerCase();
+      comparisons = comparisons.filter(
+        (c) => c.difficulty?.toLowerCase() === diff
+      );
+    }
+
+    // Tag filter
+    if (filters.tag) {
+      const tag = filters.tag.toLowerCase();
+      comparisons = comparisons.filter((c) =>
+        c.comparisonTags?.some((t) => t.toLowerCase() === tag)
+      );
+    }
+
+    // Free-text search
+    if (filters.search) {
+      const q = filters.search.toLowerCase();
+      comparisons = comparisons.filter(
+        (c) =>
+          c.title.toLowerCase().includes(q) ||
+          c.description.toLowerCase().includes(q) ||
+          c.keyDifference.toLowerCase().includes(q) ||
+          c.species.some((s) => s.toLowerCase().includes(q))
+      );
+    }
+
+    // Sort
+    const sortField = filters.sort || "title";
+    const sortOrder = filters.order === "desc" ? -1 : 1;
+    comparisons.sort((a, b) => {
+      const aVal = a[sortField as keyof SpeciesComparison] ?? "";
+      const bVal = b[sortField as keyof SpeciesComparison] ?? "";
+      if (typeof aVal === "number" && typeof bVal === "number") {
+        return (aVal - bVal) * sortOrder;
+      }
+      return String(aVal).localeCompare(String(bVal)) * sortOrder;
+    });
+
+    // Pagination
+    const total = comparisons.length;
+    const page = filters.page || 1;
+    const pageSize = filters.pageSize || 20;
+    const totalPages = Math.ceil(total / pageSize) || 1;
+    const offset = (page - 1) * pageSize;
+    const paginated = comparisons.slice(offset, offset + pageSize);
+
+    const data = paginated.map((c) => transformComparison(c, baseUrl));
+
+    const buildUrl = (p: number) => {
+      const params = new URLSearchParams(searchParams);
+      params.set("page", String(p));
+      return `${baseUrl}/api/v1/comparisons?${params}`;
+    };
+
+    const response: PaginatedResponse<ComparisonAPIResponse> = {
+      data,
+      pagination: {
+        page,
+        pageSize,
+        total,
+        totalPages,
+        hasNext: page < totalPages,
+        hasPrev: page > 1,
+      },
+      _links: {
+        self: buildUrl(page),
+        first: buildUrl(1),
+        last: buildUrl(totalPages),
+        ...(page < totalPages && { next: buildUrl(page + 1) }),
+        ...(page > 1 && { prev: buildUrl(page - 1) }),
+      },
+    };
+
+    // Add rate limit + cache headers
+    const clientId = getClientId(request);
+    const rl = checkRateLimit(clientId);
+    const headers = new Headers();
+    addRateLimitHeaders(headers, rl);
+    headers.set("Cache-Control", "public, max-age=300, s-maxage=600");
+
+    return NextResponse.json(response, { headers });
+  } catch (error) {
+    captureApiError(error, "/api/v1/comparisons", "GET");
+    return NextResponse.json(
+      {
+        error: {
+          code: "INTERNAL_ERROR",
+          message: "An unexpected error occurred",
+        },
+        _links: { documentation: "/api/docs" },
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/v1/families/route.ts
+++ b/src/app/api/v1/families/route.ts
@@ -1,57 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
 import { allTrees } from "contentlayer/generated";
 import { captureApiError } from "@/lib/error-tracking";
+import {
+  getClientId,
+  checkRateLimit,
+  addRateLimitHeaders,
+} from "@/lib/api-rate-limit";
 import type { FamiliesResponse } from "@/types/api";
-
-// Rate limiting
-const rateLimitStore = new Map<string, { count: number; resetAt: number }>();
-const RATE_LIMIT = 100;
-const RATE_WINDOW = 60 * 1000;
-
-function getClientId(request: NextRequest): string {
-  const apiKey = request.headers.get("X-API-Key");
-  if (apiKey) return `key:${apiKey}`;
-  const ip =
-    request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
-    request.headers.get("x-real-ip") ||
-    "anonymous";
-  return `ip:${ip}`;
-}
-
-function checkRateLimit(clientId: string): {
-  allowed: boolean;
-  remaining: number;
-  resetAt: number;
-} {
-  const now = Date.now();
-  const record = rateLimitStore.get(clientId);
-  if (!record || record.resetAt < now) {
-    rateLimitStore.set(clientId, { count: 1, resetAt: now + RATE_WINDOW });
-    return {
-      allowed: true,
-      remaining: RATE_LIMIT - 1,
-      resetAt: now + RATE_WINDOW,
-    };
-  }
-  if (record.count >= RATE_LIMIT) {
-    return { allowed: false, remaining: 0, resetAt: record.resetAt };
-  }
-  record.count++;
-  return {
-    allowed: true,
-    remaining: RATE_LIMIT - record.count,
-    resetAt: record.resetAt,
-  };
-}
-
-function addRateLimitHeaders(
-  headers: Headers,
-  rateLimit: { remaining: number; resetAt: number }
-): void {
-  headers.set("X-RateLimit-Limit", String(RATE_LIMIT));
-  headers.set("X-RateLimit-Remaining", String(rateLimit.remaining));
-  headers.set("X-RateLimit-Reset", String(Math.ceil(rateLimit.resetAt / 1000)));
-}
 
 /**
  * GET /api/v1/families - Get all tree families with species count

--- a/src/app/api/v1/glossary/[slug]/route.ts
+++ b/src/app/api/v1/glossary/[slug]/route.ts
@@ -1,0 +1,171 @@
+/**
+ * Public API — Get Single Glossary Term
+ *
+ * GET /api/v1/glossary/[slug] — term with related terms and example species.
+ *
+ * Part of P6.3: Public API for researchers.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { allGlossaryTerms, allTrees } from "contentlayer/generated";
+import { captureApiError } from "@/lib/error-tracking";
+import {
+  rateLimitOrNull,
+  getClientId,
+  checkRateLimit,
+  addRateLimitHeaders,
+} from "@/lib/api-rate-limit";
+
+interface RouteParams {
+  params: Promise<{ slug: string }>;
+}
+
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  const blocked = rateLimitOrNull(request);
+  if (blocked) return blocked;
+
+  try {
+    const { slug } = await params;
+    const { searchParams } = new URL(request.url);
+    const baseUrl = `${request.nextUrl.protocol}//${request.nextUrl.host}`;
+    const locale = searchParams.get("locale") || "en";
+
+    const term = allGlossaryTerms.find(
+      (t) => t.slug === slug && t.locale === locale
+    );
+
+    if (!term) {
+      const any = allGlossaryTerms.find((t) => t.slug === slug);
+      if (any) {
+        const clientId = getClientId(request);
+        const rl = checkRateLimit(clientId);
+        const headers = new Headers();
+        addRateLimitHeaders(headers, rl);
+        return NextResponse.json(
+          {
+            error: {
+              code: "LOCALE_NOT_FOUND",
+              message: `Glossary term "${slug}" not found in locale "${locale}". Available in: ${allGlossaryTerms
+                .filter((t) => t.slug === slug)
+                .map((t) => t.locale)
+                .join(", ")}`,
+            },
+            _links: {
+              documentation: "/api/docs",
+              alternatives: allGlossaryTerms
+                .filter((t) => t.slug === slug)
+                .map(
+                  (t) => `${baseUrl}/api/v1/glossary/${slug}?locale=${t.locale}`
+                ),
+            },
+          },
+          { status: 404, headers }
+        );
+      }
+
+      const clientId = getClientId(request);
+      const rl = checkRateLimit(clientId);
+      const headers = new Headers();
+      addRateLimitHeaders(headers, rl);
+      return NextResponse.json(
+        {
+          error: {
+            code: "NOT_FOUND",
+            message: `Glossary term "${slug}" not found`,
+          },
+          _links: {
+            documentation: "/api/docs",
+            glossary: `${baseUrl}/api/v1/glossary`,
+          },
+        },
+        { status: 404, headers }
+      );
+    }
+
+    // Enrich related terms
+    const relatedTermsData = term.relatedTerms
+      ?.map((rtSlug) => {
+        const rt = allGlossaryTerms.find(
+          (t) => t.slug === rtSlug && t.locale === locale
+        );
+        return rt
+          ? {
+              slug: rt.slug,
+              term: rt.term,
+              simpleDefinition: rt.simpleDefinition,
+              category: rt.category,
+              _links: {
+                self: `${baseUrl}/api/v1/glossary/${rt.slug}?locale=${locale}`,
+                html: `${baseUrl}/${locale}/glossary/${rt.slug}`,
+              },
+            }
+          : null;
+      })
+      .filter(Boolean);
+
+    // Enrich example species
+    const exampleSpeciesData = term.exampleSpecies
+      ?.map((slug) => {
+        const tree = allTrees.find(
+          (t) => t.slug === slug && t.locale === locale
+        );
+        return tree
+          ? {
+              slug: tree.slug,
+              title: tree.title,
+              scientificName: tree.scientificName,
+              _links: {
+                self: `${baseUrl}/api/v1/trees/${tree.slug}?locale=${locale}`,
+                html: `${baseUrl}/${locale}/trees/${tree.slug}`,
+              },
+            }
+          : null;
+      })
+      .filter(Boolean);
+
+    const data = {
+      slug: term.slug,
+      locale: term.locale,
+      term: term.term,
+      simpleDefinition: term.simpleDefinition,
+      technicalDefinition: term.technicalDefinition,
+      category: term.category,
+      pronunciation: term.pronunciation,
+      etymology: term.etymology,
+      exampleSpecies: term.exampleSpecies,
+      relatedTerms: term.relatedTerms,
+      image: term.image,
+      publishedAt: term.publishedAt,
+      _links: {
+        self: `${baseUrl}/api/v1/glossary/${term.slug}?locale=${locale}`,
+        html: `${baseUrl}/${locale}/glossary/${term.slug}`,
+      },
+      _embedded: {
+        ...(relatedTermsData?.length && { relatedTerms: relatedTermsData }),
+        ...(exampleSpeciesData?.length && {
+          exampleSpecies: exampleSpeciesData,
+        }),
+      },
+    };
+
+    const clientId = getClientId(request);
+    const rl = checkRateLimit(clientId);
+    const headers = new Headers();
+    addRateLimitHeaders(headers, rl);
+    headers.set("Cache-Control", "public, max-age=300, s-maxage=600");
+
+    return NextResponse.json({ data }, { headers });
+  } catch (error) {
+    captureApiError(error, "/api/v1/glossary/[slug]", "GET");
+    return NextResponse.json(
+      {
+        error: {
+          code: "INTERNAL_ERROR",
+          message: "An unexpected error occurred",
+        },
+        _links: { documentation: "/api/docs" },
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/v1/glossary/route.ts
+++ b/src/app/api/v1/glossary/route.ts
@@ -1,0 +1,178 @@
+/**
+ * Public API — List Glossary Terms
+ *
+ * GET /api/v1/glossary — paginated list with filtering by category and search.
+ *
+ * Part of P6.3: Public API for researchers.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { allGlossaryTerms, type GlossaryTerm } from "contentlayer/generated";
+import { captureApiError } from "@/lib/error-tracking";
+import {
+  rateLimitOrNull,
+  getClientId,
+  checkRateLimit,
+  addRateLimitHeaders,
+} from "@/lib/api-rate-limit";
+import type {
+  GlossaryAPIResponse,
+  GlossaryFilterOptions,
+  PaginatedResponse,
+} from "@/types/api";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function transformGlossaryTerm(
+  t: GlossaryTerm,
+  baseUrl: string
+): GlossaryAPIResponse {
+  return {
+    slug: t.slug,
+    locale: t.locale,
+    term: t.term,
+    simpleDefinition: t.simpleDefinition,
+    technicalDefinition: t.technicalDefinition,
+    category: t.category,
+    pronunciation: t.pronunciation,
+    etymology: t.etymology,
+    exampleSpecies: t.exampleSpecies,
+    relatedTerms: t.relatedTerms,
+    image: t.image,
+    publishedAt: t.publishedAt,
+    _links: {
+      self: `${baseUrl}/api/v1/glossary/${t.slug}?locale=${t.locale}`,
+      html: `${baseUrl}/${t.locale}/glossary/${t.slug}`,
+      ...(t.relatedTerms?.length && {
+        relatedTerms: t.relatedTerms.map((rt) => ({
+          slug: rt,
+          url: `${baseUrl}/api/v1/glossary/${rt}?locale=${t.locale}`,
+        })),
+      }),
+      ...(t.exampleSpecies?.length && {
+        exampleSpecies: t.exampleSpecies.map((es) => ({
+          slug: es,
+          url: `${baseUrl}/api/v1/trees/${es}?locale=${t.locale}`,
+        })),
+      }),
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Route
+// ---------------------------------------------------------------------------
+
+export async function GET(request: NextRequest) {
+  const blocked = rateLimitOrNull(request);
+  if (blocked) return blocked;
+
+  try {
+    const { searchParams } = new URL(request.url);
+    const baseUrl = `${request.nextUrl.protocol}//${request.nextUrl.host}`;
+
+    const filters: GlossaryFilterOptions = {
+      locale: (searchParams.get("locale") as "en" | "es") || undefined,
+      category: searchParams.get("category") || undefined,
+      search: searchParams.get("search") || undefined,
+      page: parseInt(searchParams.get("page") || "1", 10),
+      pageSize: Math.min(
+        Math.max(parseInt(searchParams.get("pageSize") || "20", 10), 1),
+        100
+      ),
+      sort:
+        (searchParams.get("sort") as GlossaryFilterOptions["sort"]) || "term",
+      order: (searchParams.get("order") as "asc" | "desc") || "asc",
+    };
+
+    let terms = [...allGlossaryTerms];
+
+    // Locale
+    if (filters.locale) {
+      terms = terms.filter((t) => t.locale === filters.locale);
+    }
+
+    // Category filter
+    if (filters.category) {
+      const cat = filters.category.toLowerCase();
+      terms = terms.filter((t) => t.category.toLowerCase() === cat);
+    }
+
+    // Free-text search
+    if (filters.search) {
+      const q = filters.search.toLowerCase();
+      terms = terms.filter(
+        (t) =>
+          t.term.toLowerCase().includes(q) ||
+          t.simpleDefinition.toLowerCase().includes(q) ||
+          t.technicalDefinition?.toLowerCase().includes(q)
+      );
+    }
+
+    // Sort
+    const sortField = filters.sort || "term";
+    const sortOrder = filters.order === "desc" ? -1 : 1;
+    terms.sort((a, b) => {
+      const aVal = a[sortField as keyof GlossaryTerm] ?? "";
+      const bVal = b[sortField as keyof GlossaryTerm] ?? "";
+      return String(aVal).localeCompare(String(bVal)) * sortOrder;
+    });
+
+    // Pagination
+    const total = terms.length;
+    const page = filters.page || 1;
+    const pageSize = filters.pageSize || 20;
+    const totalPages = Math.ceil(total / pageSize) || 1;
+    const offset = (page - 1) * pageSize;
+    const paginated = terms.slice(offset, offset + pageSize);
+
+    const data = paginated.map((t) => transformGlossaryTerm(t, baseUrl));
+
+    const buildUrl = (p: number) => {
+      const params = new URLSearchParams(searchParams);
+      params.set("page", String(p));
+      return `${baseUrl}/api/v1/glossary?${params}`;
+    };
+
+    const response: PaginatedResponse<GlossaryAPIResponse> = {
+      data,
+      pagination: {
+        page,
+        pageSize,
+        total,
+        totalPages,
+        hasNext: page < totalPages,
+        hasPrev: page > 1,
+      },
+      _links: {
+        self: buildUrl(page),
+        first: buildUrl(1),
+        last: buildUrl(totalPages),
+        ...(page < totalPages && { next: buildUrl(page + 1) }),
+        ...(page > 1 && { prev: buildUrl(page - 1) }),
+      },
+    };
+
+    const clientId = getClientId(request);
+    const rl = checkRateLimit(clientId);
+    const headers = new Headers();
+    addRateLimitHeaders(headers, rl);
+    headers.set("Cache-Control", "public, max-age=300, s-maxage=600");
+
+    return NextResponse.json(response, { headers });
+  } catch (error) {
+    captureApiError(error, "/api/v1/glossary", "GET");
+    return NextResponse.json(
+      {
+        error: {
+          code: "INTERNAL_ERROR",
+          message: "An unexpected error occurred",
+        },
+        _links: { documentation: "/api/docs" },
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/v1/openapi.json/route.ts
+++ b/src/app/api/v1/openapi.json/route.ts
@@ -1,0 +1,659 @@
+/**
+ * OpenAPI 3.1 Specification
+ *
+ * GET /api/v1/openapi.json — machine-readable API documentation.
+ *
+ * Part of P6.3: Public API for researchers.
+ */
+
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-static";
+
+const SPEC = {
+  openapi: "3.1.0",
+  info: {
+    title: "Costa Rica Tree Atlas API",
+    version: "1.0.0",
+    description:
+      "Public REST API for accessing Costa Rica tree species data, species comparisons, and botanical glossary terms. Free to use for research, education, and application development.",
+    license: {
+      name: "CC BY-NC-SA 4.0",
+      url: "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+    },
+    contact: {
+      name: "Costa Rica Tree Atlas",
+      url: "https://costaricatreeatlas.com",
+    },
+  },
+  servers: [
+    {
+      url: "https://costaricatreeatlas.com/api/v1",
+      description: "Production",
+    },
+  ],
+  paths: {
+    "/trees": {
+      get: {
+        operationId: "listTrees",
+        summary: "List tree species",
+        description:
+          "Retrieve a paginated list of tree species with optional filtering and sorting.",
+        tags: ["Trees"],
+        parameters: [
+          { $ref: "#/components/parameters/locale" },
+          {
+            name: "family",
+            in: "query",
+            schema: { type: "string" },
+            description: "Filter by botanical family name",
+          },
+          {
+            name: "conservationStatus",
+            in: "query",
+            schema: {
+              type: "string",
+              enum: ["LC", "NT", "VU", "EN", "CR", "EW", "EX", "DD", "NE"],
+            },
+            description: "Filter by IUCN conservation status",
+          },
+          {
+            name: "tag",
+            in: "query",
+            schema: { type: "string" },
+            description: "Filter by tag",
+          },
+          {
+            name: "distribution",
+            in: "query",
+            schema: { type: "string" },
+            description:
+              "Filter by distribution region (e.g., guanacaste, limon)",
+          },
+          {
+            name: "floweringSeason",
+            in: "query",
+            schema: { type: "string" },
+            description: "Filter by flowering month (e.g., january)",
+          },
+          {
+            name: "fruitingSeason",
+            in: "query",
+            schema: { type: "string" },
+            description: "Filter by fruiting month",
+          },
+          {
+            name: "search",
+            in: "query",
+            schema: { type: "string" },
+            description:
+              "Free-text search across title, scientific name, and description",
+          },
+          { $ref: "#/components/parameters/page" },
+          { $ref: "#/components/parameters/pageSize" },
+          {
+            name: "sort",
+            in: "query",
+            schema: {
+              type: "string",
+              enum: ["title", "scientificName", "family", "updatedAt"],
+              default: "title",
+            },
+          },
+          { $ref: "#/components/parameters/order" },
+        ],
+        responses: {
+          "200": {
+            description: "Paginated list of trees",
+            content: {
+              "application/json": {
+                schema: {
+                  allOf: [
+                    { $ref: "#/components/schemas/PaginatedResponse" },
+                    {
+                      type: "object",
+                      properties: {
+                        data: {
+                          type: "array",
+                          items: { $ref: "#/components/schemas/Tree" },
+                        },
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+          "429": { $ref: "#/components/responses/RateLimited" },
+          "500": { $ref: "#/components/responses/InternalError" },
+        },
+      },
+    },
+    "/trees/{slug}": {
+      get: {
+        operationId: "getTree",
+        summary: "Get a single tree",
+        description:
+          "Retrieve detailed information about a specific tree species by its slug.",
+        tags: ["Trees"],
+        parameters: [
+          {
+            name: "slug",
+            in: "path",
+            required: true,
+            schema: { type: "string" },
+            description: "Tree slug identifier (e.g., ceiba)",
+          },
+          { $ref: "#/components/parameters/locale" },
+        ],
+        responses: {
+          "200": {
+            description: "Tree details with related species",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    data: { $ref: "#/components/schemas/Tree" },
+                    _related: {
+                      type: "array",
+                      items: { $ref: "#/components/schemas/RelatedTree" },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          "404": { $ref: "#/components/responses/NotFound" },
+          "429": { $ref: "#/components/responses/RateLimited" },
+        },
+      },
+    },
+    "/families": {
+      get: {
+        operationId: "listFamilies",
+        summary: "List botanical families",
+        description:
+          "Get all botanical families with species counts for a given locale.",
+        tags: ["Trees"],
+        parameters: [{ $ref: "#/components/parameters/locale" }],
+        responses: {
+          "200": {
+            description: "List of families",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    data: {
+                      type: "array",
+                      items: {
+                        type: "object",
+                        properties: {
+                          name: { type: "string" },
+                          speciesCount: { type: "integer" },
+                          _links: {
+                            type: "object",
+                            properties: { species: { type: "string" } },
+                          },
+                        },
+                      },
+                    },
+                    meta: {
+                      type: "object",
+                      properties: {
+                        totalFamilies: { type: "integer" },
+                        totalSpecies: { type: "integer" },
+                        locale: { type: "string" },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          "429": { $ref: "#/components/responses/RateLimited" },
+        },
+      },
+    },
+    "/comparisons": {
+      get: {
+        operationId: "listComparisons",
+        summary: "List species comparisons",
+        description:
+          "Retrieve a paginated list of species comparison guides with optional filtering.",
+        tags: ["Comparisons"],
+        parameters: [
+          { $ref: "#/components/parameters/locale" },
+          {
+            name: "species",
+            in: "query",
+            schema: { type: "string" },
+            description:
+              "Filter by tree slug — returns comparisons involving this species",
+          },
+          {
+            name: "difficulty",
+            in: "query",
+            schema: {
+              type: "string",
+              enum: ["easy", "moderate", "challenging"],
+            },
+            description: "Filter by difficulty level",
+          },
+          {
+            name: "tag",
+            in: "query",
+            schema: { type: "string" },
+            description:
+              "Filter by comparison tag (leaves, bark, fruit, flowers, etc.)",
+          },
+          {
+            name: "search",
+            in: "query",
+            schema: { type: "string" },
+            description: "Free-text search across title and description",
+          },
+          { $ref: "#/components/parameters/page" },
+          { $ref: "#/components/parameters/pageSize" },
+          { $ref: "#/components/parameters/order" },
+        ],
+        responses: {
+          "200": {
+            description: "Paginated list of comparisons",
+            content: {
+              "application/json": {
+                schema: {
+                  allOf: [
+                    { $ref: "#/components/schemas/PaginatedResponse" },
+                    {
+                      type: "object",
+                      properties: {
+                        data: {
+                          type: "array",
+                          items: { $ref: "#/components/schemas/Comparison" },
+                        },
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+          "429": { $ref: "#/components/responses/RateLimited" },
+        },
+      },
+    },
+    "/comparisons/{slug}": {
+      get: {
+        operationId: "getComparison",
+        summary: "Get a single comparison",
+        description:
+          "Retrieve detailed info about a species comparison including embedded species data.",
+        tags: ["Comparisons"],
+        parameters: [
+          {
+            name: "slug",
+            in: "path",
+            required: true,
+            schema: { type: "string" },
+          },
+          { $ref: "#/components/parameters/locale" },
+        ],
+        responses: {
+          "200": {
+            description: "Comparison details with embedded species data",
+          },
+          "404": { $ref: "#/components/responses/NotFound" },
+          "429": { $ref: "#/components/responses/RateLimited" },
+        },
+      },
+    },
+    "/glossary": {
+      get: {
+        operationId: "listGlossary",
+        summary: "List glossary terms",
+        description:
+          "Retrieve a paginated list of botanical glossary terms with optional filtering.",
+        tags: ["Glossary"],
+        parameters: [
+          { $ref: "#/components/parameters/locale" },
+          {
+            name: "category",
+            in: "query",
+            schema: {
+              type: "string",
+              enum: [
+                "anatomy",
+                "ecology",
+                "taxonomy",
+                "morphology",
+                "reproduction",
+                "general",
+                "timber",
+              ],
+            },
+            description: "Filter by glossary category",
+          },
+          {
+            name: "search",
+            in: "query",
+            schema: { type: "string" },
+            description: "Free-text search across term and definitions",
+          },
+          { $ref: "#/components/parameters/page" },
+          { $ref: "#/components/parameters/pageSize" },
+          { $ref: "#/components/parameters/order" },
+        ],
+        responses: {
+          "200": {
+            description: "Paginated list of glossary terms",
+            content: {
+              "application/json": {
+                schema: {
+                  allOf: [
+                    { $ref: "#/components/schemas/PaginatedResponse" },
+                    {
+                      type: "object",
+                      properties: {
+                        data: {
+                          type: "array",
+                          items: { $ref: "#/components/schemas/GlossaryTerm" },
+                        },
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+          "429": { $ref: "#/components/responses/RateLimited" },
+        },
+      },
+    },
+    "/glossary/{slug}": {
+      get: {
+        operationId: "getGlossaryTerm",
+        summary: "Get a single glossary term",
+        description:
+          "Retrieve detailed info about a glossary term with embedded related terms and example species.",
+        tags: ["Glossary"],
+        parameters: [
+          {
+            name: "slug",
+            in: "path",
+            required: true,
+            schema: { type: "string" },
+          },
+          { $ref: "#/components/parameters/locale" },
+        ],
+        responses: {
+          "200": {
+            description: "Glossary term details with embedded data",
+          },
+          "404": { $ref: "#/components/responses/NotFound" },
+          "429": { $ref: "#/components/responses/RateLimited" },
+        },
+      },
+    },
+  },
+  components: {
+    parameters: {
+      locale: {
+        name: "locale",
+        in: "query",
+        schema: { type: "string", enum: ["en", "es"], default: "en" },
+        description: "Language code",
+      },
+      page: {
+        name: "page",
+        in: "query",
+        schema: { type: "integer", minimum: 1, default: 1 },
+        description: "Page number",
+      },
+      pageSize: {
+        name: "pageSize",
+        in: "query",
+        schema: { type: "integer", minimum: 1, maximum: 100, default: 20 },
+        description: "Items per page (max 100)",
+      },
+      order: {
+        name: "order",
+        in: "query",
+        schema: { type: "string", enum: ["asc", "desc"], default: "asc" },
+        description: "Sort order",
+      },
+    },
+    schemas: {
+      Tree: {
+        type: "object",
+        properties: {
+          slug: { type: "string", example: "ceiba" },
+          locale: { type: "string", example: "en" },
+          title: { type: "string", example: "Ceiba" },
+          scientificName: {
+            type: "string",
+            example: "Ceiba pentandra",
+          },
+          family: { type: "string", example: "Malvaceae" },
+          description: { type: "string" },
+          nativeRegion: { type: "string" },
+          maxHeight: { type: "string" },
+          elevation: { type: "string" },
+          conservationStatus: { type: "string", example: "LC" },
+          uses: { type: "array", items: { type: "string" } },
+          tags: { type: "array", items: { type: "string" } },
+          distribution: { type: "array", items: { type: "string" } },
+          floweringSeason: { type: "array", items: { type: "string" } },
+          fruitingSeason: { type: "array", items: { type: "string" } },
+          toxicityLevel: { type: "string" },
+          featuredImage: { type: "string" },
+          publishedAt: { type: "string", format: "date" },
+          updatedAt: { type: "string", format: "date" },
+          _links: {
+            type: "object",
+            properties: {
+              self: { type: "string" },
+              html: { type: "string" },
+            },
+          },
+        },
+        required: [
+          "slug",
+          "locale",
+          "title",
+          "scientificName",
+          "family",
+          "description",
+        ],
+      },
+      RelatedTree: {
+        type: "object",
+        properties: {
+          slug: { type: "string" },
+          title: { type: "string" },
+          scientificName: { type: "string" },
+          _links: {
+            type: "object",
+            properties: { self: { type: "string" } },
+          },
+        },
+      },
+      Comparison: {
+        type: "object",
+        properties: {
+          slug: { type: "string" },
+          locale: { type: "string" },
+          title: { type: "string" },
+          species: { type: "array", items: { type: "string" } },
+          keyDifference: { type: "string" },
+          description: { type: "string" },
+          difficulty: {
+            type: "string",
+            enum: ["easy", "moderate", "challenging"],
+          },
+          confusionRating: { type: "integer", minimum: 1, maximum: 5 },
+          comparisonTags: { type: "array", items: { type: "string" } },
+          seasonalNote: { type: "string" },
+          _links: {
+            type: "object",
+            properties: {
+              self: { type: "string" },
+              html: { type: "string" },
+            },
+          },
+        },
+        required: [
+          "slug",
+          "locale",
+          "title",
+          "species",
+          "keyDifference",
+          "description",
+        ],
+      },
+      GlossaryTerm: {
+        type: "object",
+        properties: {
+          slug: { type: "string" },
+          locale: { type: "string" },
+          term: { type: "string" },
+          simpleDefinition: { type: "string" },
+          technicalDefinition: { type: "string" },
+          category: {
+            type: "string",
+            enum: [
+              "anatomy",
+              "ecology",
+              "taxonomy",
+              "morphology",
+              "reproduction",
+              "general",
+              "timber",
+            ],
+          },
+          pronunciation: { type: "string" },
+          etymology: { type: "string" },
+          exampleSpecies: { type: "array", items: { type: "string" } },
+          relatedTerms: { type: "array", items: { type: "string" } },
+          _links: {
+            type: "object",
+            properties: {
+              self: { type: "string" },
+              html: { type: "string" },
+            },
+          },
+        },
+        required: ["slug", "locale", "term", "simpleDefinition", "category"],
+      },
+      PaginatedResponse: {
+        type: "object",
+        properties: {
+          pagination: {
+            type: "object",
+            properties: {
+              page: { type: "integer" },
+              pageSize: { type: "integer" },
+              total: { type: "integer" },
+              totalPages: { type: "integer" },
+              hasNext: { type: "boolean" },
+              hasPrev: { type: "boolean" },
+            },
+          },
+          _links: {
+            type: "object",
+            properties: {
+              self: { type: "string" },
+              first: { type: "string" },
+              last: { type: "string" },
+              next: { type: "string" },
+              prev: { type: "string" },
+            },
+          },
+        },
+      },
+      Error: {
+        type: "object",
+        properties: {
+          error: {
+            type: "object",
+            properties: {
+              code: { type: "string" },
+              message: { type: "string" },
+              details: { type: "object" },
+            },
+            required: ["code", "message"],
+          },
+          _links: {
+            type: "object",
+            properties: { documentation: { type: "string" } },
+          },
+        },
+      },
+    },
+    responses: {
+      RateLimited: {
+        description: "Rate limit exceeded (100 requests per minute)",
+        content: {
+          "application/json": {
+            schema: { $ref: "#/components/schemas/Error" },
+          },
+        },
+        headers: {
+          "X-RateLimit-Limit": {
+            schema: { type: "integer" },
+            description: "Max requests per window",
+          },
+          "X-RateLimit-Remaining": {
+            schema: { type: "integer" },
+            description: "Remaining requests in window",
+          },
+          "X-RateLimit-Reset": {
+            schema: { type: "integer" },
+            description: "Unix timestamp when window resets",
+          },
+        },
+      },
+      NotFound: {
+        description: "Resource not found",
+        content: {
+          "application/json": {
+            schema: { $ref: "#/components/schemas/Error" },
+          },
+        },
+      },
+      InternalError: {
+        description: "Internal server error",
+        content: {
+          "application/json": {
+            schema: { $ref: "#/components/schemas/Error" },
+          },
+        },
+      },
+    },
+  },
+  tags: [
+    {
+      name: "Trees",
+      description: "Tree species data — 175 species documented in EN and ES",
+    },
+    {
+      name: "Comparisons",
+      description:
+        "Species comparison guides — side-by-side identification help",
+    },
+    {
+      name: "Glossary",
+      description: "Botanical glossary — 150 terms with definitions",
+    },
+  ],
+};
+
+export function GET() {
+  return NextResponse.json(SPEC, {
+    headers: {
+      "Cache-Control": "public, max-age=86400, s-maxage=86400",
+      "Access-Control-Allow-Origin": "*",
+    },
+  });
+}

--- a/src/app/api/v1/trees/[slug]/route.ts
+++ b/src/app/api/v1/trees/[slug]/route.ts
@@ -1,57 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
 import { allTrees, type Tree } from "contentlayer/generated";
 import { captureApiError } from "@/lib/error-tracking";
+import {
+  getClientId,
+  checkRateLimit,
+  addRateLimitHeaders,
+} from "@/lib/api-rate-limit";
 import type { TreeAPIResponse } from "@/types/api";
-
-// Rate limiting (shared with parent route)
-const rateLimitStore = new Map<string, { count: number; resetAt: number }>();
-const RATE_LIMIT = 100;
-const RATE_WINDOW = 60 * 1000;
-
-function getClientId(request: NextRequest): string {
-  const apiKey = request.headers.get("X-API-Key");
-  if (apiKey) return `key:${apiKey}`;
-  const ip =
-    request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
-    request.headers.get("x-real-ip") ||
-    "anonymous";
-  return `ip:${ip}`;
-}
-
-function checkRateLimit(clientId: string): {
-  allowed: boolean;
-  remaining: number;
-  resetAt: number;
-} {
-  const now = Date.now();
-  const record = rateLimitStore.get(clientId);
-  if (!record || record.resetAt < now) {
-    rateLimitStore.set(clientId, { count: 1, resetAt: now + RATE_WINDOW });
-    return {
-      allowed: true,
-      remaining: RATE_LIMIT - 1,
-      resetAt: now + RATE_WINDOW,
-    };
-  }
-  if (record.count >= RATE_LIMIT) {
-    return { allowed: false, remaining: 0, resetAt: record.resetAt };
-  }
-  record.count++;
-  return {
-    allowed: true,
-    remaining: RATE_LIMIT - record.count,
-    resetAt: record.resetAt,
-  };
-}
-
-function addRateLimitHeaders(
-  headers: Headers,
-  rateLimit: { remaining: number; resetAt: number }
-): void {
-  headers.set("X-RateLimit-Limit", String(RATE_LIMIT));
-  headers.set("X-RateLimit-Remaining", String(rateLimit.remaining));
-  headers.set("X-RateLimit-Reset", String(Math.ceil(rateLimit.resetAt / 1000)));
-}
 
 function transformTree(tree: Tree, baseUrl: string): TreeAPIResponse {
   return {

--- a/src/app/api/v1/trees/route.ts
+++ b/src/app/api/v1/trees/route.ts
@@ -1,79 +1,16 @@
 import { NextRequest, NextResponse } from "next/server";
 import { allTrees, type Tree } from "contentlayer/generated";
 import { captureApiError } from "@/lib/error-tracking";
+import {
+  getClientId,
+  checkRateLimit,
+  addRateLimitHeaders,
+} from "@/lib/api-rate-limit";
 import type {
   TreeAPIResponse,
   PaginatedResponse,
   TreeFilterOptions,
 } from "@/types/api";
-
-// Rate limiting: simple in-memory store (use Redis/Upstash in production)
-const rateLimitStore = new Map<string, { count: number; resetAt: number }>();
-const RATE_LIMIT = 100; // requests per window
-const RATE_WINDOW = 60 * 1000; // 1 minute
-
-/**
- * Get client identifier for rate limiting
- */
-function getClientId(request: NextRequest): string {
-  // Check for API key first
-  const apiKey = request.headers.get("X-API-Key");
-  if (apiKey) {
-    return `key:${apiKey}`;
-  }
-
-  // Fall back to IP
-  const ip =
-    request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
-    request.headers.get("x-real-ip") ||
-    "anonymous";
-  return `ip:${ip}`;
-}
-
-/**
- * Check rate limit
- */
-function checkRateLimit(clientId: string): {
-  allowed: boolean;
-  remaining: number;
-  resetAt: number;
-} {
-  const now = Date.now();
-  const record = rateLimitStore.get(clientId);
-
-  if (!record || record.resetAt < now) {
-    // New window
-    rateLimitStore.set(clientId, { count: 1, resetAt: now + RATE_WINDOW });
-    return {
-      allowed: true,
-      remaining: RATE_LIMIT - 1,
-      resetAt: now + RATE_WINDOW,
-    };
-  }
-
-  if (record.count >= RATE_LIMIT) {
-    return { allowed: false, remaining: 0, resetAt: record.resetAt };
-  }
-
-  record.count++;
-  return {
-    allowed: true,
-    remaining: RATE_LIMIT - record.count,
-    resetAt: record.resetAt,
-  };
-}
-
-/**
- * Add rate limit headers to response
- */
-function addRateLimitHeaders(
-  headers: Headers,
-  rateLimit: { remaining: number; resetAt: number }
-): void {
-  headers.set("X-RateLimit-Limit", String(RATE_LIMIT));
-  headers.set("X-RateLimit-Remaining", String(rateLimit.remaining));
-  headers.set("X-RateLimit-Reset", String(Math.ceil(rateLimit.resetAt / 1000)));
-}
 
 /**
  * Transform tree to API response format

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -10,10 +10,11 @@ export async function register() {
   // Initialize Sentry on the server side when DSN is configured
   if (process.env.NEXT_PUBLIC_SENTRY_DSN) {
     try {
-      // Dynamic require to avoid compile-time resolution —
-      // @sentry/nextjs may not be installed yet
+      // Module name in a variable to prevent Turbopack from statically
+      // resolving the optional dependency and emitting build warnings.
+      const sentryModule = ["@sentry", "nextjs"].join("/");
       // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const Sentry = require("@sentry/nextjs") as {
+      const Sentry = require(sentryModule) as {
         init: (options: Record<string, unknown>) => void;
       };
 

--- a/src/lib/api-rate-limit.ts
+++ b/src/lib/api-rate-limit.ts
@@ -1,0 +1,134 @@
+/**
+ * Shared Rate Limiter for Public API v1 Routes
+ *
+ * Simple in-memory rate limiter for the public API.
+ * For production scale, replace with Redis/Upstash (see @/lib/ratelimit).
+ *
+ * Supports X-API-Key header for client identification.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+const RATE_LIMIT = 100; // requests per window
+const RATE_WINDOW = 60 * 1000; // 1 minute in ms
+
+// ---------------------------------------------------------------------------
+// In-memory store (shared across all v1 routes within one instance)
+// ---------------------------------------------------------------------------
+
+const store = new Map<string, { count: number; resetAt: number }>();
+
+// Periodic cleanup to prevent memory leaks in long-running processes
+const CLEANUP_INTERVAL = 5 * 60 * 1000; // 5 minutes
+let lastCleanup = Date.now();
+
+function cleanupExpired(): void {
+  const now = Date.now();
+  if (now - lastCleanup < CLEANUP_INTERVAL) return;
+  lastCleanup = now;
+  for (const [key, record] of store) {
+    if (record.resetAt < now) store.delete(key);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public helpers
+// ---------------------------------------------------------------------------
+
+/** Derive a stable client identifier from the request. */
+export function getClientId(request: NextRequest): string {
+  const apiKey = request.headers.get("X-API-Key");
+  if (apiKey) return `key:${apiKey}`;
+
+  const ip =
+    request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+    request.headers.get("x-real-ip") ||
+    "anonymous";
+  return `ip:${ip}`;
+}
+
+export interface RateLimitResult {
+  allowed: boolean;
+  remaining: number;
+  resetAt: number;
+}
+
+/** Check (and consume) one request for the given client. */
+export function checkRateLimit(clientId: string): RateLimitResult {
+  cleanupExpired();
+  const now = Date.now();
+  const record = store.get(clientId);
+
+  if (!record || record.resetAt < now) {
+    store.set(clientId, { count: 1, resetAt: now + RATE_WINDOW });
+    return {
+      allowed: true,
+      remaining: RATE_LIMIT - 1,
+      resetAt: now + RATE_WINDOW,
+    };
+  }
+
+  if (record.count >= RATE_LIMIT) {
+    return { allowed: false, remaining: 0, resetAt: record.resetAt };
+  }
+
+  record.count++;
+  return {
+    allowed: true,
+    remaining: RATE_LIMIT - record.count,
+    resetAt: record.resetAt,
+  };
+}
+
+/** Append standard X-RateLimit-* headers. */
+export function addRateLimitHeaders(
+  headers: Headers,
+  result: RateLimitResult
+): void {
+  headers.set("X-RateLimit-Limit", String(RATE_LIMIT));
+  headers.set("X-RateLimit-Remaining", String(result.remaining));
+  headers.set("X-RateLimit-Reset", String(Math.ceil(result.resetAt / 1000)));
+}
+
+/**
+ * Convenience: if rate-limited, return a 429 response; otherwise null.
+ * Usage:
+ *   const blocked = rateLimitOrNull(request);
+ *   if (blocked) return blocked;
+ */
+export function rateLimitOrNull(request: NextRequest): NextResponse | null {
+  const clientId = getClientId(request);
+  const rl = checkRateLimit(clientId);
+
+  if (!rl.allowed) {
+    const headers = new Headers();
+    addRateLimitHeaders(headers, rl);
+    return NextResponse.json(
+      {
+        error: {
+          code: "RATE_LIMIT_EXCEEDED",
+          message: "Too many requests. Please try again later.",
+          details: {
+            retryAfter: Math.ceil((rl.resetAt - Date.now()) / 1000),
+          },
+        },
+        _links: { documentation: "/api/docs" },
+      },
+      { status: 429, headers }
+    );
+  }
+
+  return null;
+}
+
+/**
+ * Get rate-limit result for adding headers to successful responses.
+ */
+export function getRateLimitResult(request: NextRequest): RateLimitResult {
+  const clientId = getClientId(request);
+  return checkRateLimit(clientId);
+}

--- a/src/lib/error-tracking.ts
+++ b/src/lib/error-tracking.ts
@@ -25,6 +25,10 @@ interface ErrorContext {
 let _sentry: any = null;
 let _sentryChecked = false;
 
+// Module name in a variable to prevent Turbopack from statically
+// resolving the optional dependency and emitting build warnings.
+const SENTRY_MODULE = ["@sentry", "nextjs"].join("/");
+
 /**
  * Attempt to load @sentry/nextjs dynamically.
  * Returns null if the package is not installed or DSN is not configured.
@@ -38,7 +42,7 @@ function getSentry(): any {
 
   try {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
-    _sentry = require("@sentry/nextjs");
+    _sentry = require(SENTRY_MODULE);
     return _sentry;
   } catch {
     // @sentry/nextjs not installed — that's fine, fall back to console

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -217,3 +217,94 @@ export const VALID_SORT_FIELDS = [
   "family",
   "updatedAt",
 ] as const;
+
+// ---------------------------------------------------------------------------
+// Comparison types
+// ---------------------------------------------------------------------------
+
+/**
+ * Comparison data returned by the API
+ */
+export interface ComparisonAPIResponse {
+  slug: string;
+  locale: string;
+  title: string;
+  species: string[];
+  keyDifference: string;
+  description: string;
+  difficulty?: string;
+  confusionRating?: number;
+  comparisonTags?: string[];
+  seasonalNote?: string;
+  publishedAt?: string;
+  _links: {
+    self: string;
+    html: string;
+    species: { slug: string; url: string }[];
+  };
+}
+
+/**
+ * Filter options for comparison listing
+ */
+export interface ComparisonFilterOptions {
+  locale?: "en" | "es";
+  species?: string;
+  difficulty?: string;
+  tag?: string;
+  search?: string;
+  page?: number;
+  pageSize?: number;
+  sort?: "title" | "difficulty" | "confusionRating";
+  order?: "asc" | "desc";
+}
+
+// ---------------------------------------------------------------------------
+// Glossary types
+// ---------------------------------------------------------------------------
+
+/**
+ * Glossary term data returned by the API
+ */
+export interface GlossaryAPIResponse {
+  slug: string;
+  locale: string;
+  term: string;
+  simpleDefinition: string;
+  technicalDefinition?: string;
+  category: string;
+  pronunciation?: string;
+  etymology?: string;
+  exampleSpecies?: string[];
+  relatedTerms?: string[];
+  image?: string;
+  publishedAt?: string;
+  _links: {
+    self: string;
+    html: string;
+    relatedTerms?: { slug: string; url: string }[];
+    exampleSpecies?: { slug: string; url: string }[];
+  };
+}
+
+/**
+ * Filter options for glossary listing
+ */
+export interface GlossaryFilterOptions {
+  locale?: "en" | "es";
+  category?: string;
+  search?: string;
+  page?: number;
+  pageSize?: number;
+  sort?: "term" | "category";
+  order?: "asc" | "desc";
+}
+
+/**
+ * Glossary categories response
+ */
+export interface GlossaryCategoriesResponse {
+  data: { name: string; termCount: number; _links: { terms: string } }[];
+  meta: { totalCategories: number; totalTerms: number; locale: string };
+  _links: { self: string; glossary: string };
+}

--- a/tests/api/v1-comparisons-slug.test.ts
+++ b/tests/api/v1-comparisons-slug.test.ts
@@ -1,0 +1,168 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockComparisons = [
+  {
+    slug: "ceiba-vs-pochote",
+    locale: "en",
+    title: "Ceiba vs Pochote",
+    species: ["ceiba", "pochote"],
+    keyDifference: "Trunk spines differ",
+    description: "How to tell Ceiba and Pochote apart",
+    difficulty: "moderate",
+    confusionRating: 4,
+    comparisonTags: ["trunk", "bark"],
+    seasonalNote: "Best when leafless",
+    publishedAt: "2025-01-15",
+  },
+  {
+    slug: "ceiba-vs-pochote",
+    locale: "es",
+    title: "Ceiba vs Pochote",
+    species: ["ceiba", "pochote"],
+    keyDifference: "Las espinas difieren",
+    description: "Cómo distinguir la Ceiba del Pochote",
+    difficulty: "moderate",
+    confusionRating: 4,
+    comparisonTags: ["trunk", "bark"],
+    seasonalNote: "Mejor sin hojas",
+    publishedAt: "2025-01-15",
+  },
+];
+
+const mockTrees = [
+  {
+    slug: "ceiba",
+    locale: "en",
+    title: "Ceiba",
+    scientificName: "Ceiba pentandra",
+    family: "Malvaceae",
+    description: "The magnificent ceiba tree",
+  },
+  {
+    slug: "pochote",
+    locale: "en",
+    title: "Pochote",
+    scientificName: "Pachira quinata",
+    family: "Malvaceae",
+    description: "A spiny tropical tree",
+  },
+];
+
+vi.mock("contentlayer/generated", () => ({
+  allSpeciesComparisons: mockComparisons,
+  allTrees: mockTrees,
+}));
+
+const { GET } = await import("@/app/api/v1/comparisons/[slug]/route");
+
+function createRequest(path: string): NextRequest {
+  return new NextRequest(new URL(path, "http://localhost:3000"));
+}
+
+function createParams(slug: string): { params: Promise<{ slug: string }> } {
+  return { params: Promise.resolve({ slug }) };
+}
+
+describe("GET /api/v1/comparisons/[slug]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns comparison with enriched species data", async () => {
+    const res = await GET(
+      createRequest("/api/v1/comparisons/ceiba-vs-pochote?locale=en"),
+      createParams("ceiba-vs-pochote")
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.data.slug).toBe("ceiba-vs-pochote");
+    expect(body.data.species).toEqual(["ceiba", "pochote"]);
+    expect(body.data._embedded).toBeDefined();
+    expect(body.data._embedded.species).toHaveLength(2);
+    expect(body.data._embedded.species[0].title).toBe("Ceiba");
+    expect(body.data._embedded.species[0].scientificName).toBe(
+      "Ceiba pentandra"
+    );
+    expect(body.data._embedded.species[1].title).toBe("Pochote");
+  });
+
+  it("returns 404 for non-existent slug", async () => {
+    const res = await GET(
+      createRequest("/api/v1/comparisons/no-such-comparison"),
+      createParams("no-such-comparison")
+    );
+
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("returns locale-not-found when slug exists but not in requested locale", async () => {
+    // ceiba-vs-pochote exists in en and es, but not in a made-up locale variant
+    // Actually, let's use ES locale which does exist — need to test missing locale
+    // Use en locale for a comparison that only exists in en:
+    const res = await GET(
+      createRequest("/api/v1/comparisons/ceiba-vs-pochote?locale=fr"),
+      createParams("ceiba-vs-pochote")
+    );
+
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    // The slug exists in "en" and "es", but "fr" is not found—LOCALE_NOT_FOUND
+    expect(body.error.code).toBe("LOCALE_NOT_FOUND");
+    expect(body._links.alternatives).toBeDefined();
+  });
+
+  it("includes _links self and html", async () => {
+    const res = await GET(
+      createRequest("/api/v1/comparisons/ceiba-vs-pochote?locale=en"),
+      createParams("ceiba-vs-pochote")
+    );
+    const body = await res.json();
+
+    expect(body.data._links.self).toContain(
+      "/api/v1/comparisons/ceiba-vs-pochote"
+    );
+    expect(body.data._links.html).toContain("/en/compare/ceiba-vs-pochote");
+  });
+
+  it("includes rate-limit headers", async () => {
+    const res = await GET(
+      createRequest("/api/v1/comparisons/ceiba-vs-pochote"),
+      createParams("ceiba-vs-pochote")
+    );
+    expect(res.headers.get("X-RateLimit-Limit")).toBeDefined();
+  });
+
+  it("includes cache-control header on success", async () => {
+    const res = await GET(
+      createRequest("/api/v1/comparisons/ceiba-vs-pochote"),
+      createParams("ceiba-vs-pochote")
+    );
+    expect(res.headers.get("Cache-Control")).toContain("max-age");
+  });
+
+  it("defaults to English locale", async () => {
+    const res = await GET(
+      createRequest("/api/v1/comparisons/ceiba-vs-pochote"),
+      createParams("ceiba-vs-pochote")
+    );
+    const body = await res.json();
+
+    expect(body.data.locale).toBe("en");
+    expect(body.data.keyDifference).toBe("Trunk spines differ");
+  });
+
+  it("returns Spanish locale when requested", async () => {
+    const res = await GET(
+      createRequest("/api/v1/comparisons/ceiba-vs-pochote?locale=es"),
+      createParams("ceiba-vs-pochote")
+    );
+    const body = await res.json();
+
+    expect(body.data.locale).toBe("es");
+    expect(body.data.keyDifference).toBe("Las espinas difieren");
+  });
+});

--- a/tests/api/v1-comparisons.test.ts
+++ b/tests/api/v1-comparisons.test.ts
@@ -1,0 +1,215 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockComparisons = [
+  {
+    slug: "ceiba-vs-pochote",
+    locale: "en",
+    title: "Ceiba vs Pochote",
+    species: ["ceiba", "pochote"],
+    keyDifference: "Trunk spines: Ceiba has conical, Pochote has sharp",
+    description: "How to tell Ceiba and Pochote apart",
+    difficulty: "moderate",
+    confusionRating: 4,
+    comparisonTags: ["trunk", "bark", "leaves"],
+    seasonalNote: "Best distinguished when leafless: Jan-Mar",
+    publishedAt: "2025-01-15",
+  },
+  {
+    slug: "ceiba-vs-pochote",
+    locale: "es",
+    title: "Ceiba vs Pochote",
+    species: ["ceiba", "pochote"],
+    keyDifference: "Espinas del tronco: Ceiba cónicas, Pochote afiladas",
+    description: "Cómo distinguir la Ceiba del Pochote",
+    difficulty: "moderate",
+    confusionRating: 4,
+    comparisonTags: ["trunk", "bark", "leaves"],
+    seasonalNote: "Mejor distinguir sin hojas: Ene-Mar",
+    publishedAt: "2025-01-15",
+  },
+  {
+    slug: "mango-vs-espavel",
+    locale: "en",
+    title: "Mango vs Espavel",
+    species: ["mango", "espavel"],
+    keyDifference: "Leaf arrangement and fruit type differ significantly",
+    description: "Commonly confused tropical trees",
+    difficulty: "easy",
+    confusionRating: 3,
+    comparisonTags: ["leaves", "fruit"],
+    seasonalNote: "Fruit differences most visible May-Aug",
+    publishedAt: "2025-02-01",
+  },
+  {
+    slug: "ron-ron-vs-cocobolo",
+    locale: "en",
+    title: "Ron-Ron vs Cocobolo",
+    species: ["ron-ron", "cocobolo"],
+    keyDifference: "Heartwood color and bark texture",
+    description: "Both are valuable hardwoods in dry forests",
+    difficulty: "challenging",
+    confusionRating: 5,
+    comparisonTags: ["bark", "flowers"],
+    seasonalNote: undefined,
+    publishedAt: "2025-03-01",
+  },
+];
+
+const mockTrees = [
+  {
+    slug: "ceiba",
+    locale: "en",
+    title: "Ceiba",
+    scientificName: "Ceiba pentandra",
+    family: "Malvaceae",
+    description: "The magnificent ceiba tree",
+  },
+  {
+    slug: "pochote",
+    locale: "en",
+    title: "Pochote",
+    scientificName: "Pachira quinata",
+    family: "Malvaceae",
+    description: "A spiny tropical tree",
+  },
+];
+
+vi.mock("contentlayer/generated", () => ({
+  allSpeciesComparisons: mockComparisons,
+  allTrees: mockTrees,
+}));
+
+const { GET } = await import("@/app/api/v1/comparisons/route");
+
+function createRequest(path: string): NextRequest {
+  return new NextRequest(new URL(path, "http://localhost:3000"));
+}
+
+describe("GET /api/v1/comparisons", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ----- Basic listing -----
+
+  it("returns paginated comparisons with default locale", async () => {
+    const res = await GET(createRequest("/api/v1/comparisons"));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.data).toBeDefined();
+    expect(body.pagination).toBeDefined();
+    expect(body._links).toBeDefined();
+    // No locale filter — returns all 4 comparisons across both locales
+    expect(body.pagination.total).toBe(4);
+  });
+
+  it("filters by locale", async () => {
+    const res = await GET(createRequest("/api/v1/comparisons?locale=es"));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.pagination.total).toBe(1);
+    expect(body.data[0].locale).toBe("es");
+  });
+
+  // ----- Filtering -----
+
+  it("filters by species", async () => {
+    const res = await GET(
+      createRequest("/api/v1/comparisons?species=ceiba&locale=en")
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.pagination.total).toBe(1);
+    expect(body.data[0].species).toContain("ceiba");
+  });
+
+  it("filters by difficulty", async () => {
+    const res = await GET(
+      createRequest("/api/v1/comparisons?difficulty=easy&locale=en")
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.pagination.total).toBe(1);
+    expect(body.data[0].difficulty).toBe("easy");
+  });
+
+  it("filters by tag", async () => {
+    const res = await GET(
+      createRequest("/api/v1/comparisons?tag=flowers&locale=en")
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    // Only ron-ron-vs-cocobolo has "flowers" tag
+    expect(body.pagination.total).toBe(1);
+    expect(body.data[0].slug).toBe("ron-ron-vs-cocobolo");
+  });
+
+  it("filters by free-text search", async () => {
+    const res = await GET(
+      createRequest("/api/v1/comparisons?search=hardwood&locale=en")
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.pagination.total).toBe(1);
+    expect(body.data[0].slug).toBe("ron-ron-vs-cocobolo");
+  });
+
+  // ----- Pagination -----
+
+  it("respects page and pageSize", async () => {
+    const res = await GET(
+      createRequest("/api/v1/comparisons?page=1&pageSize=2&locale=en")
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.data.length).toBe(2);
+    expect(body.pagination.page).toBe(1);
+    expect(body.pagination.pageSize).toBe(2);
+    expect(body.pagination.totalPages).toBe(2);
+    expect(body.pagination.hasNext).toBe(true);
+    expect(body.pagination.hasPrev).toBe(false);
+  });
+
+  it("returns empty data for out-of-range page", async () => {
+    const res = await GET(
+      createRequest("/api/v1/comparisons?page=99&locale=en")
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.data).toHaveLength(0);
+    expect(body.pagination.hasNext).toBe(false);
+  });
+
+  // ----- Response shape -----
+
+  it("includes _links in each comparison", async () => {
+    const res = await GET(createRequest("/api/v1/comparisons?locale=en"));
+    const body = await res.json();
+
+    const first = body.data[0];
+    expect(first._links).toBeDefined();
+    expect(first._links.self).toContain("/api/v1/comparisons/");
+    expect(first._links.html).toContain("/en/compare/");
+  });
+
+  it("includes rate-limit headers", async () => {
+    const res = await GET(createRequest("/api/v1/comparisons"));
+    expect(res.headers.get("X-RateLimit-Limit")).toBeDefined();
+    expect(res.headers.get("X-RateLimit-Remaining")).toBeDefined();
+    expect(res.headers.get("X-RateLimit-Reset")).toBeDefined();
+  });
+
+  it("includes cache-control header", async () => {
+    const res = await GET(createRequest("/api/v1/comparisons"));
+    expect(res.headers.get("Cache-Control")).toBeDefined();
+  });
+});

--- a/tests/api/v1-glossary.test.ts
+++ b/tests/api/v1-glossary.test.ts
@@ -1,0 +1,296 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockGlossaryTerms = [
+  {
+    slug: "deciduous",
+    locale: "en",
+    term: "Deciduous",
+    simpleDefinition: "A tree that loses its leaves seasonally",
+    technicalDefinition:
+      "A plant that sheds all its leaves annually in response to seasonal change",
+    category: "ecology",
+    pronunciation: "deh-SID-yoo-us",
+    etymology: "Latin deciduus, from decidere (to fall off)",
+    exampleSpecies: ["ceiba", "guanacaste"],
+    relatedTerms: ["evergreen", "semi-deciduous"],
+    image: undefined,
+    publishedAt: "2025-01-01",
+  },
+  {
+    slug: "deciduous",
+    locale: "es",
+    term: "Caducifolio",
+    simpleDefinition: "Un árbol que pierde sus hojas estacionalmente",
+    technicalDefinition:
+      "Una planta que pierde todas sus hojas anualmente en respuesta al cambio estacional",
+    category: "ecology",
+    pronunciation: "ka-du-si-FO-lio",
+    etymology: "Del latín caducus (que cae)",
+    exampleSpecies: ["ceiba", "guanacaste"],
+    relatedTerms: ["evergreen", "semi-deciduous"],
+    image: undefined,
+    publishedAt: "2025-01-01",
+  },
+  {
+    slug: "evergreen",
+    locale: "en",
+    term: "Evergreen",
+    simpleDefinition: "A tree that keeps its leaves year-round",
+    technicalDefinition: undefined,
+    category: "ecology",
+    pronunciation: undefined,
+    etymology: undefined,
+    exampleSpecies: [],
+    relatedTerms: ["deciduous"],
+    image: undefined,
+    publishedAt: "2025-01-15",
+  },
+  {
+    slug: "semi-deciduous",
+    locale: "en",
+    term: "Semi-deciduous",
+    simpleDefinition: "A tree that drops some but not all leaves",
+    technicalDefinition: undefined,
+    category: "ecology",
+    pronunciation: undefined,
+    etymology: undefined,
+    exampleSpecies: [],
+    relatedTerms: [],
+    image: undefined,
+    publishedAt: "2025-02-01",
+  },
+  {
+    slug: "phloem",
+    locale: "en",
+    term: "Phloem",
+    simpleDefinition: "The tissue that transports food in a plant",
+    technicalDefinition:
+      "Vascular tissue responsible for transporting photosynthates",
+    category: "anatomy",
+    pronunciation: "FLO-em",
+    etymology: "Greek phloios (bark)",
+    exampleSpecies: [],
+    relatedTerms: [],
+    image: undefined,
+    publishedAt: "2025-03-01",
+  },
+];
+
+const mockTrees = [
+  {
+    slug: "ceiba",
+    locale: "en",
+    title: "Ceiba",
+    scientificName: "Ceiba pentandra",
+    family: "Malvaceae",
+    description: "The magnificent ceiba tree",
+  },
+  {
+    slug: "guanacaste",
+    locale: "en",
+    title: "Guanacaste",
+    scientificName: "Enterolobium cyclocarpum",
+    family: "Fabaceae",
+    description: "National tree of Costa Rica",
+  },
+];
+
+vi.mock("contentlayer/generated", () => ({
+  allGlossaryTerms: mockGlossaryTerms,
+  allTrees: mockTrees,
+}));
+
+function createRequest(path: string): NextRequest {
+  return new NextRequest(new URL(path, "http://localhost:3000"));
+}
+
+// ---- List route ----
+
+const listRoute = await import("@/app/api/v1/glossary/route");
+
+describe("GET /api/v1/glossary", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns paginated glossary terms with default locale", async () => {
+    const res = await listRoute.GET(createRequest("/api/v1/glossary"));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.data).toBeDefined();
+    expect(body.pagination).toBeDefined();
+    // No locale filter — returns all 5 terms across both locales
+    expect(body.pagination.total).toBe(5);
+  });
+
+  it("filters by locale", async () => {
+    const res = await listRoute.GET(
+      createRequest("/api/v1/glossary?locale=es")
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.pagination.total).toBe(1);
+    expect(body.data[0].locale).toBe("es");
+  });
+
+  it("filters by category", async () => {
+    const res = await listRoute.GET(
+      createRequest("/api/v1/glossary?category=anatomy&locale=en")
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.pagination.total).toBe(1);
+    expect(body.data[0].term).toBe("Phloem");
+  });
+
+  it("filters by free-text search", async () => {
+    const res = await listRoute.GET(
+      createRequest("/api/v1/glossary?search=transport&locale=en")
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.pagination.total).toBe(1);
+    expect(body.data[0].slug).toBe("phloem");
+  });
+
+  it("paginates correctly", async () => {
+    const res = await listRoute.GET(
+      createRequest("/api/v1/glossary?page=1&pageSize=2&locale=en")
+    );
+    const body = await res.json();
+
+    expect(body.data).toHaveLength(2);
+    expect(body.pagination.page).toBe(1);
+    expect(body.pagination.totalPages).toBe(2);
+    expect(body.pagination.hasNext).toBe(true);
+  });
+
+  it("includes _links in response items", async () => {
+    const res = await listRoute.GET(
+      createRequest("/api/v1/glossary?locale=en")
+    );
+    const body = await res.json();
+
+    expect(body.data[0]._links.self).toContain("/api/v1/glossary/");
+    expect(body.data[0]._links.html).toContain("/en/glossary/");
+  });
+
+  it("includes rate-limit and cache headers", async () => {
+    const res = await listRoute.GET(createRequest("/api/v1/glossary"));
+    expect(res.headers.get("X-RateLimit-Limit")).toBeDefined();
+    expect(res.headers.get("Cache-Control")).toBeDefined();
+  });
+});
+
+// ---- Detail route ----
+
+const detailRoute = await import("@/app/api/v1/glossary/[slug]/route");
+
+function createParams(slug: string): { params: Promise<{ slug: string }> } {
+  return { params: Promise.resolve({ slug }) };
+}
+
+describe("GET /api/v1/glossary/[slug]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns term with enriched related terms", async () => {
+    const res = await detailRoute.GET(
+      createRequest("/api/v1/glossary/deciduous?locale=en"),
+      createParams("deciduous")
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.data.slug).toBe("deciduous");
+    expect(body.data.term).toBe("Deciduous");
+    expect(body.data._embedded).toBeDefined();
+    expect(body.data._embedded.relatedTerms.length).toBeGreaterThan(0);
+    expect(body.data._embedded.relatedTerms[0].term).toBe("Evergreen");
+  });
+
+  it("returns term with enriched example species", async () => {
+    const res = await detailRoute.GET(
+      createRequest("/api/v1/glossary/deciduous?locale=en"),
+      createParams("deciduous")
+    );
+    const body = await res.json();
+
+    expect(body.data._embedded.exampleSpecies).toBeDefined();
+    expect(body.data._embedded.exampleSpecies).toHaveLength(2);
+    expect(body.data._embedded.exampleSpecies[0].title).toBe("Ceiba");
+    expect(body.data._embedded.exampleSpecies[0].scientificName).toBe(
+      "Ceiba pentandra"
+    );
+  });
+
+  it("returns 404 for non-existent slug", async () => {
+    const res = await detailRoute.GET(
+      createRequest("/api/v1/glossary/nonexistent"),
+      createParams("nonexistent")
+    );
+
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("returns locale-not-found when term exists in other locale", async () => {
+    const res = await detailRoute.GET(
+      createRequest("/api/v1/glossary/deciduous?locale=fr"),
+      createParams("deciduous")
+    );
+
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error.code).toBe("LOCALE_NOT_FOUND");
+    expect(body._links.alternatives).toBeDefined();
+  });
+
+  it("includes _links self and html", async () => {
+    const res = await detailRoute.GET(
+      createRequest("/api/v1/glossary/deciduous?locale=en"),
+      createParams("deciduous")
+    );
+    const body = await res.json();
+
+    expect(body.data._links.self).toContain("/api/v1/glossary/deciduous");
+    expect(body.data._links.html).toContain("/en/glossary/deciduous");
+  });
+
+  it("defaults to English locale", async () => {
+    const res = await detailRoute.GET(
+      createRequest("/api/v1/glossary/deciduous"),
+      createParams("deciduous")
+    );
+    const body = await res.json();
+
+    expect(body.data.locale).toBe("en");
+    expect(body.data.term).toBe("Deciduous");
+  });
+
+  it("returns Spanish locale when requested", async () => {
+    const res = await detailRoute.GET(
+      createRequest("/api/v1/glossary/deciduous?locale=es"),
+      createParams("deciduous")
+    );
+    const body = await res.json();
+
+    expect(body.data.locale).toBe("es");
+    expect(body.data.term).toBe("Caducifolio");
+  });
+
+  it("includes rate-limit headers", async () => {
+    const res = await detailRoute.GET(
+      createRequest("/api/v1/glossary/deciduous"),
+      createParams("deciduous")
+    );
+    expect(res.headers.get("X-RateLimit-Limit")).toBeDefined();
+  });
+});

--- a/tests/api/v1-openapi.test.ts
+++ b/tests/api/v1-openapi.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+const { GET } = await import("@/app/api/v1/openapi.json/route");
+
+describe("GET /api/v1/openapi.json", () => {
+  it("returns a valid OpenAPI 3.1 spec", async () => {
+    const res = GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.openapi).toBe("3.1.0");
+    expect(body.info.title).toBe("Costa Rica Tree Atlas API");
+    expect(body.info.version).toBe("1.0.0");
+    expect(body.paths).toBeDefined();
+  });
+
+  it("documents all v1 endpoints", async () => {
+    const res = GET();
+    const body = await res.json();
+
+    const paths = Object.keys(body.paths);
+    expect(paths).toContain("/trees");
+    expect(paths).toContain("/trees/{slug}");
+    expect(paths).toContain("/families");
+    expect(paths).toContain("/comparisons");
+    expect(paths).toContain("/comparisons/{slug}");
+    expect(paths).toContain("/glossary");
+    expect(paths).toContain("/glossary/{slug}");
+  });
+
+  it("includes component schemas", async () => {
+    const res = GET();
+    const body = await res.json();
+
+    const schemas = Object.keys(body.components.schemas);
+    expect(schemas).toContain("Tree");
+    expect(schemas).toContain("Comparison");
+    expect(schemas).toContain("GlossaryTerm");
+    expect(schemas).toContain("PaginatedResponse");
+    expect(schemas).toContain("Error");
+  });
+
+  it("includes CORS header", async () => {
+    const res = GET();
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+  });
+
+  it("includes cache header", async () => {
+    const res = GET();
+    expect(res.headers.get("Cache-Control")).toContain("max-age");
+  });
+});


### PR DESCRIPTION
## P6.3: Public API — Comparisons, Glossary & OpenAPI Spec

### Summary
Completes the P6.3 Public API milestone by adding comparison and glossary endpoints, an OpenAPI specification, and refactoring existing endpoints to use a shared rate limiter.

### Changes

#### New Endpoints
- **GET /api/v1/comparisons** — List comparison guides with locale/slug filtering
- **GET /api/v1/comparisons/[slug]** — Single comparison with embedded species data
- **GET /api/v1/glossary** — List glossary terms with locale/category/search filtering  
- **GET /api/v1/glossary/[slug]** — Single glossary term with cross-references
- **GET /api/v1/openapi.json** — Full OpenAPI 3.1 specification for all 7 v1 endpoints

#### Refactoring
- **Shared rate limiter** (`src/lib/api-rate-limit.ts`) — Extracted duplicated rate-limiting logic from trees and families endpoints into a shared module with automatic cleanup
- **API types** (`src/types/api.ts`) — Added comparison and glossary response types

#### Bug Fixes
- **Sentry/Turbopack** — Fixed dynamic import warnings in `instrumentation.ts` and `error-tracking.ts`

### Tests
- 39 new tests across 4 test files (comparisons, comparisons/[slug], glossary, openapi)
- All 541 tests passing, 0 lint errors

### Documentation
- Updated `NEXT_AGENT_HANDOFF.md` with Run 11 summary

## Summary by Sourcery

Add public API v1 endpoints for species comparisons and glossary terms, expose an OpenAPI 3.1 specification, and consolidate API rate limiting into a shared module used across endpoints.

New Features:
- Introduce /api/v1/comparisons list and detail endpoints to expose species comparison guides with filtering, pagination, and embedded species links.
- Introduce /api/v1/glossary list and detail endpoints to expose botanical glossary terms with filtering, pagination, and enriched cross-references.
- Expose a static /api/v1/openapi.json endpoint serving the OpenAPI 3.1 specification for all public v1 API routes.

Bug Fixes:
- Adjust Sentry dynamic imports to avoid Turbopack build warnings by preventing static resolution of the optional @sentry/nextjs dependency.

Enhancements:
- Extract duplicated in-route rate limiting into a shared api-rate-limit utility with centralized configuration and memory-safe cleanup, and apply it across existing and new v1 API routes.
- Extend API type definitions to cover comparison and glossary response and filter shapes.
- Update project handoff documentation to reflect the new public API surface, tests, and current run status.

Tests:
- Add comparison, glossary, and OpenAPI endpoint test suites, increasing overall API test coverage and validating rate-limit and caching headers.