### PR TITLE
feat: P6.2 — Contributor Reputation System with Badges and Trust Levels

### DIFF
--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -9,40 +9,40 @@
 
 ### Content Coverage
 
-| Metric             | Count                                                  | Status      |
-| ------------------ | ------------------------------------------------------ | ----------- |
-| Species documented | 175 (EN + ES)                                          | ✅ Complete |
-| Comparison guides  | 20 (EN + ES)                                           | ✅ Complete |
-| Glossary terms     | 150 (EN + ES)                                          | ✅ Complete |
-| Care guidance      | 175/175                                                | ✅ Complete |
+| Metric             | Count                                                   | Status      |
+| ------------------ | ------------------------------------------------------- | ----------- |
+| Species documented | 175 (EN + ES)                                           | ✅ Complete |
+| Comparison guides  | 20 (EN + ES)                                            | ✅ Complete |
+| Glossary terms     | 150 (EN + ES)                                           | ✅ Complete |
+| Care guidance      | 175/175                                                 | ✅ Complete |
 | Photo galleries    | 174/175 (1 intentionally excluded; no photos available) | ✅ Complete |
-| GBIF + IUCN links  | 175/175                                                | ✅ Complete |
-| Bilingual parity   | 100%                                                   | ✅ Complete |
+| GBIF + IUCN links  | 175/175                                                 | ✅ Complete |
+| Bilingual parity   | 100%                                                    | ✅ Complete |
 
 ### Technical Health
 
-| Metric          | Current (Feb 28) | Target | Status                                                |
-| --------------- | ---------------- | ------ | ----------------------------------------------------- |
+| Metric          | Current (Feb 28) | Target | Status                                                  |
+| --------------- | ---------------- | ------ | ------------------------------------------------------- |
 | Lighthouse Perf | **85**           | >90    | 🟡 Below target; LCP (4.0s) is the remaining bottleneck |
-| LCP             | **4.0 s**        | <2.5s  | 🔴 Homepage tree card images served as JPEG, not AVIF |
-| TBT             | **30 ms**        | <200ms | ✅ Fixed                                              |
-| FCP             | **2.1 s**        | <1.8s  | 🟡 300ms render-blocking CSS                          |
-| CLS             | **0**            | <0.1   | ✅ Perfect                                            |
-| TTI             | **4.2 s**        | <5s    | ✅ Fixed                                              |
-| Accessibility   | **96**           | 100    | 🟡 Contrast fixes shipped; needs re-measurement       |
-| SEO             | **100**          | 100    | ✅ Perfect                                            |
-| Best Practices  | **100**          | 100    | ✅ Perfect                                            |
-| Tests           | **577/577**      | 100%   | ✅ All passing                                        |
-| Lint errors     | **0**            | 0      | ✅                                                    |
+| LCP             | **4.0 s**        | <2.5s  | 🔴 Homepage tree card images served as JPEG, not AVIF   |
+| TBT             | **30 ms**        | <200ms | ✅ Fixed                                                |
+| FCP             | **2.1 s**        | <1.8s  | 🟡 300ms render-blocking CSS                            |
+| CLS             | **0**            | <0.1   | ✅ Perfect                                              |
+| TTI             | **4.2 s**        | <5s    | ✅ Fixed                                                |
+| Accessibility   | **96**           | 100    | 🟡 Contrast fixes shipped; needs re-measurement         |
+| SEO             | **100**          | 100    | ✅ Perfect                                              |
+| Best Practices  | **100**          | 100    | ✅ Perfect                                              |
+| Tests           | **577/577**      | 100%   | ✅ All passing                                          |
+| Lint errors     | **0**            | 0      | ✅                                                      |
 
 ### Performance Budgets
 
-| Resource          | Budget | Current                      | Status                                                              |
-| ----------------- | ------ | ---------------------------- | ------------------------------------------------------------------- |
-| JavaScript        | <300KB | ~553KB (uncompressed, main)  | 🔴 Over budget (~553KB > 300KB). 23KB unused JS remains to be pruned |
-| CSS               | <100KB | ~80KB                        | ✅ (300ms render-blocking chunk to investigate)                     |
-| Images (Cards)    | <100KB | ~270KB largest               | 🔴 Not using AVIF/WebP                                              |
-| Total Page Weight | <2MB   | ~1.6 MB                      | ✅                                                                  |
+| Resource          | Budget | Current                     | Status                                                               |
+| ----------------- | ------ | --------------------------- | -------------------------------------------------------------------- |
+| JavaScript        | <300KB | ~553KB (uncompressed, main) | 🔴 Over budget (~553KB > 300KB). 23KB unused JS remains to be pruned |
+| CSS               | <100KB | ~80KB                       | ✅ (300ms render-blocking chunk to investigate)                      |
+| Images (Cards)    | <100KB | ~270KB largest              | 🔴 Not using AVIF/WebP                                               |
+| Total Page Weight | <2MB   | ~1.6 MB                     | ✅                                                                   |
 
 ---
 
@@ -98,14 +98,18 @@
 - [ ] Save search preferences (Zustand persist)
 - [ ] Search analytics — track common queries to improve content
 
-### 5. Community Contributions — Remaining (P6.2) — Medium
+### 5. Community Contributions — Remaining (P6.2) — ✅ Complete
 
 **Impact:** Medium — community engagement features
 **Effort:** High
 **Already done:** Submit species/corrections (`/contribute`), rate trees (`TreeRating`), photo upload (`/contribute/photo`)
 
-- [ ] Share local knowledge and traditional uses (form + admin review workflow)
-- [ ] User reputation system (track contributions, display badges, tiered trust levels)
+- [x] Share local knowledge and traditional uses (form + admin review workflow)
+  - Fixed: region field now saved to DB, "Share local knowledge" CTA rendered on tree pages, URL params pre-select type/tree
+- [x] User reputation system (track contributions, display badges, tiered trust levels)
+  - ContributorProfile model, reputation API, 9 badges, 4 trust levels, profile page, BadgeDisplay component
+  - Admin view shows contributor trust level and reputation score
+  - 46 new tests (39 unit + 7 API)
 
 ### 6. Offline Enhancements (P8.2) — Lower
 

--- a/docs/NEXT_AGENT_HANDOFF.md
+++ b/docs/NEXT_AGENT_HANDOFF.md
@@ -2,14 +2,56 @@
 
 Last updated: 2026-02-28
 
-## Latest Run Summary (2026-02-28 — Run 14)
+## Latest Run Summary (2026-02-28 — Run 15)
 
-- **Branch**: `feature/p4.5-csp-inline-style-refactor`
+- **Branch**: `feature/p6.2-reputation-system`
 - **Tasks completed**:
-  1. **P4.5: CSP inline style optimization — complete** — Previously marked as "Manual Sprint — Requires Human" in the implementation plan. Assessed all 54 inline `style={{}}` occurrences across components (excluding 88 in OG/Twitter images which require them). Converted 4 components fully to Tailwind classes (SkeletonText, SkeletonGrid, SafeImage opacity, QRCodeGenerator). Created reusable `ProgressBar` component (`src/components/ProgressBar.tsx`) with proper ARIA attributes that centralizes the single dynamic-width inline style. Replaced 9 duplicated inline progress bar implementations across 9 files. Updated CSP `style-src` comments in all 3 policy variants — removed stale TODO. Remaining ~30 inline styles are genuinely irreducible dynamic runtime values (virtualizer positions, data-driven IUCN colors, SVG fills, animation delays, slider positions). `'unsafe-inline'` in `style-src` is industry standard and will remain.
-  2. **Verified**: 577/577 tests pass, 0 lint errors, build clean.
+  1. **P6.2: User Reputation System — full implementation** — Built the complete contributor reputation system with badges and tiered trust levels:
+     - **Prisma schema**: Added `ContributorProfile` model (sessionId, displayName, stats, reputationScore, trustLevel, badges[]), `TrustLevel` enum (NEW/CONTRIBUTOR/TRUSTED/EXPERT), added `region` column to `Contribution`
+     - **Migration**: `prisma/migrations/20260228000000_add_contributor_profiles/migration.sql`
+     - **Pure logic module**: `src/lib/reputation.ts` — `calculateReputation()` (scoring: +10/approved, -3/rejected, +2/rating, +5/photo, +15/knowledge), `getNextBadge()`, 4 trust levels with threshold configs, 9 badge definitions
+     - **API route**: `GET /api/reputation` — fetches/computes contributor profile with badges and nextBadge progress, session cookie auth, rate limited, 503 fallback
+     - **Admin integration**: Reputation recalculation on approve/reject/implement in PATCH `/api/admin/contributions/[id]`, trust level + reputation score visible in admin contribution list and detail modal
+     - **Profile page**: `/contribute/profile` with trust level badge, stats grid, full badge display with earned/unearned states and progress bar for next badge
+     - **BadgeDisplay component**: `src/components/BadgeDisplay.tsx` — compact (inline) and expanded (full grid) variants with progress tracking
+     - **i18n**: Complete `reputation` namespace in EN + ES (~60 keys each) covering trust levels, stats, 9 badges, UI strings
+  2. **Bug fix: region field silently dropped** — `ContributeClient` collected region/whereFound but payload construction omitted them. Fixed mapping for both LOCAL_KNOWLEDGE and NEW_SPECIES types. Added `region` column to schema + API.
+  3. **Bug fix: unused "Share local knowledge" CTA** — Translation keys existed but no link was rendered in `ContributeCTA`. Added third CTA link pointing to `/contribute?type=LOCAL_KNOWLEDGE&tree={slug}`.
+  4. **Bug fix: no URL param pre-selection** — Added `searchParams` handling in contribute page, `initialType`/`initialTree` props in `ContributeClient` for deep-linking from tree detail CTAs.
+  5. **Bug fix: region not shown in admin** — Added region display in admin contribution detail modal.
+  6. **Contributions API improvement**: LEFT JOIN with `contributor_profiles` to include trust level + reputation score in admin contribution listings. Table-aliased WHERE conditions for unambiguous queries.
+  7. **Profile link in success state**: Added "View Your Contributions" link on contribution submission success screen.
+  8. **Tests**: 46 new tests — `tests/lib/reputation.test.ts` (39 tests: scoring formula, trust level determination, all 9 badges, edge cases, getNextBadge), `tests/api/reputation.test.ts` (7 tests: no session, existing profile, nextBadge, computed profile, no activity, 503, 500)
+  9. **Verified**: 623/623 tests pass (+46 new), 0 lint errors, build clean.
 
-## Previous Run Summary (2026-02-28 — Run 13)
+## Created/Modified Files
+
+### Created
+
+- `prisma/migrations/20260228000000_add_contributor_profiles/migration.sql`
+- `src/lib/reputation.ts`
+- `src/app/api/reputation/route.ts`
+- `src/components/BadgeDisplay.tsx`
+- `src/app/[locale]/contribute/profile/page.tsx`
+- `src/app/[locale]/contribute/profile/ContributorProfileClient.tsx`
+- `tests/lib/reputation.test.ts`
+- `tests/api/reputation.test.ts`
+
+### Modified
+
+- `prisma/schema.prisma` — Added ContributorProfile model, TrustLevel enum, region column
+- `src/types/contributions.ts` — Added region, contributorTrustLevel, contributorReputationScore fields
+- `src/app/api/contributions/route.ts` — Region in POST, LEFT JOIN for trust level in GET
+- `src/app/api/admin/contributions/[id]/route.ts` — Region in GET, reputation recalculation in PATCH
+- `src/app/[locale]/contribute/ContributeClient.tsx` — Region in payload, initialType/initialTree, viewProfile link
+- `src/app/[locale]/contribute/page.tsx` — searchParams handling, viewProfile translation
+- `src/components/ContributeCTA.tsx` — Third "Share local knowledge" CTA link
+- `src/app/[locale]/admin/contributions/ContributionsListClient.tsx` — Trust level display, region display
+- `messages/en.json` — reputation namespace, success.viewProfile
+- `messages/es.json` — reputation namespace, success.viewProfile
+- `docs/IMPLEMENTATION_PLAN.md` — P6.2 marked complete
+
+## Previous Run Summary (2026-02-28 — Run 14)
 
 - **Branch**: `feature/p6.2-contributions-ratings-security-fixes`
 - **Tasks completed**:

--- a/messages/en.json
+++ b/messages/en.json
@@ -760,7 +760,8 @@
     "success": {
       "title": "Thank You!",
       "message": "Your contribution has been submitted and will be reviewed by our team.",
-      "another": "Submit Another Contribution"
+      "another": "Submit Another Contribution",
+      "viewProfile": "View Your Contributions"
     },
     "error": {
       "title": "Submission Failed",
@@ -894,5 +895,64 @@
     "suggestCorrection": "Suggest a correction",
     "uploadPhoto": "Upload a photo",
     "shareKnowledge": "Share local knowledge"
+  },
+  "reputation": {
+    "title": "Your Contributions",
+    "description": "Track your contributions, earn badges, and build your reputation in the Costa Rica Tree Atlas community.",
+    "memberSince": "Member since",
+    "trustLevel": {
+      "title": "Trust Level",
+      "NEW": "New Contributor",
+      "CONTRIBUTOR": "Contributor",
+      "TRUSTED": "Trusted Contributor",
+      "EXPERT": "Expert",
+      "NEW_description": "Welcome! Your contributions will be reviewed by moderators.",
+      "CONTRIBUTOR_description": "An active community member with verified contributions.",
+      "TRUSTED_description": "A reliable contributor with a strong track record.",
+      "EXPERT_description": "Recognized expert — granted by administrators."
+    },
+    "stats": {
+      "title": "Statistics",
+      "totalContributions": "Total Contributions",
+      "approved": "Approved",
+      "rejected": "Rejected",
+      "ratings": "Ratings Given",
+      "photos": "Photos Uploaded",
+      "score": "Reputation Score"
+    },
+    "badges": {
+      "title": "Badges",
+      "earned": "Earned",
+      "locked": "Locked",
+      "nextBadge": "Next badge",
+      "progress": "{current} of {target}",
+      "allEarned": "All badges earned!",
+      "first_contribution": "First Steps",
+      "first_contribution_desc": "Submitted your first approved contribution",
+      "naturalist_5": "Naturalist",
+      "naturalist_5_desc": "5 approved contributions",
+      "naturalist_10": "Expert Naturalist",
+      "naturalist_10_desc": "10 approved contributions",
+      "naturalist_25": "Master Naturalist",
+      "naturalist_25_desc": "25 approved contributions",
+      "knowledge_keeper": "Knowledge Keeper",
+      "knowledge_keeper_desc": "3 approved local knowledge contributions",
+      "corrector": "Fact Checker",
+      "corrector_desc": "5 approved corrections",
+      "photographer": "Photographer",
+      "photographer_desc": "3 approved photo uploads",
+      "active_rater": "Active Reviewer",
+      "active_rater_desc": "Rated 10 or more trees",
+      "explorer": "Explorer",
+      "explorer_desc": "Rated 25 or more trees"
+    },
+    "contributions": {
+      "title": "Your Contributions",
+      "empty": "You haven't submitted any contributions yet.",
+      "startContributing": "Start contributing"
+    },
+    "noProfile": "You haven't contributed yet. Start contributing to build your reputation!",
+    "viewProfile": "Your Contributions",
+    "loading": "Loading your profile..."
   }
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -759,7 +759,8 @@
     "success": {
       "title": "¡Gracias!",
       "message": "Tu contribución ha sido enviada y será revisada por nuestro equipo.",
-      "another": "Enviar Otra Contribución"
+      "another": "Enviar Otra Contribución",
+      "viewProfile": "Ver Tus Contribuciones"
     },
     "error": {
       "title": "Error al Enviar",
@@ -893,5 +894,64 @@
     "suggestCorrection": "Sugerir una corrección",
     "uploadPhoto": "Subir una foto",
     "shareKnowledge": "Compartir conocimiento local"
+  },
+  "reputation": {
+    "title": "Tus Contribuciones",
+    "description": "Sigue tus contribuciones, gana insignias y construye tu reputación en la comunidad del Atlas de Árboles de Costa Rica.",
+    "memberSince": "Miembro desde",
+    "trustLevel": {
+      "title": "Nivel de Confianza",
+      "NEW": "Nuevo Colaborador",
+      "CONTRIBUTOR": "Colaborador",
+      "TRUSTED": "Colaborador de Confianza",
+      "EXPERT": "Experto",
+      "NEW_description": "¡Bienvenido! Tus contribuciones serán revisadas por moderadores.",
+      "CONTRIBUTOR_description": "Un miembro activo de la comunidad con contribuciones verificadas.",
+      "TRUSTED_description": "Un colaborador confiable con un sólido historial.",
+      "EXPERT_description": "Experto reconocido — otorgado por administradores."
+    },
+    "stats": {
+      "title": "Estadísticas",
+      "totalContributions": "Contribuciones Totales",
+      "approved": "Aprobadas",
+      "rejected": "Rechazadas",
+      "ratings": "Calificaciones Dadas",
+      "photos": "Fotos Subidas",
+      "score": "Puntuación de Reputación"
+    },
+    "badges": {
+      "title": "Insignias",
+      "earned": "Obtenida",
+      "locked": "Bloqueada",
+      "nextBadge": "Próxima insignia",
+      "progress": "{current} de {target}",
+      "allEarned": "¡Todas las insignias obtenidas!",
+      "first_contribution": "Primeros Pasos",
+      "first_contribution_desc": "Enviaste tu primera contribución aprobada",
+      "naturalist_5": "Naturalista",
+      "naturalist_5_desc": "5 contribuciones aprobadas",
+      "naturalist_10": "Naturalista Experto",
+      "naturalist_10_desc": "10 contribuciones aprobadas",
+      "naturalist_25": "Naturalista Maestro",
+      "naturalist_25_desc": "25 contribuciones aprobadas",
+      "knowledge_keeper": "Guardián del Conocimiento",
+      "knowledge_keeper_desc": "3 contribuciones de conocimiento local aprobadas",
+      "corrector": "Verificador de Datos",
+      "corrector_desc": "5 correcciones aprobadas",
+      "photographer": "Fotógrafo",
+      "photographer_desc": "3 fotos subidas aprobadas",
+      "active_rater": "Revisor Activo",
+      "active_rater_desc": "Calificaste 10 o más árboles",
+      "explorer": "Explorador",
+      "explorer_desc": "Calificaste 25 o más árboles"
+    },
+    "contributions": {
+      "title": "Tus Contribuciones",
+      "empty": "Aún no has enviado ninguna contribución.",
+      "startContributing": "Empieza a contribuir"
+    },
+    "noProfile": "Aún no has contribuido. ¡Empieza a contribuir para construir tu reputación!",
+    "viewProfile": "Tus Contribuciones",
+    "loading": "Cargando tu perfil..."
   }
 }

