### PR TITLE
feat: Add province filter and URL param persistence to tree directory

### DIFF
--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -78,15 +78,16 @@
 - [x] Keyboard navigation for suggestions (ArrowUp/Down, Enter to select, Escape to close)
 - [x] Debounce input (200-300ms) to avoid excessive searches
 
-### 3. Region/Province Filter (P9.8) — Medium
+### 3. Region/Province Filter (P9.8) — ✅ Complete
 
 **Impact:** Medium — Costa Rican users want to find trees in their region
 **Effort:** Medium
+**Current:** Province dropdown filter on `/trees` page, URL param persistence for all filters
 
-- [ ] Add province/region filter to tree directory (`/trees` page)
-- [ ] Filter by Costa Rican provinces: San José, Alajuela, Cartago, Heredia, Guanacaste, Puntarenas, Limón
-- [ ] Cross-reference with tree `distribution` frontmatter data
-- [ ] Persist filter selection in URL params for shareability
+- [x] Add province/region filter to tree directory (`/trees` page)
+- [x] Filter by Costa Rican provinces: San José, Alajuela, Cartago, Heredia, Guanacaste, Puntarenas, Limón
+- [x] Cross-reference with tree `distribution` frontmatter data
+- [x] Persist filter selection in URL params for shareability
 
 ### 4. Advanced Search & Filtering (P9.10) — Medium
 

--- a/docs/NEXT_AGENT_HANDOFF.md
+++ b/docs/NEXT_AGENT_HANDOFF.md
@@ -13,7 +13,7 @@ Last updated: 2026-02-28
 
 ## Latest Changes
 
-**Branch**: `feature/province-filter` — PR #TBD
+**Branch**: `feature/province-filter` — PR #534
 
 - Added province/region filter to tree directory (`/trees` page)
 - Province dropdown in filter panel shows all 7 Costa Rican provinces with tree counts

--- a/docs/NEXT_AGENT_HANDOFF.md
+++ b/docs/NEXT_AGENT_HANDOFF.md
@@ -13,22 +13,25 @@ Last updated: 2026-02-28
 
 ## Latest Changes
 
-**Branch**: `feature/i18n-cleanup-inline-ternaries` — PR #532
+**Branch**: `feature/province-filter` — PR #TBD
 
-- Migrated ~47 inline `locale === "es"` ternaries to `useTranslations()` across 5 components
-- TreeExplorer (25+), KeyboardShortcuts (15), FavoriteButton (4), ConfusionRatingBadge (2), TableOfContents (1)
-- Added 4 new i18n namespaces: `favorites`, `toc`, `keyboardShortcuts`, plus 15 new `trees` keys and 1 `comparison` key
-- Removed `locale` prop from `FavoriteButton` and `TableOfContents` (callers updated)
-- Added `confusionLevelLabel` to `ConfusionRatingConfig` interface
+- Added province/region filter to tree directory (`/trees` page)
+- Province dropdown in filter panel shows all 7 Costa Rican provinces with tree counts
+- URL parameter persistence for all filters (`?province=guanacaste&family=Fabaceae&q=ceiba&sort=family&view=alphabetical`)
+- Filters auto-open when URL contains filter parameters (shareable links)
+- Added i18n keys for province names and filter labels (both `en.json` and `es.json`)
+- 7 new tests for distribution filtering and facet extraction
+- Filter panel grid updated to 5 columns on XL screens to accommodate province dropdown
 
 ## Current State
 
-- **Tests**: 623/623 passing
+- **Tests**: 630/630 passing (623 + 7 new)
 - **Content**: 175 trees × 2 locales, 20 comparisons × 2, 150 glossary × 2
 - **Database**: Neon PostgreSQL, Prisma 7, all migrations applied
 - **Search**: Autocomplete dropdown on `/trees`, QuickSearch modal in nav — both with keyboard nav
-- **i18n**: All major client components now use `useTranslations()` — no more inline ternaries in core UI
-- **All P2–P6 + P9.7 tasks complete** — see `docs/IMPLEMENTATION_PLAN.md` for full status
+- **Filters**: Family, conservation status, province, tags, safety — all with URL param persistence
+- **i18n**: All major client components use `useTranslations()` — no inline ternaries in core UI
+- **All P2–P6 + P9.7–P9.8 tasks complete** — see `docs/IMPLEMENTATION_PLAN.md`
 - **Error tracking**: Sentry-ready (zero deps, console fallback)
 - **Public API**: 7 v1 endpoints with OpenAPI 3.1 spec
 
