### PR TITLE
perf: P4.6 — Fix LCP by removing priority from below-fold images

### DIFF
--- a/docs/NEXT_AGENT_HANDOFF.md
+++ b/docs/NEXT_AGENT_HANDOFF.md
@@ -13,20 +13,20 @@ Last updated: 2026-02-28
 
 ## Latest Changes
 
-**Branch**: `feature/p6.2-reputation-system`
+**Branch**: `fix/p4.6-lcp-image-optimization` — PR #529
 
-- P6.2 User Reputation System — complete (Prisma model, API, profile page, BadgeDisplay, i18n)
-- Tree rating system — complete (DB, API, UI, i18n)
-- SQL injection fix in `/api/contributions` GET (was `$queryRawUnsafe` with string concat)
-- Bug fixes: region field in contributions, CTA deep-linking, admin display
-- 46 new tests (reputation logic + API)
+- P4.6 LCP image optimization: removed `priority` + `fetchPriority="high"` from below-fold images
+- TreeOfTheDay (4th section) and FeaturedTreesSection (6th section) were preloading images, competing with the hero LCP image for bandwidth
+- Only the hero image now has priority on the homepage; `/trees` index page priority unchanged
+- `next.config.ts` already had `formats: ["image/avif", "image/webp"]` — no changes needed
+- Included package-lock.json updates
 
 ## Current State
 
-- **Tests**: 623/623 passing
+- **Tests**: 622/623 passing (1 pre-existing flaky timing test in redos.test.ts)
 - **Content**: 175 trees × 2 locales, 20 comparisons × 2, 150 glossary × 2
-- **Database**: Neon PostgreSQL, Prisma 7, all migrations applied including `tree_ratings` and `contributor_profiles`
-- **Lighthouse**: 85 perf / 100 SEO / 100 BP
+- **Database**: Neon PostgreSQL, Prisma 7, all migrations applied
+- **Lighthouse**: LCP fix deployed — needs re-measurement after merge
 - **All P2–P6 tasks complete** — see `docs/IMPLEMENTATION_PLAN.md` for full status
 - **Error tracking**: Sentry-ready (zero deps, console fallback)
 - **Public API**: 7 v1 endpoints with OpenAPI 3.1 spec
@@ -34,18 +34,21 @@ Last updated: 2026-02-28
 ## In-Flight / Gotchas
 
 - `orey` is the only tree without an iNaturalist gallery (no photos available)
-- LCP is 4.0s — network-bound, not code-fixable
+- LCP was 4.0s — priority fix should improve; re-run Lighthouse after merge to measure
+- 300ms render-blocking CSS is the Tailwind bundle; marginal gains from splitting print.css (~3KB gzipped) not worth the complexity
 - `'unsafe-inline'` in CSP `style-src` is intentional (irreducible runtime values)
 - Sentry DSN not yet configured in Vercel env vars (works via console fallback)
+- `redos.test.ts` timing test is flaky (expects <1ms, sometimes takes 1.2ms)
 
 ## What's Next
 
 Pick from `docs/IMPLEMENTATION_PLAN.md`. Top candidates:
 
-1. Install `@sentry/nextjs` and configure DSN in Vercel (manual step)
-2. P7 — additional languages (requires native speaker review)
-3. P8 — UX enhancements (search autocomplete, offline support, perf monitoring)
-4. General polish and tech debt
+1. Re-run Lighthouse after P4.6 merge to validate LCP improvement
+2. P9.7 — Search autocomplete (suggestions dropdown, keyboard nav, debounce)
+3. P9.8 — Region/province filter for tree directory
+4. Install `@sentry/nextjs` and configure DSN in Vercel (manual step)
+5. General polish and tech debt
 
 ## Operator Preferences
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1706,12 +1706,43 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/@eslint/js": {
       "version": "9.39.3",
@@ -9560,6 +9591,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/globalthis": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
@@ -15037,6 +15081,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/style-to-js": {

--- a/src/components/FeaturedTreesSection.tsx
+++ b/src/components/FeaturedTreesSection.tsx
@@ -37,13 +37,8 @@ export function FeaturedTreesSection({
 
       {featuredTreesList.length > 0 ? (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
-          {featuredTreesList.map((tree, index) => (
-            <TreeCard
-              key={tree.slug}
-              tree={tree}
-              locale={locale}
-              priority={index < 2}
-            />
+          {featuredTreesList.map((tree) => (
+            <TreeCard key={tree.slug} tree={tree} locale={locale} />
           ))}
         </div>
       ) : (

--- a/src/components/home/TreeOfTheDay.tsx
+++ b/src/components/home/TreeOfTheDay.tsx
@@ -63,8 +63,6 @@ export function TreeOfTheDay({
               fill
               sizes="(max-width: 768px) 100vw, 40vw"
               quality={70}
-              priority
-              fetchPriority="high"
               className="object-cover"
               fallback="placeholder"
             />


### PR DESCRIPTION
## Summary

Fix LCP bandwidth competition by removing `priority` and `fetchPriority` from below-fold homepage images. Only the hero image should be priority-loaded.

## Problem

The homepage had **4 priority-loaded images** competing for bandwidth:
1. **Hero image** (above-fold) — correct ✅
2. **TreeOfTheDay** (4th section, below-fold) — `priority` + `fetchPriority="high"` ❌
3. **FeaturedTreesSection** (6th section, way below-fold) — `priority={index < 2}` on first 2 cards ❌

With 4 preloaded images, the browser splits bandwidth across all of them, slowing the actual LCP element (hero image) from loading quickly. This was a primary cause of the 4.0s LCP.

## Changes

- **`TreeOfTheDay.tsx`**: Removed `priority` and `fetchPriority="high"` from the `SafeImage`. The image now lazy-loads, freeing bandwidth for the hero.
- **`FeaturedTreesSection.tsx`**: Removed `priority={index < 2}` from the `TreeCard` loop. These cards are 6 sections below the fold and should never be preloaded.
- **`package-lock.json`**: Updated from `npm install`.

## What stays the same

- **Hero image** keeps `priority` + `fetchPriority="high"` + preload hints — it's the LCP element ✅
- **Trees index page** (`/trees`) keeps `priority={index < 2}` on first 2 cards — those ARE the LCP element on that page ✅
- **`next.config.ts`** already has `formats: ["image/avif", "image/webp"]` — AVIF is prioritized ✅

## Validation

- ✅ Build passes
- ✅ 0 lint errors (286 pre-existing warnings)
- ✅ 622/623 tests pass (1 pre-existing flaky timing test)

## Impact

By concentrating all priority bandwidth on the single above-fold hero image, LCP should improve significantly. The hero image (AVIF via `<picture>` element with preload hints) can now load without competition.

## Summary by Sourcery

Concentrate image loading priority on the homepage hero by removing priority hints from below-the-fold images to improve LCP.

Bug Fixes:
- Stop below-the-fold homepage images from competing with the hero image for bandwidth by removing their priority loading hints.

Enhancements:
- Simplify FeaturedTreesSection card rendering by no longer marking any featured tree images as priority-loaded.

Build:
- Refresh package-lock.json from the latest dependency resolution.