--- a/prisma/migrations/20260228000000_add_contributor_profiles/migration.sql
+++ b/prisma/migrations/20260228000000_add_contributor_profiles/migration.sql
@@ -1,0 +1,33 @@
+-- Add region column to contributions table
+ALTER TABLE "contributions" ADD COLUMN "region" VARCHAR(255);
+
+-- CreateEnum
+CREATE TYPE "TrustLevel" AS ENUM ('NEW', 'CONTRIBUTOR', 'TRUSTED', 'EXPERT');
+
+-- CreateTable
+CREATE TABLE "contributor_profiles" (
+    "id" TEXT NOT NULL,
+    "session_id" VARCHAR(64) NOT NULL,
+    "display_name" VARCHAR(255),
+    "total_contributions" INTEGER NOT NULL DEFAULT 0,
+    "approved_contributions" INTEGER NOT NULL DEFAULT 0,
+    "rejected_contributions" INTEGER NOT NULL DEFAULT 0,
+    "total_ratings" INTEGER NOT NULL DEFAULT 0,
+    "total_photos" INTEGER NOT NULL DEFAULT 0,
+    "reputation_score" INTEGER NOT NULL DEFAULT 0,
+    "trust_level" "TrustLevel" NOT NULL DEFAULT 'NEW',
+    "badges" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "contributor_profiles_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "contributor_profiles_session_id_key" ON "contributor_profiles"("session_id");
+
+-- CreateIndex
+CREATE INDEX "contributor_profiles_trust_level_idx" ON "contributor_profiles"("trust_level");
+
+-- CreateIndex
+CREATE INDEX "contributor_profiles_reputation_score_idx" ON "contributor_profiles"("reputation_score");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -343,6 +343,9 @@ model Contribution {
   ipHash           String? @db.VarChar(64) // Hashed IP for rate limiting
   userId           String? // If logged in
 
+  // Location context (for LOCAL_KNOWLEDGE region or NEW_SPECIES location)
+  region String? @db.VarChar(255)
+
   // Review workflow
   status       ContributionStatus   @default(PENDING)
   priority     ContributionPriority @default(MEDIUM)
@@ -390,4 +393,46 @@ model TreeRating {
   @@index([sessionId])
   @@index([ipHash, updatedAt]) // Supports rate-limit query: ip_hash + updated_at
   @@map("tree_ratings")
+}
+
+// ============================================================================
+// CONTRIBUTOR REPUTATION SYSTEM
+// Track contribution history, badges, and trust levels for community members
+// ============================================================================
+
+// Trust levels for contributors
+enum TrustLevel {
+  NEW // Default for all new contributors
+  CONTRIBUTOR // 3+ approved contributions
+  TRUSTED // 10+ approved contributions, <20% rejection rate
+  EXPERT // Admin-granted only
+}
+
+// Contributor profile — aggregated stats and earned badges
+model ContributorProfile {
+  id        String @id @default(cuid())
+  sessionId String @unique @db.VarChar(64) // Links to contribution_session cookie
+
+  // Optional display info
+  displayName String? @db.VarChar(255)
+
+  // Contribution stats (denormalized for performance)
+  totalContributions    Int @default(0)
+  approvedContributions Int @default(0)
+  rejectedContributions Int @default(0)
+  totalRatings          Int @default(0)
+  totalPhotos           Int @default(0)
+
+  // Reputation
+  reputationScore Int        @default(0)
+  trustLevel      TrustLevel @default(NEW)
+  badges          String[]   @default([]) // Array of earned badge IDs
+
+  // Metadata
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([trustLevel])
+  @@index([reputationScore])
+  @@map("contributor_profiles")
 }

--- a/src/app/[locale]/admin/contributions/ContributionsListClient.tsx
+++ b/src/app/[locale]/admin/contributions/ContributionsListClient.tsx
@@ -44,6 +44,22 @@ const STATUS_COLORS: Record<ContributionStatus, string> = {
     "bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-200",
 };
 
+const TRUST_LEVEL_LABELS: Record<string, string> = {
+  NEW: "🌱 New",
+  CONTRIBUTOR: "🌿 Contributor",
+  TRUSTED: "🌳 Trusted",
+  EXPERT: "🏆 Expert",
+};
+
+const TRUST_LEVEL_COLORS: Record<string, string> = {
+  NEW: "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400",
+  CONTRIBUTOR:
+    "bg-blue-50 text-blue-600 dark:bg-blue-900/30 dark:text-blue-400",
+  TRUSTED:
+    "bg-green-50 text-green-600 dark:bg-green-900/30 dark:text-green-400",
+  EXPERT: "bg-amber-50 text-amber-600 dark:bg-amber-900/30 dark:text-amber-400",
+};
+
 export function ContributionsListClient() {
   const [contributions, setContributions] = useState<Contribution[]>([]);
   const [loading, setLoading] = useState(true);
@@ -266,6 +282,15 @@ export function ContributionsListClient() {
                     {contribution.contributorName && (
                       <span>By: {contribution.contributorName}</span>
                     )}
+                    {contribution.contributorTrustLevel && (
+                      <span
+                        className={`px-1.5 py-0.5 rounded text-[10px] font-medium ${TRUST_LEVEL_COLORS[contribution.contributorTrustLevel] || TRUST_LEVEL_COLORS.NEW}`}
+                      >
+                        {TRUST_LEVEL_LABELS[
+                          contribution.contributorTrustLevel
+                        ] || contribution.contributorTrustLevel}
+                      </span>
+                    )}
                   </div>
                 </div>
                 <div className="text-2xl">→</div>
@@ -357,6 +382,15 @@ export function ContributionsListClient() {
                   </div>
                 )}
 
+                {selectedContribution.region && (
+                  <div>
+                    <label className="text-sm font-medium text-muted-foreground">
+                      Region
+                    </label>
+                    <p className="mt-1">{selectedContribution.region}</p>
+                  </div>
+                )}
+
                 {/* New species specific fields */}
                 {selectedContribution.type === "NEW_SPECIES" && (
                   <div className="grid grid-cols-2 gap-4">
@@ -411,6 +445,22 @@ export function ContributionsListClient() {
                     {selectedContribution.contributorEmail && (
                       <span className="ml-2 text-muted-foreground">
                         ({selectedContribution.contributorEmail})
+                      </span>
+                    )}
+                    {selectedContribution.contributorTrustLevel && (
+                      <span
+                        className={`ml-2 px-2 py-0.5 rounded text-xs font-medium ${TRUST_LEVEL_COLORS[selectedContribution.contributorTrustLevel] || TRUST_LEVEL_COLORS.NEW}`}
+                      >
+                        {TRUST_LEVEL_LABELS[
+                          selectedContribution.contributorTrustLevel
+                        ] || selectedContribution.contributorTrustLevel}
+                        {selectedContribution.contributorReputationScore !=
+                          null && (
+                          <span className="ml-1 opacity-75">
+                            ({selectedContribution.contributorReputationScore}{" "}
+                            pts)
+                          </span>
+                        )}
                       </span>
                     )}
                   </div>

--- a/src/app/[locale]/contribute/ContributeClient.tsx
+++ b/src/app/[locale]/contribute/ContributeClient.tsx
@@ -51,21 +51,47 @@ interface Translations {
   };
   fields: Record<string, string>;
   knowledgeTypes: Record<string, string>;
-  success: { title: string; message: string; another: string };
+  success: {
+    title: string;
+    message: string;
+    another: string;
+    viewProfile: string;
+  };
   error: { title: string; tryAgain: string };
 }
 
 interface ContributeClientProps {
   trees: TreeOption[];
   translations: Translations;
+  initialType?: string;
+  initialTree?: string;
 }
 
 export function ContributeClient({
   trees,
   translations: t,
+  initialType,
+  initialTree,
 }: ContributeClientProps) {
+  // Resolve initial type from URL query param
+  const validTypes: ContributionType[] = [
+    "NEW_SPECIES",
+    "CORRECTION",
+    "LOCAL_KNOWLEDGE",
+  ];
+  const resolvedInitialType = validTypes.includes(
+    initialType as ContributionType
+  )
+    ? (initialType as ContributionType)
+    : null;
+
+  // Resolve initial tree from URL query param
+  const resolvedInitialTree = initialTree
+    ? trees.find((tree) => tree.slug === initialTree)
+    : null;
+
   const [selectedType, setSelectedType] = useState<ContributionType | null>(
-    null
+    resolvedInitialType
   );
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitStatus, setSubmitStatus] = useState<
@@ -75,7 +101,7 @@ export function ContributeClient({
 
   // Form state
   const [formData, setFormData] = useState({
-    treeSlug: "",
+    treeSlug: resolvedInitialTree?.slug || "",
     targetField: "description",
     knowledgeType: "traditional_uses",
     title: "",
@@ -91,7 +117,11 @@ export function ContributeClient({
     contributorEmail: "",
   });
 
-  const [treeSearch, setTreeSearch] = useState("");
+  const [treeSearch, setTreeSearch] = useState(
+    resolvedInitialTree
+      ? `${resolvedInitialTree.title} (${resolvedInitialTree.scientificName})`
+      : ""
+  );
 
   const filteredTrees = trees.filter(
     (tree) =>
@@ -133,6 +163,12 @@ export function ContributeClient({
         commonNameEs:
           selectedType === "NEW_SPECIES" ? formData.commonNameEs : null,
         family: selectedType === "NEW_SPECIES" ? formData.family : null,
+        region:
+          selectedType === "LOCAL_KNOWLEDGE"
+            ? formData.region || null
+            : selectedType === "NEW_SPECIES"
+              ? formData.whereFound || null
+              : null,
         contributorName: formData.contributorName || null,
         contributorEmail: formData.contributorEmail || null,
       };
@@ -189,12 +225,20 @@ export function ContributeClient({
         <div className="text-6xl mb-4">🎉</div>
         <h2 className="text-2xl font-bold mb-4">{t.success.title}</h2>
         <p className="text-muted-foreground mb-8">{t.success.message}</p>
-        <button
-          onClick={resetForm}
-          className="px-6 py-3 bg-primary text-primary-foreground rounded-lg hover:opacity-90 transition"
-        >
-          {t.success.another}
-        </button>
+        <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
+          <button
+            onClick={resetForm}
+            className="px-6 py-3 bg-primary text-primary-foreground rounded-lg hover:opacity-90 transition"
+          >
+            {t.success.another}
+          </button>
+          <Link
+            href="/contribute/profile"
+            className="px-6 py-3 border border-border rounded-lg hover:bg-muted transition text-sm"
+          >
+            {t.success.viewProfile}
+          </Link>
+        </div>
       </div>
     );
   }

--- a/src/app/[locale]/contribute/page.tsx
+++ b/src/app/[locale]/contribute/page.tsx
@@ -5,6 +5,7 @@ import { allTrees, type Tree } from "contentlayer/generated";
 
 interface PageProps {
   params: Promise<{ locale: string }>;
+  searchParams: Promise<{ type?: string; tree?: string }>;
 }
 
 export async function generateMetadata({
@@ -19,8 +20,12 @@ export async function generateMetadata({
   };
 }
 
-export default async function ContributePage({ params }: PageProps) {
+export default async function ContributePage({
+  params,
+  searchParams,
+}: PageProps) {
   const { locale } = await params;
+  const { type: initialType, tree: initialTree } = await searchParams;
   const t = await getTranslations({ locale, namespace: "contribute" });
 
   // Get list of trees for the current locale (for correction/knowledge forms)
@@ -47,6 +52,8 @@ export default async function ContributePage({ params }: PageProps) {
         {/* Contribution options */}
         <ContributeClient
           trees={trees}
+          initialType={initialType}
+          initialTree={initialTree}
           translations={{
             chooseType: t("chooseType"),
             newSpecies: {
@@ -133,6 +140,7 @@ export default async function ContributePage({ params }: PageProps) {
               title: t("success.title"),
               message: t("success.message"),
               another: t("success.another"),
+              viewProfile: t("success.viewProfile"),
             },
             error: {
               title: t("error.title"),

--- a/src/app/[locale]/contribute/profile/ContributorProfileClient.tsx
+++ b/src/app/[locale]/contribute/profile/ContributorProfileClient.tsx
@@ -1,0 +1,223 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
+import { Link } from "@i18n/navigation";
+import { BadgeDisplay } from "@/components/BadgeDisplay";
+
+interface ProfileData {
+  displayName: string | null;
+  totalContributions: number;
+  approvedContributions: number;
+  rejectedContributions: number;
+  totalRatings: number;
+  totalPhotos: number;
+  reputationScore: number;
+  trustLevel: string;
+  trustLevelInfo: { minApproved: number; label: string };
+  badges: {
+    badgeId: string;
+    id: string;
+    name: string;
+    description: string;
+    icon: string;
+    category: string;
+  }[];
+  nextBadge: {
+    badge: { id: string; name: string; icon: string };
+    progress: number;
+    target: number;
+  } | null;
+  memberSince: string;
+}
+
+interface ApiResponse {
+  profile: ProfileData | null;
+  message?: string;
+}
+
+const TRUST_LEVEL_COLORS: Record<string, string> = {
+  NEW: "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300",
+  CONTRIBUTOR: "bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300",
+  TRUSTED: "bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300",
+  EXPERT: "bg-amber-100 text-amber-700 dark:bg-amber-900 dark:text-amber-300",
+};
+
+const TRUST_LEVEL_ICONS: Record<string, string> = {
+  NEW: "🌱",
+  CONTRIBUTOR: "🌿",
+  TRUSTED: "🌳",
+  EXPERT: "🏆",
+};
+
+export function ContributorProfileClient() {
+  const t = useTranslations("reputation");
+  const [profile, setProfile] = useState<ProfileData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function fetchProfile() {
+      try {
+        const res = await fetch("/api/reputation");
+        if (!res.ok) {
+          throw new Error("Failed to fetch profile");
+        }
+        const data: ApiResponse = await res.json();
+        setProfile(data.profile);
+      } catch {
+        setError("Failed to load profile");
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    fetchProfile();
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-16">
+        <div className="animate-pulse text-muted-foreground">
+          {t("loading")}
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="text-center py-16">
+        <p className="text-destructive mb-4">{error}</p>
+        <Link href="/contribute" className="text-primary hover:underline">
+          {t("contributions.startContributing")}
+        </Link>
+      </div>
+    );
+  }
+
+  if (!profile) {
+    return (
+      <div className="text-center py-16">
+        <p className="text-lg text-muted-foreground mb-6">{t("noProfile")}</p>
+        <Link
+          href="/contribute"
+          className="inline-flex items-center gap-2 px-6 py-3 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition-colors"
+        >
+          {t("contributions.startContributing")}
+        </Link>
+      </div>
+    );
+  }
+
+  const memberDate = new Date(profile.memberSince).toLocaleDateString(
+    undefined,
+    {
+      year: "numeric",
+      month: "long",
+    }
+  );
+
+  return (
+    <div className="space-y-8">
+      {/* Header with trust level */}
+      <div className="flex flex-col sm:flex-row items-start sm:items-center gap-4 p-6 rounded-xl border border-border bg-card">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-3 mb-2">
+            <span
+              className={`inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-sm font-medium ${
+                TRUST_LEVEL_COLORS[profile.trustLevel] || TRUST_LEVEL_COLORS.NEW
+              }`}
+            >
+              <span aria-hidden="true">
+                {TRUST_LEVEL_ICONS[profile.trustLevel] || "🌱"}
+              </span>
+              {t(`trustLevel.${profile.trustLevel}` as Parameters<typeof t>[0])}
+            </span>
+          </div>
+          <p className="text-sm text-muted-foreground">
+            {t(
+              `trustLevel.${profile.trustLevel}_description` as Parameters<
+                typeof t
+              >[0]
+            )}
+          </p>
+          <p className="text-xs text-muted-foreground mt-1">
+            {t("memberSince")} {memberDate}
+          </p>
+        </div>
+        <div className="flex items-center gap-2 px-4 py-2 rounded-lg bg-primary/5 border border-primary/20">
+          <span className="text-2xl font-bold text-primary">
+            {profile.reputationScore}
+          </span>
+          <span className="text-xs text-muted-foreground">
+            {t("stats.score")}
+          </span>
+        </div>
+      </div>
+
+      {/* Stats grid */}
+      <div>
+        <h2 className="text-lg font-semibold mb-4">{t("stats.title")}</h2>
+        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-4">
+          <StatCard
+            label={t("stats.totalContributions")}
+            value={profile.totalContributions}
+          />
+          <StatCard
+            label={t("stats.approved")}
+            value={profile.approvedContributions}
+            accent="green"
+          />
+          <StatCard
+            label={t("stats.rejected")}
+            value={profile.rejectedContributions}
+            accent={profile.rejectedContributions > 0 ? "red" : undefined}
+          />
+          <StatCard label={t("stats.ratings")} value={profile.totalRatings} />
+          <StatCard label={t("stats.photos")} value={profile.totalPhotos} />
+        </div>
+      </div>
+
+      {/* Badges */}
+      <BadgeDisplay
+        earnedBadges={profile.badges}
+        nextBadge={profile.nextBadge}
+      />
+
+      {/* Actions */}
+      <div className="flex flex-col sm:flex-row gap-3 pt-4 border-t border-border">
+        <Link
+          href="/contribute"
+          className="inline-flex items-center justify-center gap-2 px-5 py-2.5 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition-colors text-sm font-medium"
+        >
+          {t("contributions.startContributing")}
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+function StatCard({
+  label,
+  value,
+  accent,
+}: {
+  label: string;
+  value: number;
+  accent?: "green" | "red";
+}) {
+  const accentClasses =
+    accent === "green"
+      ? "text-green-600 dark:text-green-400"
+      : accent === "red"
+        ? "text-red-600 dark:text-red-400"
+        : "text-foreground";
+
+  return (
+    <div className="p-4 rounded-lg border border-border bg-card text-center">
+      <p className={`text-2xl font-bold ${accentClasses}`}>{value}</p>
+      <p className="text-xs text-muted-foreground mt-1">{label}</p>
+    </div>
+  );
+}

--- a/src/app/[locale]/contribute/profile/page.tsx
+++ b/src/app/[locale]/contribute/profile/page.tsx
@@ -1,0 +1,40 @@
+import { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
+import { ContributorProfileClient } from "./ContributorProfileClient";
+
+interface PageProps {
+  params: Promise<{ locale: string }>;
+}
+
+export async function generateMetadata({
+  params,
+}: PageProps): Promise<Metadata> {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "reputation" });
+
+  return {
+    title: t("title"),
+    description: t("description"),
+  };
+}
+
+export default async function ContributorProfilePage({ params }: PageProps) {
+  await params; // ensure locale is resolved
+  const t = await getTranslations("reputation");
+
+  return (
+    <main className="container mx-auto px-4 py-8">
+      <div className="max-w-3xl mx-auto">
+        {/* Header */}
+        <div className="text-center mb-10">
+          <h1 className="text-3xl font-bold mb-3">{t("title")}</h1>
+          <p className="text-muted-foreground max-w-xl mx-auto">
+            {t("description")}
+          </p>
+        </div>
+
+        <ContributorProfileClient />
+      </div>
+    </main>
+  );
+}

--- a/src/app/api/admin/contributions/[id]/route.ts
+++ b/src/app/api/admin/contributions/[id]/route.ts
@@ -3,6 +3,7 @@ import prisma from "@/lib/prisma";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/app/api/auth/[...nextauth]/route";
 import { captureApiError } from "@/lib/error-tracking";
+import { calculateReputation, type ContributorStats } from "@/lib/reputation";
 import type {
   ContributionStatus,
   ContributionPriority,
@@ -36,6 +37,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
       common_name_en: string | null;
       common_name_es: string | null;
       family: string | null;
+      region: string | null;
       proposed_images: string[];
       contributor_name: string | null;
       contributor_email: string | null;
@@ -76,6 +78,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
       commonNameEn: c.common_name_en,
       commonNameEs: c.common_name_es,
       family: c.family,
+      region: c.region,
       proposedImages: c.proposed_images,
       contributorName: c.contributor_name,
       contributorEmail: c.contributor_email,
@@ -155,6 +158,16 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
       WHERE id = ${id}
     `;
 
+    // Recalculate contributor reputation on status changes that affect scoring
+    if (["approve", "reject", "implement"].includes(action)) {
+      try {
+        await recalculateContributorReputation(id);
+      } catch (reputationError) {
+        // Non-blocking — log but don't fail the review action
+        console.warn("Failed to recalculate reputation:", reputationError);
+      }
+    }
+
     return NextResponse.json({
       success: true,
       message: `Contribution ${action}ed successfully`,
@@ -196,4 +209,153 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
       { status: 500 }
     );
   }
+}
+
+// ---------------------------------------------------------------------------
+// Reputation recalculation helper
+// ---------------------------------------------------------------------------
+
+interface ContributionCountRow {
+  type: string;
+  status: string;
+  count: bigint;
+}
+
+interface CountRow {
+  count: bigint;
+}
+
+/**
+ * Recalculate a contributor's reputation after a review action.
+ * Looks up the contribution's sessionId, aggregates all their stats,
+ * and upserts the ContributorProfile.
+ */
+async function recalculateContributorReputation(
+  contributionId: string
+): Promise<void> {
+  // Get the session ID for this contribution
+  const contributions = await prisma.$queryRaw<
+    [{ session_id: string }]
+  >`SELECT session_id FROM contributions WHERE id = ${contributionId}`;
+
+  if (contributions.length === 0) return;
+  const sessionId = contributions[0].session_id;
+
+  // Aggregate contribution stats
+  const contributionCounts = await prisma.$queryRaw<ContributionCountRow[]>`
+    SELECT type, status, COUNT(*) as count
+    FROM contributions
+    WHERE session_id = ${sessionId}
+    GROUP BY type, status
+  `;
+
+  // Count ratings
+  const ratingCounts = await prisma.$queryRaw<CountRow[]>`
+    SELECT COUNT(*) as count FROM tree_ratings WHERE session_id = ${sessionId}
+  `;
+
+  // Count approved photos
+  let photoCounts: CountRow[] = [{ count: BigInt(0) }];
+  try {
+    photoCounts = await prisma.$queryRaw<CountRow[]>`
+      SELECT COUNT(*) as count
+      FROM image_proposals
+      WHERE source = 'USER_UPLOAD'::"ImageProposalSource"
+      AND status IN ('APPROVED'::"ImageProposalStatus", 'APPLIED'::"ImageProposalStatus")
+      AND id IN (
+        SELECT proposal_id FROM image_audits
+        WHERE actor_session = ${sessionId}
+        AND action = 'PROPOSAL_CREATED'::"ImageAuditAction"
+      )
+    `;
+  } catch {
+    // image tables may not exist
+  }
+
+  // Check if already EXPERT (preserve admin-granted level)
+  const existingProfiles = await prisma.$queryRaw<
+    [{ trust_level: string }]
+  >`SELECT trust_level FROM contributor_profiles WHERE session_id = ${sessionId}`;
+  const isExpert =
+    existingProfiles.length > 0 && existingProfiles[0].trust_level === "EXPERT";
+
+  // Build stats
+  const stats: ContributorStats = {
+    totalContributions: contributionCounts.reduce(
+      (sum: number, r: ContributionCountRow) => sum + Number(r.count),
+      0
+    ),
+    approvedContributions: contributionCounts
+      .filter(
+        (r: ContributionCountRow) =>
+          r.status === "APPROVED" || r.status === "IMPLEMENTED"
+      )
+      .reduce(
+        (sum: number, r: ContributionCountRow) => sum + Number(r.count),
+        0
+      ),
+    rejectedContributions: contributionCounts
+      .filter((r: ContributionCountRow) => r.status === "REJECTED")
+      .reduce(
+        (sum: number, r: ContributionCountRow) => sum + Number(r.count),
+        0
+      ),
+    approvedKnowledge: contributionCounts
+      .filter(
+        (r: ContributionCountRow) =>
+          r.type === "LOCAL_KNOWLEDGE" &&
+          (r.status === "APPROVED" || r.status === "IMPLEMENTED")
+      )
+      .reduce(
+        (sum: number, r: ContributionCountRow) => sum + Number(r.count),
+        0
+      ),
+    approvedCorrections: contributionCounts
+      .filter(
+        (r: ContributionCountRow) =>
+          r.type === "CORRECTION" &&
+          (r.status === "APPROVED" || r.status === "IMPLEMENTED")
+      )
+      .reduce(
+        (sum: number, r: ContributionCountRow) => sum + Number(r.count),
+        0
+      ),
+    totalRatings: Number(ratingCounts[0]?.count || 0),
+    totalPhotos: Number(photoCounts[0]?.count || 0),
+    isExpert,
+  };
+
+  const result = calculateReputation(stats);
+
+  // Upsert the profile
+  await prisma.$executeRaw`
+    INSERT INTO contributor_profiles (
+      id, session_id, total_contributions, approved_contributions,
+      rejected_contributions, total_ratings, total_photos,
+      reputation_score, trust_level, badges, created_at, updated_at
+    ) VALUES (
+      gen_random_uuid()::text,
+      ${sessionId},
+      ${stats.totalContributions},
+      ${stats.approvedContributions},
+      ${stats.rejectedContributions},
+      ${stats.totalRatings},
+      ${stats.totalPhotos},
+      ${result.reputationScore},
+      ${result.trustLevel}::"TrustLevel",
+      ${result.badges}::text[],
+      NOW(),
+      NOW()
+    )
+    ON CONFLICT (session_id) DO UPDATE SET
+      total_contributions = EXCLUDED.total_contributions,
+      approved_contributions = EXCLUDED.approved_contributions,
+      rejected_contributions = EXCLUDED.rejected_contributions,
+      total_ratings = EXCLUDED.total_ratings,
+      total_photos = EXCLUDED.total_photos,
+      reputation_score = EXCLUDED.reputation_score,
+      trust_level = EXCLUDED.trust_level,
+      badges = EXCLUDED.badges,
+      updated_at = NOW()
+  `;
 }

--- a/src/app/api/contributions/route.ts
+++ b/src/app/api/contributions/route.ts
@@ -146,6 +146,7 @@ export async function POST(request: NextRequest) {
       commonNameEn: body.commonNameEn?.trim().substring(0, 255) || null,
       commonNameEs: body.commonNameEs?.trim().substring(0, 255) || null,
       family: body.family?.trim().substring(0, 100) || null,
+      region: body.region?.trim().substring(0, 255) || null,
       proposedImages: Array.isArray(body.proposedImages)
         ? body.proposedImages.slice(0, 10).map((url: string) => url.trim())
         : [],
@@ -161,9 +162,9 @@ export async function POST(request: NextRequest) {
     const result = await prisma.$queryRaw<[{ id: string }]>`
       INSERT INTO contributions (
         id, type, tree_slug, target_field, title, description, evidence,
-        scientific_name, common_name_en, common_name_es, family, proposed_images,
-        contributor_name, contributor_email, session_id, ip_hash, user_id,
-        status, priority, locale, created_at, updated_at
+        scientific_name, common_name_en, common_name_es, family, region,
+        proposed_images, contributor_name, contributor_email, session_id,
+        ip_hash, user_id, status, priority, locale, created_at, updated_at
       ) VALUES (
         gen_random_uuid()::text,
         ${contributionData.type}::"ContributionType",
@@ -176,6 +177,7 @@ export async function POST(request: NextRequest) {
         ${contributionData.commonNameEn},
         ${contributionData.commonNameEs},
         ${contributionData.family},
+        ${contributionData.region},
         ${contributionData.proposedImages}::text[],
         ${contributionData.contributorName},
         ${contributionData.contributorEmail},
@@ -277,6 +279,7 @@ interface ContributionRow {
   common_name_en: string | null;
   common_name_es: string | null;
   family: string | null;
+  region: string | null;
   proposed_images: string[];
   contributor_name: string | null;
   contributor_email: string | null;
@@ -291,6 +294,9 @@ interface ContributionRow {
   locale: string;
   created_at: Date;
   updated_at: Date;
+  // Joined from contributor_profiles (admin only)
+  trust_level: string | null;
+  reputation_score: number | null;
 }
 
 function transformContribution(c: ContributionRow, isAdmin: boolean) {
@@ -306,6 +312,7 @@ function transformContribution(c: ContributionRow, isAdmin: boolean) {
     commonNameEn: c.common_name_en,
     commonNameEs: c.common_name_es,
     family: c.family,
+    region: c.region,
     proposedImages: c.proposed_images,
     contributorName: isAdmin ? c.contributor_name : null,
     contributorEmail: isAdmin ? c.contributor_email : null,
@@ -313,6 +320,8 @@ function transformContribution(c: ContributionRow, isAdmin: boolean) {
     userId: c.user_id,
     status: c.status,
     priority: c.priority,
+    contributorTrustLevel: isAdmin ? c.trust_level : null,
+    contributorReputationScore: isAdmin ? c.reputation_score : null,
     reviewedBy: c.reviewed_by,
     reviewedAt: c.reviewed_at,
     reviewNotes: c.review_notes,
@@ -378,19 +387,19 @@ export async function GET(request: NextRequest) {
     // combination of filters is supported without a combinatorial if/else tree.
     // All values are validated above, so enum casts are safe.
     const conditions: Prisma.Sql[] = [];
-    if (!isAdmin) conditions.push(Prisma.sql`session_id = ${sessionId}`);
+    if (!isAdmin) conditions.push(Prisma.sql`c.session_id = ${sessionId}`);
     if (typeFilter)
-      conditions.push(Prisma.sql`type = ${typeFilter}::"ContributionType"`);
+      conditions.push(Prisma.sql`c.type = ${typeFilter}::"ContributionType"`);
     if (statusFilter)
       conditions.push(
-        Prisma.sql`status = ${statusFilter}::"ContributionStatus"`
+        Prisma.sql`c.status = ${statusFilter}::"ContributionStatus"`
       );
     if (priorityFilter)
       conditions.push(
-        Prisma.sql`priority = ${priorityFilter}::"ContributionPriority"`
+        Prisma.sql`c.priority = ${priorityFilter}::"ContributionPriority"`
       );
     if (treeSlugFilter)
-      conditions.push(Prisma.sql`tree_slug = ${treeSlugFilter}`);
+      conditions.push(Prisma.sql`c.tree_slug = ${treeSlugFilter}`);
 
     const whereClause =
       conditions.length > 0
@@ -398,11 +407,14 @@ export async function GET(request: NextRequest) {
         : Prisma.empty;
 
     const contributions = await prisma.$queryRaw<ContributionRow[]>`
-      SELECT * FROM contributions
+      SELECT c.*, cp.trust_level, cp.reputation_score
+      FROM contributions c
+      LEFT JOIN contributor_profiles cp ON c.session_id = cp.session_id
       ${whereClause}
-      ORDER BY created_at DESC LIMIT ${pageSize} OFFSET ${offset}`;
+      ORDER BY c.created_at DESC LIMIT ${pageSize} OFFSET ${offset}`;
     const countResult = await prisma.$queryRaw<[{ count: bigint }]>`
-      SELECT COUNT(*) as count FROM contributions
+      SELECT COUNT(*) as count FROM contributions c
+      LEFT JOIN contributor_profiles cp ON c.session_id = cp.session_id
       ${whereClause}`;
 
     const total = Number(countResult[0]?.count || 0);

--- a/src/app/api/reputation/route.ts
+++ b/src/app/api/reputation/route.ts
@@ -1,0 +1,356 @@
+import { NextRequest, NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+import { captureApiError } from "@/lib/error-tracking";
+import {
+  rateLimitOrNull,
+  getRateLimitResult,
+  addRateLimitHeaders,
+} from "@/lib/api-rate-limit";
+import {
+  calculateReputation,
+  getNextBadge,
+  BADGE_MAP,
+  TRUST_LEVEL_CONFIG,
+  type ContributorStats,
+} from "@/lib/reputation";
+
+interface ContributionCountRow {
+  type: string;
+  status: string;
+  count: bigint;
+}
+
+interface RatingCountRow {
+  count: bigint;
+}
+
+interface PhotoCountRow {
+  count: bigint;
+}
+
+interface ProfileRow {
+  id: string;
+  session_id: string;
+  display_name: string | null;
+  total_contributions: number;
+  approved_contributions: number;
+  rejected_contributions: number;
+  total_ratings: number;
+  total_photos: number;
+  reputation_score: number;
+  trust_level: string;
+  badges: string[];
+  created_at: Date;
+  updated_at: Date;
+}
+
+/**
+ * GET /api/reputation — Get current session's contributor profile
+ *
+ * Returns the contributor's reputation score, trust level, badges, and stats.
+ * Uses the contribution_session cookie for identification.
+ */
+export async function GET(request: NextRequest) {
+  // Rate limit
+  const blocked = rateLimitOrNull(request);
+  if (blocked) return blocked;
+
+  try {
+    const sessionId = request.cookies.get("contribution_session")?.value;
+
+    if (!sessionId) {
+      // No session — return empty profile (not an error)
+      const rl = getRateLimitResult(request);
+      const headers = new Headers();
+      addRateLimitHeaders(headers, rl);
+
+      return NextResponse.json(
+        {
+          profile: null,
+          message:
+            "No contribution session found. Submit a contribution to start building your reputation.",
+        },
+        { headers }
+      );
+    }
+
+    // Try to fetch existing profile
+    const profiles = await prisma.$queryRaw<ProfileRow[]>`
+      SELECT * FROM contributor_profiles WHERE session_id = ${sessionId}
+    `;
+
+    if (profiles.length > 0) {
+      const p = profiles[0];
+
+      // Compute nextBadge from stored stats
+      const storedStats: ContributorStats = {
+        totalContributions: p.total_contributions,
+        approvedContributions: p.approved_contributions,
+        rejectedContributions: p.rejected_contributions,
+        approvedKnowledge: 0, // Not stored separately, but getNextBadge handles gracefully
+        approvedCorrections: 0,
+        totalRatings: p.total_ratings,
+        totalPhotos: p.total_photos,
+      };
+      const nextBadge = getNextBadge(storedStats, p.badges);
+
+      const rl = getRateLimitResult(request);
+      const headers = new Headers();
+      addRateLimitHeaders(headers, rl);
+
+      return NextResponse.json(
+        {
+          profile: {
+            displayName: p.display_name,
+            totalContributions: p.total_contributions,
+            approvedContributions: p.approved_contributions,
+            rejectedContributions: p.rejected_contributions,
+            totalRatings: p.total_ratings,
+            totalPhotos: p.total_photos,
+            reputationScore: p.reputation_score,
+            trustLevel: p.trust_level,
+            trustLevelInfo:
+              TRUST_LEVEL_CONFIG[
+                p.trust_level as keyof typeof TRUST_LEVEL_CONFIG
+              ],
+            badges: p.badges
+              .map((badgeId: string) => {
+                const def = BADGE_MAP.get(badgeId);
+                return def ? { badgeId, ...def } : null;
+              })
+              .filter(Boolean),
+            nextBadge: nextBadge
+              ? {
+                  badge: {
+                    id: nextBadge.badge.id,
+                    name: nextBadge.badge.name,
+                    icon: nextBadge.badge.icon,
+                  },
+                  progress: nextBadge.progress,
+                  target: nextBadge.target,
+                }
+              : null,
+            memberSince: p.created_at,
+          },
+        },
+        { headers }
+      );
+    }
+
+    // No profile yet — compute from raw data
+    const stats = await computeStatsFromDb(sessionId);
+    if (!stats) {
+      const rl = getRateLimitResult(request);
+      const headers = new Headers();
+      addRateLimitHeaders(headers, rl);
+
+      return NextResponse.json(
+        {
+          profile: null,
+          message:
+            "No contributions found for this session. Submit a contribution to start building your reputation.",
+        },
+        { headers }
+      );
+    }
+
+    // Calculate reputation and create profile
+    const result = calculateReputation(stats);
+    const nextBadge = getNextBadge(stats, result.badges);
+
+    await prisma.$executeRaw`
+      INSERT INTO contributor_profiles (
+        id, session_id, total_contributions, approved_contributions,
+        rejected_contributions, total_ratings, total_photos,
+        reputation_score, trust_level, badges, created_at, updated_at
+      ) VALUES (
+        gen_random_uuid()::text,
+        ${sessionId},
+        ${stats.totalContributions},
+        ${stats.approvedContributions},
+        ${stats.rejectedContributions},
+        ${stats.totalRatings},
+        ${stats.totalPhotos},
+        ${result.reputationScore},
+        ${result.trustLevel}::"TrustLevel",
+        ${result.badges}::text[],
+        NOW(),
+        NOW()
+      )
+      ON CONFLICT (session_id) DO UPDATE SET
+        total_contributions = EXCLUDED.total_contributions,
+        approved_contributions = EXCLUDED.approved_contributions,
+        rejected_contributions = EXCLUDED.rejected_contributions,
+        total_ratings = EXCLUDED.total_ratings,
+        total_photos = EXCLUDED.total_photos,
+        reputation_score = EXCLUDED.reputation_score,
+        trust_level = EXCLUDED.trust_level,
+        badges = EXCLUDED.badges,
+        updated_at = NOW()
+    `;
+
+    const rl = getRateLimitResult(request);
+    const headers = new Headers();
+    addRateLimitHeaders(headers, rl);
+
+    return NextResponse.json(
+      {
+        profile: {
+          displayName: null,
+          totalContributions: stats.totalContributions,
+          approvedContributions: stats.approvedContributions,
+          rejectedContributions: stats.rejectedContributions,
+          totalRatings: stats.totalRatings,
+          totalPhotos: stats.totalPhotos,
+          reputationScore: result.reputationScore,
+          trustLevel: result.trustLevel,
+          trustLevelInfo: TRUST_LEVEL_CONFIG[result.trustLevel],
+          badges: result.badges
+            .map((badgeId) => {
+              const def = BADGE_MAP.get(badgeId);
+              return def ? { badgeId, ...def } : null;
+            })
+            .filter(Boolean),
+          nextBadge: nextBadge
+            ? {
+                badge: {
+                  id: nextBadge.badge.id,
+                  name: nextBadge.badge.name,
+                  icon: nextBadge.badge.icon,
+                },
+                progress: nextBadge.progress,
+                target: nextBadge.target,
+              }
+            : null,
+          memberSince: new Date(),
+        },
+      },
+      { headers }
+    );
+  } catch (error) {
+    captureApiError(error, "/api/reputation", "GET");
+
+    // Graceful fallback for missing tables
+    if (
+      error instanceof Error &&
+      (error.message.includes("contributor_profiles") ||
+        error.message.includes("P1001"))
+    ) {
+      return NextResponse.json(
+        {
+          profile: null,
+          message: "Reputation system is being set up. Please try again later.",
+        },
+        { status: 503 }
+      );
+    }
+
+    return NextResponse.json(
+      { error: "Failed to fetch reputation profile." },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * Compute contributor stats from raw database records.
+ * Used when no pre-computed profile exists yet.
+ */
+async function computeStatsFromDb(
+  sessionId: string
+): Promise<ContributorStats | null> {
+  try {
+    // Get contribution counts by type and status
+    const contributionCounts = await prisma.$queryRaw<ContributionCountRow[]>`
+      SELECT type, status, COUNT(*) as count
+      FROM contributions
+      WHERE session_id = ${sessionId}
+      GROUP BY type, status
+    `;
+
+    // Get rating count
+    const ratingCounts = await prisma.$queryRaw<RatingCountRow[]>`
+      SELECT COUNT(*) as count
+      FROM tree_ratings
+      WHERE session_id = ${sessionId}
+    `;
+
+    // Get photo count (approved image proposals from this session)
+    let photoCounts: PhotoCountRow[] = [{ count: BigInt(0) }];
+    try {
+      photoCounts = await prisma.$queryRaw<PhotoCountRow[]>`
+        SELECT COUNT(*) as count
+        FROM image_proposals
+        WHERE source = 'USER_UPLOAD'::"ImageProposalSource"
+        AND status IN ('APPROVED'::"ImageProposalStatus", 'APPLIED'::"ImageProposalStatus")
+        AND id IN (
+          SELECT proposal_id FROM image_audits
+          WHERE actor_session = ${sessionId}
+          AND action = 'PROPOSAL_CREATED'::"ImageAuditAction"
+        )
+      `;
+    } catch {
+      // image_proposals table may not exist; default to 0
+    }
+
+    const totalContributions = contributionCounts.reduce(
+      (sum: number, r: ContributionCountRow) => sum + Number(r.count),
+      0
+    );
+
+    if (totalContributions === 0 && Number(ratingCounts[0]?.count || 0) === 0) {
+      return null; // No activity at all
+    }
+
+    const approvedContributions = contributionCounts
+      .filter(
+        (r: ContributionCountRow) =>
+          r.status === "APPROVED" || r.status === "IMPLEMENTED"
+      )
+      .reduce(
+        (sum: number, r: ContributionCountRow) => sum + Number(r.count),
+        0
+      );
+
+    const rejectedContributions = contributionCounts
+      .filter((r: ContributionCountRow) => r.status === "REJECTED")
+      .reduce(
+        (sum: number, r: ContributionCountRow) => sum + Number(r.count),
+        0
+      );
+
+    const approvedKnowledge = contributionCounts
+      .filter(
+        (r: ContributionCountRow) =>
+          r.type === "LOCAL_KNOWLEDGE" &&
+          (r.status === "APPROVED" || r.status === "IMPLEMENTED")
+      )
+      .reduce(
+        (sum: number, r: ContributionCountRow) => sum + Number(r.count),
+        0
+      );
+
+    const approvedCorrections = contributionCounts
+      .filter(
+        (r: ContributionCountRow) =>
+          r.type === "CORRECTION" &&
+          (r.status === "APPROVED" || r.status === "IMPLEMENTED")
+      )
+      .reduce(
+        (sum: number, r: ContributionCountRow) => sum + Number(r.count),
+        0
+      );
+
+    return {
+      totalContributions,
+      approvedContributions,
+      rejectedContributions,
+      approvedKnowledge,
+      approvedCorrections,
+      totalRatings: Number(ratingCounts[0]?.count || 0),
+      totalPhotos: Number(photoCounts[0]?.count || 0),
+    };
+  } catch {
+    return null;
+  }
+}

--- a/src/components/BadgeDisplay.tsx
+++ b/src/components/BadgeDisplay.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { BADGE_DEFINITIONS, BADGE_MAP } from "@/lib/reputation";
+
+interface BadgeInfo {
+  badgeId: string;
+  id: string;
+  name: string;
+  description: string;
+  icon: string;
+  category: string;
+}
+
+interface BadgeDisplayProps {
+  /** Array of earned badge objects from API */
+  earnedBadges: BadgeInfo[];
+  /** Compact mode — shows only earned badges inline */
+  compact?: boolean;
+  /** Next badge progress info */
+  nextBadge?: {
+    badge: { id: string; name: string; icon: string };
+    progress: number;
+    target: number;
+  } | null;
+}
+
+export function BadgeDisplay({
+  earnedBadges,
+  compact = false,
+  nextBadge,
+}: BadgeDisplayProps) {
+  const t = useTranslations("reputation.badges");
+  const earnedIds = new Set(earnedBadges.map((b) => b.badgeId));
+
+  if (compact) {
+    return (
+      <div className="flex flex-wrap gap-2">
+        {earnedBadges.map((badge) => (
+          <span
+            key={badge.badgeId}
+            className="inline-flex items-center gap-1 px-2 py-1 rounded-full bg-primary/10 text-sm"
+            title={badge.description}
+          >
+            <span aria-hidden="true">{badge.icon}</span>
+            <span>{badge.name}</span>
+          </span>
+        ))}
+        {earnedBadges.length === 0 && (
+          <span className="text-sm text-muted-foreground italic">
+            {t("locked")}
+          </span>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <h3 className="text-lg font-semibold">{t("title")}</h3>
+
+      {/* Earned badges */}
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+        {BADGE_DEFINITIONS.map((badge) => {
+          const isEarned = earnedIds.has(badge.id);
+          return (
+            <div
+              key={badge.id}
+              className={`flex items-start gap-3 p-3 rounded-lg border transition-colors ${
+                isEarned
+                  ? "border-primary/30 bg-primary/5"
+                  : "border-border bg-muted/30 opacity-50"
+              }`}
+            >
+              <span
+                className={`text-2xl ${isEarned ? "" : "grayscale"}`}
+                aria-hidden="true"
+              >
+                {badge.icon}
+              </span>
+              <div className="min-w-0 flex-1">
+                <p
+                  className={`text-sm font-medium ${
+                    isEarned ? "text-foreground" : "text-muted-foreground"
+                  }`}
+                >
+                  {t(badge.id as Parameters<typeof t>[0])}
+                </p>
+                <p className="text-xs text-muted-foreground truncate">
+                  {t(`${badge.id}_desc` as Parameters<typeof t>[0])}
+                </p>
+                {isEarned && (
+                  <span className="inline-block mt-1 text-xs text-primary font-medium">
+                    ✓ {t("earned")}
+                  </span>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Next badge progress */}
+      {nextBadge && (
+        <div className="rounded-lg border border-border p-4 bg-card">
+          <p className="text-sm font-medium text-muted-foreground mb-2">
+            {t("nextBadge")}
+          </p>
+          <div className="flex items-center gap-3">
+            <span className="text-2xl" aria-hidden="true">
+              {nextBadge.badge.icon}
+            </span>
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-medium">
+                {BADGE_MAP.get(nextBadge.badge.id)?.name ||
+                  nextBadge.badge.name}
+              </p>
+              <div className="flex items-center gap-2 mt-1">
+                <div className="flex-1 h-2 bg-muted rounded-full overflow-hidden">
+                  <div
+                    className="h-full bg-primary rounded-full transition-all"
+                    style={{
+                      width: `${Math.min(100, (nextBadge.progress / nextBadge.target) * 100)}%`,
+                    }}
+                    role="progressbar"
+                    aria-valuenow={nextBadge.progress}
+                    aria-valuemin={0}
+                    aria-valuemax={nextBadge.target}
+                  />
+                </div>
+                <span className="text-xs text-muted-foreground whitespace-nowrap">
+                  {nextBadge.progress}/{nextBadge.target}
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {earnedBadges.length === BADGE_DEFINITIONS.length && (
+        <p className="text-center text-sm text-primary font-medium">
+          🏆 {t("allEarned")}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/ContributeCTA.tsx
+++ b/src/components/ContributeCTA.tsx
@@ -31,6 +31,13 @@ export async function ContributeCTA({ locale, treeSlug }: ContributeCTAProps) {
           <span aria-hidden="true">📷</span>
           {t("uploadPhoto")}
         </Link>
+        <Link
+          href={`/contribute?type=LOCAL_KNOWLEDGE&tree=${treeSlug}`}
+          className="inline-flex items-center gap-2 text-sm font-medium text-primary hover:text-primary-dark transition-colors"
+        >
+          <span aria-hidden="true">🧠</span>
+          {t("shareKnowledge")}
+        </Link>
       </div>
     </div>
   );

--- a/src/lib/reputation.ts
+++ b/src/lib/reputation.ts
@@ -1,0 +1,318 @@
+/**
+ * Contributor Reputation System
+ *
+ * Pure functions for calculating reputation scores, trust levels, and badges.
+ * No database dependencies — operates on aggregated stats.
+ *
+ * @see prisma/schema.prisma ContributorProfile model
+ */
+
+// ---------------------------------------------------------------------------
+// Trust Levels
+// ---------------------------------------------------------------------------
+
+export type TrustLevel = "NEW" | "CONTRIBUTOR" | "TRUSTED" | "EXPERT";
+
+export const TRUST_LEVELS: readonly TrustLevel[] = [
+  "NEW",
+  "CONTRIBUTOR",
+  "TRUSTED",
+  "EXPERT",
+] as const;
+
+export interface TrustLevelInfo {
+  level: TrustLevel;
+  label: string;
+  description: string;
+  minApproved: number;
+  maxRejectionRate: number;
+  adminOnly: boolean;
+}
+
+export const TRUST_LEVEL_CONFIG: Record<TrustLevel, TrustLevelInfo> = {
+  NEW: {
+    level: "NEW",
+    label: "New Contributor",
+    description: "Welcome! Your contributions will be reviewed by moderators.",
+    minApproved: 0,
+    maxRejectionRate: 1,
+    adminOnly: false,
+  },
+  CONTRIBUTOR: {
+    level: "CONTRIBUTOR",
+    label: "Contributor",
+    description: "An active community member with verified contributions.",
+    minApproved: 3,
+    maxRejectionRate: 0.5,
+    adminOnly: false,
+  },
+  TRUSTED: {
+    level: "TRUSTED",
+    label: "Trusted Contributor",
+    description:
+      "A reliable contributor with a strong track record of quality submissions.",
+    minApproved: 10,
+    maxRejectionRate: 0.2,
+    adminOnly: false,
+  },
+  EXPERT: {
+    level: "EXPERT",
+    label: "Expert",
+    description: "Recognized expert — this level is granted by administrators.",
+    minApproved: 0,
+    maxRejectionRate: 1,
+    adminOnly: true,
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Badges
+// ---------------------------------------------------------------------------
+
+export interface BadgeDefinition {
+  id: string;
+  name: string;
+  description: string;
+  icon: string; // Emoji icon for display
+  category: "contributions" | "knowledge" | "photos" | "ratings";
+}
+
+export const BADGE_DEFINITIONS: readonly BadgeDefinition[] = [
+  // Contribution badges
+  {
+    id: "first_contribution",
+    name: "First Steps",
+    description: "Submitted your first approved contribution",
+    icon: "🌱",
+    category: "contributions",
+  },
+  {
+    id: "naturalist_5",
+    name: "Naturalist",
+    description: "5 approved contributions",
+    icon: "🌿",
+    category: "contributions",
+  },
+  {
+    id: "naturalist_10",
+    name: "Expert Naturalist",
+    description: "10 approved contributions",
+    icon: "🌳",
+    category: "contributions",
+  },
+  {
+    id: "naturalist_25",
+    name: "Master Naturalist",
+    description: "25 approved contributions",
+    icon: "🏔️",
+    category: "contributions",
+  },
+  // Knowledge badges
+  {
+    id: "knowledge_keeper",
+    name: "Knowledge Keeper",
+    description: "3 approved local knowledge contributions",
+    icon: "🧠",
+    category: "knowledge",
+  },
+  {
+    id: "corrector",
+    name: "Fact Checker",
+    description: "5 approved corrections",
+    icon: "✏️",
+    category: "contributions",
+  },
+  // Photo badges
+  {
+    id: "photographer",
+    name: "Photographer",
+    description: "3 approved photo uploads",
+    icon: "📸",
+    category: "photos",
+  },
+  // Rating badges
+  {
+    id: "active_rater",
+    name: "Active Reviewer",
+    description: "Rated 10 or more trees",
+    icon: "⭐",
+    category: "ratings",
+  },
+  {
+    id: "explorer",
+    name: "Explorer",
+    description: "Rated 25 or more trees",
+    icon: "🧭",
+    category: "ratings",
+  },
+] as const;
+
+/** Map of badge ID → definition for quick lookup */
+export const BADGE_MAP = new Map<string, BadgeDefinition>(
+  BADGE_DEFINITIONS.map((b) => [b.id, b])
+);
+
+// ---------------------------------------------------------------------------
+// Contributor Stats (input to calculation)
+// ---------------------------------------------------------------------------
+
+export interface ContributorStats {
+  totalContributions: number;
+  approvedContributions: number;
+  rejectedContributions: number;
+  /** Number of approved LOCAL_KNOWLEDGE contributions */
+  approvedKnowledge: number;
+  /** Number of approved CORRECTION contributions */
+  approvedCorrections: number;
+  totalRatings: number;
+  totalPhotos: number;
+  /** Whether the user has been manually granted EXPERT level */
+  isExpert?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Reputation Calculation
+// ---------------------------------------------------------------------------
+
+export interface ReputationResult {
+  reputationScore: number;
+  trustLevel: TrustLevel;
+  badges: string[];
+}
+
+/**
+ * Calculate reputation score, trust level, and earned badges from stats.
+ *
+ * Scoring:
+ * - +10 per approved contribution
+ * - -3 per rejected contribution
+ * - +2 per rating given
+ * - +5 per approved photo
+ * - +15 bonus per approved local knowledge (on top of the +10)
+ *
+ * Trust level thresholds:
+ * - NEW: default
+ * - CONTRIBUTOR: 3+ approved, <50% rejection rate
+ * - TRUSTED: 10+ approved, <20% rejection rate
+ * - EXPERT: admin-granted only (preserved if isExpert=true)
+ */
+export function calculateReputation(stats: ContributorStats): ReputationResult {
+  // Calculate score
+  const score =
+    stats.approvedContributions * 10 +
+    stats.rejectedContributions * -3 +
+    stats.totalRatings * 2 +
+    stats.totalPhotos * 5 +
+    stats.approvedKnowledge * 15; // bonus for knowledge sharing
+
+  const reputationScore = Math.max(0, score);
+
+  // Calculate rejection rate
+  const totalReviewed =
+    stats.approvedContributions + stats.rejectedContributions;
+  const rejectionRate =
+    totalReviewed > 0 ? stats.rejectedContributions / totalReviewed : 0;
+
+  // Determine trust level
+  let trustLevel: TrustLevel = "NEW";
+
+  if (stats.isExpert) {
+    trustLevel = "EXPERT";
+  } else if (
+    stats.approvedContributions >= TRUST_LEVEL_CONFIG.TRUSTED.minApproved &&
+    rejectionRate <= TRUST_LEVEL_CONFIG.TRUSTED.maxRejectionRate
+  ) {
+    trustLevel = "TRUSTED";
+  } else if (
+    stats.approvedContributions >= TRUST_LEVEL_CONFIG.CONTRIBUTOR.minApproved &&
+    rejectionRate <= TRUST_LEVEL_CONFIG.CONTRIBUTOR.maxRejectionRate
+  ) {
+    trustLevel = "CONTRIBUTOR";
+  }
+
+  // Calculate earned badges
+  const badges: string[] = [];
+
+  if (stats.approvedContributions >= 1) badges.push("first_contribution");
+  if (stats.approvedContributions >= 5) badges.push("naturalist_5");
+  if (stats.approvedContributions >= 10) badges.push("naturalist_10");
+  if (stats.approvedContributions >= 25) badges.push("naturalist_25");
+  if (stats.approvedKnowledge >= 3) badges.push("knowledge_keeper");
+  if (stats.approvedCorrections >= 5) badges.push("corrector");
+  if (stats.totalPhotos >= 3) badges.push("photographer");
+  if (stats.totalRatings >= 10) badges.push("active_rater");
+  if (stats.totalRatings >= 25) badges.push("explorer");
+
+  return { reputationScore, trustLevel, badges };
+}
+
+/**
+ * Get the next badge the contributor is closest to earning.
+ * Returns null if all badges are earned.
+ */
+export function getNextBadge(
+  stats: ContributorStats,
+  earnedBadges: string[]
+): { badge: BadgeDefinition; progress: number; target: number } | null {
+  const thresholds: {
+    badgeId: string;
+    current: number;
+    target: number;
+  }[] = [
+    {
+      badgeId: "first_contribution",
+      current: stats.approvedContributions,
+      target: 1,
+    },
+    {
+      badgeId: "naturalist_5",
+      current: stats.approvedContributions,
+      target: 5,
+    },
+    {
+      badgeId: "naturalist_10",
+      current: stats.approvedContributions,
+      target: 10,
+    },
+    {
+      badgeId: "naturalist_25",
+      current: stats.approvedContributions,
+      target: 25,
+    },
+    {
+      badgeId: "knowledge_keeper",
+      current: stats.approvedKnowledge,
+      target: 3,
+    },
+    {
+      badgeId: "corrector",
+      current: stats.approvedCorrections,
+      target: 5,
+    },
+    { badgeId: "photographer", current: stats.totalPhotos, target: 3 },
+    { badgeId: "active_rater", current: stats.totalRatings, target: 10 },
+    { badgeId: "explorer", current: stats.totalRatings, target: 25 },
+  ];
+
+  // Find the first unearned badge with highest progress ratio
+  let best: {
+    badge: BadgeDefinition;
+    progress: number;
+    target: number;
+  } | null = null;
+  let bestRatio = -1;
+
+  for (const { badgeId, current, target } of thresholds) {
+    if (earnedBadges.includes(badgeId)) continue;
+    const badge = BADGE_MAP.get(badgeId);
+    if (!badge) continue;
+
+    const ratio = current / target;
+    if (ratio > bestRatio) {
+      bestRatio = ratio;
+      best = { badge, progress: current, target };
+    }
+  }
+
+  return best;
+}

--- a/src/types/contributions.ts
+++ b/src/types/contributions.ts
@@ -107,6 +107,9 @@ export interface Contribution {
   family: string | null;
   proposedImages: string[];
 
+  // Location context
+  region: string | null;
+
   // Contributor info
   contributorName: string | null;
   contributorEmail: string | null;
@@ -126,6 +129,10 @@ export interface Contribution {
   locale: string;
   createdAt: Date;
   updatedAt: Date;
+
+  // Reputation (populated for admin views)
+  contributorTrustLevel?: string | null;
+  contributorReputationScore?: number | null;
 }
 
 /**

--- a/tests/api/reputation.test.ts
+++ b/tests/api/reputation.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Tests for GET /api/reputation
+ *
+ * Covers:
+ *  - No session cookie → null profile
+ *  - Existing profile found → returns formatted profile with badges
+ *  - No profile but has activity → computes, upserts, returns profile
+ *  - No activity at all → null profile
+ *  - Database error → 503 graceful fallback
+ *  - NextBadge included in response
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+let mockProfile: Record<string, unknown>[] = [];
+let mockContributionCounts: Record<string, unknown>[] = [];
+let mockRatingCounts: Record<string, unknown>[] = [];
+let mockPhotoCounts: Record<string, unknown>[] = [];
+let dbError: Error | null = null;
+
+const queryRawMock = vi.fn(async (strings: TemplateStringsArray) => {
+  if (dbError) throw dbError;
+
+  const sql = strings.join(" ");
+
+  // Profile lookup
+  if (sql.includes("FROM contributor_profiles")) {
+    return mockProfile;
+  }
+
+  // Contribution counts
+  if (sql.includes("FROM contributions") && sql.includes("GROUP BY")) {
+    return mockContributionCounts;
+  }
+
+  // Rating count
+  if (sql.includes("FROM tree_ratings")) {
+    return mockRatingCounts;
+  }
+
+  // Photo count
+  if (sql.includes("FROM image_proposals")) {
+    return mockPhotoCounts;
+  }
+
+  return [];
+});
+
+const executeRawMock = vi.fn(async () => ({ count: 1 }));
+
+vi.mock("@/lib/prisma", () => ({
+  default: {
+    $queryRaw: queryRawMock,
+    $executeRaw: executeRawMock,
+  },
+}));
+
+vi.mock("@/lib/error-tracking", () => ({
+  captureApiError: vi.fn(),
+}));
+
+vi.mock("@/lib/api-rate-limit", () => ({
+  rateLimitOrNull: vi.fn(() => null),
+  getRateLimitResult: vi.fn(() => ({
+    success: true,
+    remaining: 10,
+    limit: 20,
+  })),
+  addRateLimitHeaders: vi.fn(),
+}));
+
+const { GET } = await import("@/app/api/reputation/route");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createRequest(sessionId?: string): NextRequest {
+  const req = new NextRequest(
+    new URL("/api/reputation", "http://localhost:3000")
+  );
+  if (sessionId) {
+    req.cookies.set("contribution_session", sessionId);
+  }
+  return req;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("GET /api/reputation", () => {
+  beforeEach(() => {
+    mockProfile = [];
+    mockContributionCounts = [];
+    mockRatingCounts = [{ count: BigInt(0) }];
+    mockPhotoCounts = [{ count: BigInt(0) }];
+    dbError = null;
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns null profile when no session cookie", async () => {
+    const res = await GET(createRequest());
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.profile).toBeNull();
+    expect(data.message).toBeTruthy();
+  });
+
+  it("returns existing profile from database", async () => {
+    mockProfile = [
+      {
+        id: "prof-1",
+        session_id: "test-session",
+        display_name: "Test User",
+        total_contributions: 5,
+        approved_contributions: 3,
+        rejected_contributions: 1,
+        total_ratings: 10,
+        total_photos: 2,
+        reputation_score: 57,
+        trust_level: "CONTRIBUTOR",
+        badges: ["first_contribution", "naturalist_5"],
+        created_at: new Date("2025-01-01"),
+        updated_at: new Date("2025-02-01"),
+      },
+    ];
+
+    const res = await GET(createRequest("test-session"));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.profile).not.toBeNull();
+    expect(data.profile.displayName).toBe("Test User");
+    expect(data.profile.trustLevel).toBe("CONTRIBUTOR");
+    expect(data.profile.reputationScore).toBe(57);
+    expect(data.profile.badges).toHaveLength(2);
+    expect(data.profile.badges[0].badgeId).toBe("first_contribution");
+    expect(data.profile.trustLevelInfo).toBeTruthy();
+    expect(data.profile.memberSince).toBeTruthy();
+  });
+
+  it("includes nextBadge in profile response", async () => {
+    mockProfile = [
+      {
+        id: "prof-1",
+        session_id: "test-session",
+        display_name: null,
+        total_contributions: 4,
+        approved_contributions: 4,
+        rejected_contributions: 0,
+        total_ratings: 0,
+        total_photos: 0,
+        reputation_score: 40,
+        trust_level: "CONTRIBUTOR",
+        badges: ["first_contribution"],
+        created_at: new Date("2025-01-01"),
+        updated_at: new Date("2025-02-01"),
+      },
+    ];
+
+    const res = await GET(createRequest("test-session"));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.profile.nextBadge).not.toBeNull();
+    expect(data.profile.nextBadge.badge.id).toBe("naturalist_5");
+    expect(data.profile.nextBadge.progress).toBe(4);
+    expect(data.profile.nextBadge.target).toBe(5);
+  });
+
+  it("computes profile from raw data when no profile record exists", async () => {
+    mockProfile = [];
+    mockContributionCounts = [
+      { type: "CORRECTION", status: "APPROVED", count: BigInt(2) },
+      { type: "LOCAL_KNOWLEDGE", status: "APPROVED", count: BigInt(1) },
+    ];
+    mockRatingCounts = [{ count: BigInt(5) }];
+    mockPhotoCounts = [{ count: BigInt(0) }];
+
+    const res = await GET(createRequest("new-session"));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.profile).not.toBeNull();
+    expect(data.profile.totalContributions).toBe(3);
+    expect(data.profile.approvedContributions).toBe(3);
+    expect(data.profile.totalRatings).toBe(5);
+    // Should have created/upserted the profile
+    expect(executeRawMock).toHaveBeenCalled();
+  });
+
+  it("returns null profile when session exists but no activity", async () => {
+    mockProfile = [];
+    mockContributionCounts = [];
+    mockRatingCounts = [{ count: BigInt(0) }];
+
+    const res = await GET(createRequest("empty-session"));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.profile).toBeNull();
+    expect(data.message).toBeTruthy();
+  });
+
+  it("returns 503 when contributor_profiles table is missing", async () => {
+    dbError = new Error('relation "contributor_profiles" does not exist');
+
+    const res = await GET(createRequest("test-session"));
+    const data = await res.json();
+
+    expect(res.status).toBe(503);
+    expect(data.profile).toBeNull();
+    expect(data.message).toContain("being set up");
+  });
+
+  it("returns 500 for unexpected errors", async () => {
+    dbError = new Error("unexpected database error");
+
+    const res = await GET(createRequest("test-session"));
+
+    expect(res.status).toBe(500);
+    const data = await res.json();
+    expect(data.error).toBeTruthy();
+  });
+});

--- a/tests/lib/reputation.test.ts
+++ b/tests/lib/reputation.test.ts
@@ -1,0 +1,418 @@
+/**
+ * Tests for src/lib/reputation.ts
+ *
+ * Covers:
+ *  - calculateReputation scoring formula
+ *  - Trust level determination (NEW, CONTRIBUTOR, TRUSTED, EXPERT)
+ *  - Badge earning logic for all 9 badges
+ *  - Edge cases: zero stats, negative score clamped, high rejection rate
+ *  - getNextBadge: progress tracking, all-earned case, closest-badge logic
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  calculateReputation,
+  getNextBadge,
+  BADGE_DEFINITIONS,
+  BADGE_MAP,
+  TRUST_LEVEL_CONFIG,
+  TRUST_LEVELS,
+  type ContributorStats,
+} from "@/lib/reputation";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Default zero-activity stats */
+function makeStats(
+  overrides: Partial<ContributorStats> = {}
+): ContributorStats {
+  return {
+    totalContributions: 0,
+    approvedContributions: 0,
+    rejectedContributions: 0,
+    approvedKnowledge: 0,
+    approvedCorrections: 0,
+    totalRatings: 0,
+    totalPhotos: 0,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// calculateReputation
+// ---------------------------------------------------------------------------
+
+describe("calculateReputation", () => {
+  describe("scoring", () => {
+    it("returns 0 for zero-activity stats", () => {
+      const result = calculateReputation(makeStats());
+      expect(result.reputationScore).toBe(0);
+    });
+
+    it("awards +10 per approved contribution", () => {
+      const result = calculateReputation(
+        makeStats({ totalContributions: 5, approvedContributions: 5 })
+      );
+      expect(result.reputationScore).toBe(50);
+    });
+
+    it("deducts -3 per rejected contribution", () => {
+      const result = calculateReputation(
+        makeStats({
+          totalContributions: 2,
+          approvedContributions: 1,
+          rejectedContributions: 1,
+        })
+      );
+      // 1*10 + 1*(-3) = 7
+      expect(result.reputationScore).toBe(7);
+    });
+
+    it("awards +2 per rating", () => {
+      const result = calculateReputation(makeStats({ totalRatings: 10 }));
+      expect(result.reputationScore).toBe(20);
+    });
+
+    it("awards +5 per approved photo", () => {
+      const result = calculateReputation(makeStats({ totalPhotos: 3 }));
+      expect(result.reputationScore).toBe(15);
+    });
+
+    it("awards +15 bonus per approved local knowledge", () => {
+      const result = calculateReputation(
+        makeStats({
+          totalContributions: 2,
+          approvedContributions: 2,
+          approvedKnowledge: 2,
+        })
+      );
+      // 2*10 (approved) + 2*15 (knowledge bonus) = 50
+      expect(result.reputationScore).toBe(50);
+    });
+
+    it("clamps score to minimum 0 (many rejections)", () => {
+      const result = calculateReputation(
+        makeStats({
+          totalContributions: 10,
+          approvedContributions: 0,
+          rejectedContributions: 10,
+        })
+      );
+      // 0*10 + 10*(-3) = -30 → clamped to 0
+      expect(result.reputationScore).toBe(0);
+    });
+
+    it("combines all scoring factors correctly", () => {
+      const result = calculateReputation(
+        makeStats({
+          totalContributions: 12,
+          approvedContributions: 10,
+          rejectedContributions: 2,
+          approvedKnowledge: 3,
+          approvedCorrections: 2,
+          totalRatings: 15,
+          totalPhotos: 4,
+        })
+      );
+      // 10*10 + 2*(-3) + 15*2 + 4*5 + 3*15
+      // = 100 - 6 + 30 + 20 + 45 = 189
+      expect(result.reputationScore).toBe(189);
+    });
+  });
+
+  describe("trust levels", () => {
+    it("assigns NEW for zero activity", () => {
+      const result = calculateReputation(makeStats());
+      expect(result.trustLevel).toBe("NEW");
+    });
+
+    it("assigns NEW for 2 approved (below CONTRIBUTOR threshold)", () => {
+      const result = calculateReputation(
+        makeStats({ totalContributions: 2, approvedContributions: 2 })
+      );
+      expect(result.trustLevel).toBe("NEW");
+    });
+
+    it("assigns CONTRIBUTOR for 3+ approved with low rejection rate", () => {
+      const result = calculateReputation(
+        makeStats({
+          totalContributions: 4,
+          approvedContributions: 3,
+          rejectedContributions: 1,
+        })
+      );
+      // rejection rate = 1/4 = 25% < 50%
+      expect(result.trustLevel).toBe("CONTRIBUTOR");
+    });
+
+    it("does NOT assign CONTRIBUTOR if rejection rate > 50%", () => {
+      const result = calculateReputation(
+        makeStats({
+          totalContributions: 8,
+          approvedContributions: 3,
+          rejectedContributions: 5,
+        })
+      );
+      // rejection rate = 5/8 = 62.5% > 50%
+      expect(result.trustLevel).toBe("NEW");
+    });
+
+    it("assigns CONTRIBUTOR when rejection rate equals exactly 50%", () => {
+      const result = calculateReputation(
+        makeStats({
+          totalContributions: 6,
+          approvedContributions: 3,
+          rejectedContributions: 3,
+        })
+      );
+      // rejection rate = 3/6 = 50% — <= 50% qualifies
+      expect(result.trustLevel).toBe("CONTRIBUTOR");
+    });
+
+    it("assigns TRUSTED for 10+ approved with low rejection rate", () => {
+      const result = calculateReputation(
+        makeStats({
+          totalContributions: 12,
+          approvedContributions: 10,
+          rejectedContributions: 2,
+        })
+      );
+      // rejection rate = 2/12 ≈ 16.7% < 20%
+      expect(result.trustLevel).toBe("TRUSTED");
+    });
+
+    it("does NOT assign TRUSTED if rejection rate >= 20%", () => {
+      const result = calculateReputation(
+        makeStats({
+          totalContributions: 15,
+          approvedContributions: 10,
+          rejectedContributions: 5,
+        })
+      );
+      // rejection rate = 5/15 ≈ 33% >= 20%
+      // But 10 approved, 33% rejection → falls back to CONTRIBUTOR check
+      // 33% < 50% and 10 >= 3 → CONTRIBUTOR
+      expect(result.trustLevel).toBe("CONTRIBUTOR");
+    });
+
+    it("preserves EXPERT when isExpert is true", () => {
+      const result = calculateReputation(makeStats({ isExpert: true }));
+      expect(result.trustLevel).toBe("EXPERT");
+    });
+
+    it("EXPERT overrides computed level", () => {
+      const result = calculateReputation(
+        makeStats({
+          totalContributions: 30,
+          approvedContributions: 25,
+          rejectedContributions: 0,
+          isExpert: true,
+        })
+      );
+      expect(result.trustLevel).toBe("EXPERT");
+    });
+  });
+
+  describe("badges", () => {
+    it("awards first_contribution at 1 approved", () => {
+      const result = calculateReputation(
+        makeStats({ totalContributions: 1, approvedContributions: 1 })
+      );
+      expect(result.badges).toContain("first_contribution");
+    });
+
+    it("awards naturalist_5 at 5 approved", () => {
+      const result = calculateReputation(
+        makeStats({ totalContributions: 5, approvedContributions: 5 })
+      );
+      expect(result.badges).toContain("naturalist_5");
+      expect(result.badges).toContain("first_contribution");
+    });
+
+    it("awards naturalist_10 at 10 approved", () => {
+      const result = calculateReputation(
+        makeStats({ totalContributions: 10, approvedContributions: 10 })
+      );
+      expect(result.badges).toContain("naturalist_10");
+    });
+
+    it("awards naturalist_25 at 25 approved", () => {
+      const result = calculateReputation(
+        makeStats({ totalContributions: 25, approvedContributions: 25 })
+      );
+      expect(result.badges).toContain("naturalist_25");
+    });
+
+    it("awards knowledge_keeper at 3 approved knowledge contributions", () => {
+      const result = calculateReputation(
+        makeStats({
+          totalContributions: 3,
+          approvedContributions: 3,
+          approvedKnowledge: 3,
+        })
+      );
+      expect(result.badges).toContain("knowledge_keeper");
+    });
+
+    it("awards corrector at 5 approved corrections", () => {
+      const result = calculateReputation(
+        makeStats({
+          totalContributions: 5,
+          approvedContributions: 5,
+          approvedCorrections: 5,
+        })
+      );
+      expect(result.badges).toContain("corrector");
+    });
+
+    it("awards photographer at 3 approved photos", () => {
+      const result = calculateReputation(makeStats({ totalPhotos: 3 }));
+      expect(result.badges).toContain("photographer");
+    });
+
+    it("awards active_rater at 10 ratings", () => {
+      const result = calculateReputation(makeStats({ totalRatings: 10 }));
+      expect(result.badges).toContain("active_rater");
+    });
+
+    it("awards explorer at 25 ratings", () => {
+      const result = calculateReputation(makeStats({ totalRatings: 25 }));
+      expect(result.badges).toContain("explorer");
+      expect(result.badges).toContain("active_rater");
+    });
+
+    it("awards no badges for zero activity", () => {
+      const result = calculateReputation(makeStats());
+      expect(result.badges).toEqual([]);
+    });
+
+    it("does NOT award badges below threshold", () => {
+      const result = calculateReputation(
+        makeStats({
+          totalContributions: 4,
+          approvedContributions: 4,
+          approvedKnowledge: 2,
+          approvedCorrections: 4,
+          totalRatings: 9,
+          totalPhotos: 2,
+        })
+      );
+      expect(result.badges).not.toContain("naturalist_5");
+      expect(result.badges).not.toContain("knowledge_keeper");
+      expect(result.badges).not.toContain("corrector");
+      expect(result.badges).not.toContain("active_rater");
+      expect(result.badges).not.toContain("photographer");
+      // But should earn first_contribution
+      expect(result.badges).toContain("first_contribution");
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getNextBadge
+// ---------------------------------------------------------------------------
+
+describe("getNextBadge", () => {
+  it("returns the closest unearned badge", () => {
+    const stats = makeStats({
+      totalContributions: 4,
+      approvedContributions: 4,
+    });
+    const earned = ["first_contribution"];
+    const next = getNextBadge(stats, earned);
+    expect(next).not.toBeNull();
+    expect(next!.badge.id).toBe("naturalist_5");
+    expect(next!.progress).toBe(4);
+    expect(next!.target).toBe(5);
+  });
+
+  it("returns null when all badges are earned", () => {
+    const stats = makeStats({
+      totalContributions: 25,
+      approvedContributions: 25,
+      approvedKnowledge: 3,
+      approvedCorrections: 5,
+      totalRatings: 25,
+      totalPhotos: 3,
+    });
+    const allBadgeIds = BADGE_DEFINITIONS.map((b) => b.id);
+    const next = getNextBadge(stats, allBadgeIds);
+    expect(next).toBeNull();
+  });
+
+  it("prefers the badge with highest progress ratio", () => {
+    const stats = makeStats({
+      totalContributions: 2,
+      approvedContributions: 2,
+      totalRatings: 9, // 9/10 = 90% toward active_rater
+    });
+    const earned = ["first_contribution"];
+    const next = getNextBadge(stats, earned);
+    // 9/10 = 90% vs 2/5 = 40% (naturalist_5)
+    expect(next).not.toBeNull();
+    expect(next!.badge.id).toBe("active_rater");
+    expect(next!.progress).toBe(9);
+    expect(next!.target).toBe(10);
+  });
+
+  it("works with zero progress (brand new user)", () => {
+    const stats = makeStats();
+    const next = getNextBadge(stats, []);
+    expect(next).not.toBeNull();
+    // Should return some badge (first_contribution with 0/1)
+    expect(next!.progress).toBe(0);
+    expect(next!.target).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+describe("constants", () => {
+  it("TRUST_LEVELS has 4 levels", () => {
+    expect(TRUST_LEVELS).toHaveLength(4);
+  });
+
+  it("TRUST_LEVEL_CONFIG has entries for all levels", () => {
+    for (const level of TRUST_LEVELS) {
+      expect(TRUST_LEVEL_CONFIG).toHaveProperty(level);
+      expect(TRUST_LEVEL_CONFIG[level].level).toBe(level);
+    }
+  });
+
+  it("BADGE_DEFINITIONS has 9 badges", () => {
+    expect(BADGE_DEFINITIONS).toHaveLength(9);
+  });
+
+  it("BADGE_MAP contains all badge definitions", () => {
+    expect(BADGE_MAP.size).toBe(BADGE_DEFINITIONS.length);
+    for (const badge of BADGE_DEFINITIONS) {
+      expect(BADGE_MAP.has(badge.id)).toBe(true);
+    }
+  });
+
+  it("all badges have required fields", () => {
+    for (const badge of BADGE_DEFINITIONS) {
+      expect(badge.id).toBeTruthy();
+      expect(badge.name).toBeTruthy();
+      expect(badge.description).toBeTruthy();
+      expect(badge.icon).toBeTruthy();
+      expect(["contributions", "knowledge", "photos", "ratings"]).toContain(
+        badge.category
+      );
+    }
+  });
+
+  it("EXPERT trust level is admin-only", () => {
+    expect(TRUST_LEVEL_CONFIG.EXPERT.adminOnly).toBe(true);
+  });
+
+  it("non-EXPERT trust levels are not admin-only", () => {
+    expect(TRUST_LEVEL_CONFIG.NEW.adminOnly).toBe(false);
+    expect(TRUST_LEVEL_CONFIG.CONTRIBUTOR.adminOnly).toBe(false);
+    expect(TRUST_LEVEL_CONFIG.TRUSTED.adminOnly).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Completes **P6.2: Community Contributions — Remaining** by implementing the full contributor reputation system and fixing 3 bugs in the local knowledge sharing flow.

## Bug Fixes

- **Region field silently dropped** — `ContributeClient` collected `region`/`whereFound` but the payload construction omitted them. Fixed mapping for both `LOCAL_KNOWLEDGE` and `NEW_SPECIES` types. Added `region` column to schema + API.
- **Unused "Share local knowledge" CTA** — Translation keys `contributeCta.shareKnowledge` existed but no link was rendered in `ContributeCTA`. Added third CTA link pointing to `/contribute?type=LOCAL_KNOWLEDGE&tree={slug}`.
- **No URL param pre-selection** — Added `searchParams` handling in contribute page, `initialType`/`initialTree` props in `ContributeClient` for deep-linking from tree detail CTAs.
- **Region not shown in admin** — Added region display in admin contribution detail modal.

## New Features

### Reputation System
- **Prisma model**: `ContributorProfile` with `TrustLevel` enum (NEW/CONTRIBUTOR/TRUSTED/EXPERT), session-based identity, stats tracking, badges array
- **Pure logic module** (`src/lib/reputation.ts`): `calculateReputation()` scoring (+10/approved, -3/rejected, +2/rating, +5/photo, +15/knowledge bonus), `getNextBadge()` progress tracking, 9 badge definitions, 4 trust level configs
- **API endpoint**: `GET /api/reputation` — fetches/computes contributor profile with badges and next badge progress, session cookie auth, rate limited, graceful 503 fallback
- **Admin integration**: Reputation recalculation on approve/reject/implement; trust level + reputation score visible in contribution list and detail modal
- **Profile page**: `/contribute/profile` — trust level badge, stats grid, full badge display with earned/unearned states and progress bar
- **BadgeDisplay component**: Compact (inline) and expanded (full grid) variants with progress tracking
- **i18n**: Complete `reputation` namespace in EN + ES (~60 keys each)
- **Profile link**: "View Your Contributions" button on submission success screen

### Badges (9 total)
| Badge | Requirement |
|-------|------------|
| 🌱 First Steps | 1 approved contribution |
| 🌿 Naturalist | 5 approved contributions |
| 🌳 Expert Naturalist | 10 approved contributions |
| 🏔️ Master Naturalist | 25 approved contributions |
| 🧠 Knowledge Keeper | 3 approved local knowledge |
| ✏️ Fact Checker | 5 approved corrections |
| 📸 Photographer | 3 approved photos |
| ⭐ Active Reviewer | 10 tree ratings |
| 🧭 Explorer | 25 tree ratings |

### Trust Levels
| Level | Requirement |
|-------|------------|
| 🌱 New | Default |
| 🌿 Contributor | 3+ approved, <50% rejection |
| 🌳 Trusted | 10+ approved, <20% rejection |
| 🏆 Expert | Admin-granted only |

## Migration

```sql
ALTER TABLE contributions ADD COLUMN region VARCHAR(255);
CREATE TYPE "TrustLevel" AS ENUM ('NEW', 'CONTRIBUTOR', 'TRUSTED', 'EXPERT');
CREATE TABLE contributor_profiles (...);
```

## Testing

- **46 new tests** (39 unit + 7 API)
- **623/623 total tests passing** (baseline was 577)
- 0 lint errors, build clean

## Files Changed

### Created (8)
- `prisma/migrations/20260228000000_add_contributor_profiles/migration.sql`
- `src/lib/reputation.ts`
- `src/app/api/reputation/route.ts`
- `src/components/BadgeDisplay.tsx`
- `src/app/[locale]/contribute/profile/page.tsx`
- `src/app/[locale]/contribute/profile/ContributorProfileClient.tsx`
- `tests/lib/reputation.test.ts`
- `tests/api/reputation.test.ts`

### Modified (11)
- `prisma/schema.prisma`, `src/types/contributions.ts`
- `src/app/api/contributions/route.ts`, `src/app/api/admin/contributions/[id]/route.ts`
- `src/app/[locale]/contribute/ContributeClient.tsx`, `page.tsx`
- `src/components/ContributeCTA.tsx`
- `src/app/[locale]/admin/contributions/ContributionsListClient.tsx`
- `messages/en.json`, `messages/es.json`
- `docs/IMPLEMENTATION_PLAN.md`, `docs/NEXT_AGENT_HANDOFF.md`