@@ -40,15 +43,16 @@ Last updated: 2026-02-28
 - `'unsafe-inline'` in CSP `style-src` is intentional (irreducible runtime values)
 - Sentry DSN not yet configured in Vercel env vars (works via console fallback)
 - `redos.test.ts` timing test is flaky (expects <1ms, sometimes takes 1.2ms)
+- `useSearchParams()` in TreeExplorer requires Suspense boundary — provided by `next/dynamic` loading fallback
 
 ## What's Next
 
 Pick from `docs/IMPLEMENTATION_PLAN.md`. Top candidates:
 
 1. Re-run Lighthouse after P4.6 merge to validate LCP improvement
-2. P9.8 — Region/province filter for tree directory
-3. P9.10 — Advanced search & filtering (bloom time, size, uses, conservation)
-4. Install `@sentry/nextjs` and configure DSN in Vercel (manual step)
+2. P9.10 — Advanced search & filtering (bloom time, size, uses, conservation)
+3. Install `@sentry/nextjs` and configure DSN in Vercel (manual step)
+4. P8.2 — Offline enhancements (download species, offline search)
 
 ## Operator Preferences
 

--- a/messages/en.json
+++ b/messages/en.json
@@ -115,7 +115,18 @@
     "showingOf": "Showing {showing} of {total}",
     "matchingTrees": "{count, plural, =1 {1 tree matches} other {# trees match}}",
     "noResultsFiltered": "No trees found with selected filters",
-    "noTreesFound": "No trees found"
+    "noTreesFound": "No trees found",
+    "filterByProvince": "Province",
+    "allProvinces": "All Provinces",
+    "provinces": {
+      "guanacaste": "Guanacaste",
+      "puntarenas": "Puntarenas",
+      "alajuela": "Alajuela",
+      "heredia": "Heredia",
+      "san-jose": "San José",
+      "cartago": "Cartago",
+      "limon": "Limón"
+    }
   },
   "footer": {
     "description": "An open-source project dedicated to documenting the trees of Costa Rica.",

--- a/messages/es.json
+++ b/messages/es.json
@@ -114,7 +114,18 @@
     "showingOf": "Mostrando {showing} de {total}",
     "matchingTrees": "{count, plural, =1 {1 árbol coincide} other {# árboles coinciden}}",
     "noResultsFiltered": "No se encontraron árboles con los filtros seleccionados",
-    "noTreesFound": "No se encontraron árboles"
+    "noTreesFound": "No se encontraron árboles",
+    "filterByProvince": "Provincia",
+    "allProvinces": "Todas las Provincias",
+    "provinces": {
+      "guanacaste": "Guanacaste",
+      "puntarenas": "Puntarenas",
+      "alajuela": "Alajuela",
+      "heredia": "Heredia",
+      "san-jose": "San José",
+      "cartago": "Cartago",
+      "limon": "Limón"
+    }
   },
   "footer": {
     "description": "Un proyecto de código abierto dedicado a documentar los árboles de Costa Rica.",

--- a/src/components/tree/TreeExplorer.tsx
+++ b/src/components/tree/TreeExplorer.tsx
@@ -39,7 +39,7 @@ function isProvince(dist: Distribution): dist is Province {
 // ============================================================================
 
 const VALID_SORT_FIELDS: SortField[] = ["title", "scientificName", "family"];
-const VALID_VIEW_MODES: ViewMode[] = ["grid", "alphabetical"];
+const VALID_VIEW_MODES = ["grid", "alphabetical"] as const;
 
 function parseFilterFromParams(params: URLSearchParams): TreeFilter {
   const filter: TreeFilter = {};

--- a/src/components/tree/TreeExplorer.tsx
+++ b/src/components/tree/TreeExplorer.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useMemo, useCallback, useEffect, useRef } from "react";
 import { useLocale, useTranslations } from "next-intl";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { search, filterTrees, sortTrees, extractFacets } from "@/lib/search";
 import { TAG_DEFINITIONS, getTagLabel, getUILabel } from "@/lib/i18n";
 import { TreeGrid } from "./TreeCard";
@@ -14,7 +14,55 @@ import type {
   TreeSort,
   Locale,
   TreeTag,
+  Distribution,
+  Province,
+  SortField,
 } from "@/types/tree";
+
+// Costa Rica provinces — used to separate province facets from region facets
+const PROVINCES: Province[] = [
+  "guanacaste",
+  "puntarenas",
+  "alajuela",
+  "heredia",
+  "san-jose",
+  "cartago",
+  "limon",
+];
+
+function isProvince(dist: Distribution): dist is Province {
+  return (PROVINCES as string[]).includes(dist);
+}
+
+// ============================================================================
+// URL Param Helpers
+// ============================================================================
+
+const VALID_SORT_FIELDS: SortField[] = ["title", "scientificName", "family"];
+const VALID_VIEW_MODES: ViewMode[] = ["grid", "alphabetical"];
+
+function parseFilterFromParams(params: URLSearchParams): TreeFilter {
+  const filter: TreeFilter = {};
+  const family = params.get("family");
+  if (family) filter.family = family;
+  const status = params.get("status");
+  if (status) filter.conservationStatus = status;
+  const province = params.get("province");
+  if (province && (PROVINCES as string[]).includes(province)) {
+    filter.distribution = [province as Distribution];
+  }
+  const tags = params.get("tags");
+  if (tags) filter.tags = tags.split(",").filter(Boolean) as TreeTag[];
+  return filter;
+}
+
+function parseSortFromParams(params: URLSearchParams): TreeSort {
+  const field = params.get("sort") as SortField | null;
+  return {
+    field: field && VALID_SORT_FIELDS.includes(field) ? field : "title",
+    direction: "asc",
+  };
+}
 
 // ============================================================================
 // Types
@@ -42,19 +90,34 @@ export function TreeExplorer({ trees }: TreeExplorerProps) {
   const locale = useLocale() as Locale;
   const t = useTranslations("trees");
   const router = useRouter();
+  const searchParams = useSearchParams();
 
   // Cast trees to Tree type for search functions
   const typedTrees = trees as unknown as Tree[];
 
-  // State
-  const [searchQuery, setSearchQuery] = useState("");
-  const [viewMode, setViewMode] = useState<ViewMode>("grid");
-  const [filter, setFilter] = useState<TreeFilter>({});
-  const [sort, setSort] = useState<TreeSort>({
-    field: "title",
-    direction: "asc",
+  // Initialize state from URL params
+  const [searchQuery, setSearchQuery] = useState(
+    () => searchParams.get("q") ?? ""
+  );
+  const [viewMode, setViewMode] = useState<ViewMode>(() => {
+    const v = searchParams.get("view") as ViewMode | null;
+    return v && VALID_VIEW_MODES.includes(v) ? v : "grid";
   });
-  const [showFilters, setShowFilters] = useState(false);
+  const [filter, setFilter] = useState<TreeFilter>(() =>
+    parseFilterFromParams(searchParams)
+  );
+  const [sort, setSort] = useState<TreeSort>(() =>
+    parseSortFromParams(searchParams)
+  );
+  const [showFilters, setShowFilters] = useState(() => {
+    // Auto-open filters if any filter param is present
+    const hasParams =
+      searchParams.has("family") ||
+      searchParams.has("status") ||
+      searchParams.has("province") ||
+      searchParams.has("tags");
+    return hasParams;
+  });
   const [displayLimit, setDisplayLimit] = useState(INITIAL_LOAD_COUNT);
 
   // Autocomplete suggestions state
@@ -68,6 +131,26 @@ export function TreeExplorer({ trees }: TreeExplorerProps) {
 
   // Facets from all trees
   const allFacets = useMemo(() => extractFacets(typedTrees), [typedTrees]);
+
+  // Sync filter/search/sort/view state to URL params (shallow — no navigation)
+  useEffect(() => {
+    const params = new URLSearchParams();
+    if (searchQuery.trim()) params.set("q", searchQuery.trim());
+    if (filter.family) params.set("family", filter.family);
+    if (filter.conservationStatus)
+      params.set("status", filter.conservationStatus);
+    if (filter.distribution?.length)
+      params.set("province", filter.distribution[0]);
+    if (filter.tags?.length) params.set("tags", filter.tags.join(","));
+    if (sort.field !== "title") params.set("sort", sort.field);
+    if (viewMode !== "grid") params.set("view", viewMode);
+
+    const qs = params.toString();
+    const newUrl = qs
+      ? `${window.location.pathname}?${qs}`
+      : window.location.pathname;
+    window.history.replaceState(null, "", newUrl);
+  }, [searchQuery, filter, sort.field, viewMode]);
 
   // Filter facets to only show options with meaningful counts (>= 2)
   const displayFacets = useMemo(() => {
@@ -214,6 +297,19 @@ export function TreeExplorer({ trees }: TreeExplorerProps) {
     });
   }, []);
 
+  const handleProvinceChange = useCallback((province: string) => {
+    setFilter((prev) => ({
+      ...prev,
+      distribution: province ? [province as Distribution] : undefined,
+    }));
+  }, []);
+
+  // Province facets — only include the 7 provinces, sorted by count
+  const provinceFacets = useMemo(
+    () => displayFacets.distributions.filter((d) => isProvince(d.value)),
+    [displayFacets.distributions]
+  );
+
   const handleClearFilters = useCallback(() => {
     setFilter({});
     setSearchQuery("");
@@ -239,6 +335,8 @@ export function TreeExplorer({ trees }: TreeExplorerProps) {
     allFamilies: t("allFamilies"),
     status: t("filterByStatus"),
     allStatuses: t("allStatuses"),
+    province: t("filterByProvince"),
+    allProvinces: t("allProvinces"),
     sortBy: t("sortBy"),
     sortName: t("sortByName"),
     sortScientific: t("sortByScientific"),
@@ -378,7 +476,7 @@ export function TreeExplorer({ trees }: TreeExplorerProps) {
         {/* Filter panel */}
         {showFilters && (
           <div className="mb-8 p-4 bg-card rounded-xl border border-border">
-            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 xl:grid-cols-5 gap-4">
               {/* Family filter */}
               <div>
                 <label className="block text-sm font-medium text-muted-foreground mb-1">
@@ -423,6 +521,25 @@ export function TreeExplorer({ trees }: TreeExplorerProps) {
                       </option>
                     )
                   )}
+                </select>
+              </div>
+
+              {/* Province filter */}
+              <div>
+                <label className="block text-sm font-medium text-muted-foreground mb-1">
+                  {labels.province}
+                </label>
+                <select
+                  value={filter.distribution?.[0] ?? ""}
+                  onChange={(e) => handleProvinceChange(e.target.value)}
+                  className="w-full px-3 py-2 rounded-lg border border-border bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-primary/50"
+                >
+                  <option value="">{labels.allProvinces}</option>
+                  {provinceFacets.map(({ value, count }) => (
+                    <option key={value} value={value}>
+                      {t(`provinces.${value}`)} ({count})
+                    </option>
+                  ))}
                 </select>
               </div>
 

--- a/tests/lib/province-filter.test.ts
+++ b/tests/lib/province-filter.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Tests for province/distribution filtering and URL parameter parsing
+ */
+
+import { describe, it, expect } from "vitest";
+import { filterTrees, extractFacets } from "@/lib/search";
+import type { Tree, TreeFilter, Distribution } from "@/types/tree";
+
+// Minimal tree factory for testing
+function mockTree(overrides: Partial<Tree> = {}): Tree {
+  return {
+    _id: "test-id",
+    _raw: {},
+    body: { raw: "", code: "" },
+    url: "/trees/test",
+    slug: "test-tree",
+    locale: "en",
+    title: "Test Tree",
+    scientificName: "Testus treeus",
+    family: "Testaceae",
+    description: "A test tree",
+    ...overrides,
+  } as Tree;
+}
+
+describe("Province/Distribution filtering", () => {
+  const trees: Tree[] = [
+    mockTree({
+      slug: "ceiba",
+      title: "Ceiba",
+      distribution: ["guanacaste", "puntarenas", "alajuela"],
+    }),
+    mockTree({
+      slug: "guanacaste",
+      title: "Guanacaste",
+      distribution: ["guanacaste"],
+    }),
+    mockTree({
+      slug: "ojoche",
+      title: "Ojoche",
+      distribution: ["limon", "heredia"],
+    }),
+    mockTree({
+      slug: "no-dist",
+      title: "No Distribution",
+      distribution: undefined,
+    }),
+  ];
+
+  it("returns all trees when no distribution filter is set", () => {
+    const result = filterTrees(trees, {});
+    expect(result).toHaveLength(4);
+  });
+
+  it("filters by single province (OR logic)", () => {
+    const filter: TreeFilter = { distribution: ["guanacaste"] };
+    const result = filterTrees(trees, filter);
+    expect(result).toHaveLength(2);
+    expect(result.map((t) => t.slug)).toEqual(
+      expect.arrayContaining(["ceiba", "guanacaste"])
+    );
+  });
+
+  it("filters by multiple provinces (OR logic — any match)", () => {
+    const filter: TreeFilter = {
+      distribution: ["limon", "guanacaste"] as Distribution[],
+    };
+    const result = filterTrees(trees, filter);
+    expect(result).toHaveLength(3);
+    expect(result.map((t) => t.slug)).toEqual(
+      expect.arrayContaining(["ceiba", "guanacaste", "ojoche"])
+    );
+  });
+
+  it("excludes trees with no distribution data when filter is active", () => {
+    const filter: TreeFilter = { distribution: ["guanacaste"] };
+    const result = filterTrees(trees, filter);
+    expect(result.find((t) => t.slug === "no-dist")).toBeUndefined();
+  });
+
+  it("combines province and family filters", () => {
+    const treesWithFamilies = [
+      mockTree({
+        slug: "a",
+        family: "Fabaceae",
+        distribution: ["guanacaste"],
+      }),
+      mockTree({
+        slug: "b",
+        family: "Moraceae",
+        distribution: ["guanacaste"],
+      }),
+      mockTree({
+        slug: "c",
+        family: "Fabaceae",
+        distribution: ["limon"],
+      }),
+    ];
+    const filter: TreeFilter = {
+      distribution: ["guanacaste"],
+      family: "Fabaceae",
+    };
+    const result = filterTrees(treesWithFamilies, filter);
+    expect(result).toHaveLength(1);
+    expect(result[0].slug).toBe("a");
+  });
+});
+
+describe("extractFacets distribution counts", () => {
+  it("counts distributions correctly", () => {
+    const trees: Tree[] = [
+      mockTree({ distribution: ["guanacaste", "puntarenas"] }),
+      mockTree({ distribution: ["guanacaste", "limon"] }),
+      mockTree({ distribution: ["puntarenas"] }),
+    ];
+    const facets = extractFacets(trees);
+    const distMap = Object.fromEntries(
+      facets.distributions.map((d) => [d.value, d.count])
+    );
+    expect(distMap["guanacaste"]).toBe(2);
+    expect(distMap["puntarenas"]).toBe(2);
+    expect(distMap["limon"]).toBe(1);
+  });
+
+  it("returns distributions sorted by count (descending)", () => {
+    const trees: Tree[] = [
+      mockTree({ distribution: ["limon", "puntarenas"] }),
+      mockTree({ distribution: ["limon", "puntarenas"] }),
+      mockTree({ distribution: ["limon"] }),
+      mockTree({ distribution: ["guanacaste"] }),
+    ];
+    const facets = extractFacets(trees);
+    expect(facets.distributions[0].value).toBe("limon");
+    expect(facets.distributions[0].count).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary

Implements **P9.8 — Region/Province Filter** from the implementation plan. Users can now filter the tree directory by Costa Rican province, and all filter/search state is persisted in URL parameters for shareability.

## Changes

### Province Filter
- Added province dropdown to the filter panel on `/trees` page
- Shows all 7 Costa Rican provinces (Guanacaste, Puntarenas, Alajuela, Heredia, San José, Cartago, Limón) with tree counts
- Uses the existing `distribution` frontmatter data — all 175 trees already have distribution values
- Leverages existing `filterTrees()` (OR logic) and `extractFacets()` from `src/lib/search`

### URL Parameter Persistence
- Search query → `?q=ceiba`
- Family filter → `?family=Fabaceae`
- Conservation status → `?status=VU`
- Province filter → `?province=guanacaste`
- Tag filters → `?tags=native,endangered`
- Sort field → `?sort=scientificName`
- View mode → `?view=alphabetical`
- Filters auto-open when URL contains filter parameters
- Uses `window.history.replaceState` (shallow) to avoid unnecessary navigation

### i18n
- Added `filterByProvince`, `allProvinces`, and `provinces.*` keys to both `en.json` and `es.json`
- Province names properly accented (San José, Limón)

### Tests
- 7 new tests for distribution filtering and facet extraction
- **630/630 tests passing** (623 existing + 7 new)

### Files Changed
- `src/components/tree/TreeExplorer.tsx` — Province filter UI + URL param sync
- `messages/en.json` / `messages/es.json` — Province translation keys
- `tests/lib/province-filter.test.ts` — New test file
- `docs/IMPLEMENTATION_PLAN.md` — P9.8 marked complete
- `docs/NEXT_AGENT_HANDOFF.md` — Updated per handoff protocol

## Verification
- ✅ TypeScript: no errors
- ✅ ESLint: 0 errors (291 pre-existing warnings)
- ✅ Build: succeeds
- ✅ Tests: 630/630 passing