### PR TITLE
docs(readme): reframe README for private project usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,7 @@
 # Costa Rica Tree Atlas
 
-Costa Rica Tree Atlas will truly never have ads, donations, sales, or other revenue
+A bilingual (English/Spanish) web application and private reference project documenting the magnificent trees of Costa Rica. Built with Next.js 16, TypeScript, and modern web technologies.
 
-A bilingual (English/Spanish) open-source web application showcasing the magnificent trees of Costa Rica. Built with Next.js 16, TypeScript, and modern web technologies.
-
-[![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](LICENSE)
-[![License: CC BY-NC-SA 4.0](https://img.shields.io/badge/License-CC_BY--NC--SA_4.0-lightgrey.svg)](LICENSE-CONTENT.md)
 [![Next.js](https://img.shields.io/badge/Next.js-16-black)](https://nextjs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5-blue)](https://www.typescriptlang.org/)
 [![Tailwind CSS](https://img.shields.io/badge/Tailwind-4-38bdf8)](https://tailwindcss.com/)
@@ -97,7 +93,7 @@ API endpoints are protected with persistent rate limiting using Upstash Redis:
 | `/api/species/images` | 30 requests  | 1 minute |
 | `/api/species/random` | 100 requests | 1 minute |
 
-See **[Contributing Guide](CONTRIBUTING.md)** for development setup instructions.
+See **[Development Notes](CONTRIBUTING.md)** for development setup instructions.
 
 ## Roadmap
 
@@ -113,24 +109,17 @@ See **[Contributing Guide](CONTRIBUTING.md)** for development setup instructions
 Comprehensive documentation is available in the **[docs/](docs/)** directory:
 
 - **[Documentation Index](docs/README.md)** - Complete guide to all documentation
-- **[Contributing Guide](CONTRIBUTING.md)** - Setup and contribution instructions
+- **[Development Notes](CONTRIBUTING.md)** - Setup notes for project owner/collaborators
 - **[Content Standards](docs/CONTENT_STANDARDIZATION_GUIDE.md)** - Tree profile standards
 - **[Project Roadmap](docs/improvement-roadmap.md)** - Feature status and roadmap
 - **[AI Agent Instructions](AGENTS.md)** - Coding conventions and patterns
 
 ## Contributing
 
-Contributions are welcome! We're building this as an open-source resource for education and conservation.
+This repository is maintained as a private project.
 
-See our **[Contributing Guidelines](CONTRIBUTING.md)** for setup instructions and how to get started.
-
-### Ways to Contribute
-
-- **Add Tree Profiles**: Document new species with descriptions and images
-- **Improve Translations**: Enhance Spanish content or add new languages
-- **Fix Bugs**: Report issues or submit fixes
-- **Add Features**: Implement items from the roadmap
-- **Contribute Photography**: Share high-quality tree photographs (with proper licensing)
+Public contributions and external pull requests are currently closed.
+If you're an approved collaborator, use **[Development Notes](CONTRIBUTING.md)** for local setup and workflow details.
 
 ### Automated Quality Assurance
 
@@ -212,74 +201,13 @@ This repository is optimized for AI-assisted development with comprehensive agen
 
 These instructions help AI agents understand our architecture, maintain consistency, and follow project best practices when making contributions.
 
-## License
+## Rights & Usage
 
-This project uses a **dual-license structure** to protect both the technical infrastructure and educational content:
+This project and its contents are private and maintained by the owner.
 
-### 📜 Code License: AGPL-3.0
+Unless explicitly permitted in writing by the owner, all rights are reserved and public reuse, redistribution, or derivative publication is not authorized.
 
-All software, code, and technical infrastructure is licensed under the [GNU Affero General Public License v3.0](LICENSE).
-
-**What this means:**
-
-- You can freely use, modify, and distribute the code
-- Any modifications or deployments must remain open source
-- Network use requires sharing source code of modifications
-- Ensures derivative works remain free and open
-
-**Applies to:**
-
-- TypeScript/JavaScript files (`.ts`, `.tsx`, `.js`, `.jsx`, `.mjs`)
-- Configuration files (`next.config.ts`, `tailwind.config.js`, etc.)
-- Build scripts and utilities
-- API routes and server code
-
-### 📚 Content License: CC BY-NC-SA 4.0
-
-All educational content, tree data, and images are licensed under [Creative Commons Attribution-NonCommercial-ShareAlike 4.0](LICENSE-CONTENT.md).
-
-**What this means:**
-
-- Free for educational, research, and non-commercial use
-- Attribution required when sharing or adapting
-- Derivative works must use the same license
-- Commercial use requires permission
-
-**Applies to:**
-
-- Tree descriptions and profiles (`.mdx` files)
-- Photographs and illustrations
-- Educational documentation
-- Multimedia content
-
-### 🌿 Why This Approach?
-
-We chose this dual-license structure to:
-
-1. **Protect the educational mission**: Prevent commercial exploitation of biodiversity data
-2. **Ensure accessibility**: Keep the resource free for education and conservation
-3. **Maintain openness**: Guarantee all improvements remain available to the community
-4. **Support conservation**: Align with ethical, sustainable use of natural history information
-
-### 💼 Commercial Licensing
-
-Interested in commercial use? We're open to discussion, especially for:
-
-- Eco-tourism educational materials
-- Conservation-focused applications
-- Environmental education platforms
-- Documentary and publishing projects
-
-Please open a [GitHub Issue](https://github.com/sandgraal/Costa-Rica-Tree-Atlas/issues) to discuss commercial licensing.
-
-### 📋 Usage Policy
-
-For detailed ethical usage guidelines, see [USAGE-POLICY.md](USAGE-POLICY.md).
-
-### 📄 Full License Texts
-
-- [LICENSE](LICENSE) - AGPL-3.0 for code
-- [LICENSE-CONTENT.md](LICENSE-CONTENT.md) - CC BY-NC-SA 4.0 for content
+For internal guidance, see [USAGE-POLICY.md](USAGE-POLICY.md).
 
 ## Acknowledgments
 
@@ -287,7 +215,7 @@ For detailed ethical usage guidelines, see [USAGE-POLICY.md](USAGE-POLICY.md).
 - [SINAC](https://www.sinac.go.cr/) - Costa Rica's National System of Conservation Areas
 - [INBio](https://inbio.ac.cr/) - Costa Rica's National Biodiversity Institute
 - The conservation organizations working to protect Costa Rica's forests
-- The open-source community for the amazing tools that made this project possible
+- The maintainers and collaborators supporting this project
 
 ## Contact & Support
 


### PR DESCRIPTION
### Motivation
- Align public-facing documentation with the project's current private, owner-maintained status rather than open-source/grant-style framing.
- Remove explicit license badges and permissive reuse language that imply public redistribution or community contribution is allowed.
- Close public contribution messaging while keeping an owner/collaborator setup path for internal development.

### Description
- Updated `README.md` top description to a neutral private-project wording and removed the line about never having ads/donations/sales. 
- Removed AGPL and CC license badges and replaced the long dual-license section with a concise `Rights & Usage` notice that reserves rights to the owner. 
- Rewrote the `Contributing` section to state that public contributions and external PRs are closed and relabeled contributing links to `Development Notes` (`CONTRIBUTING.md`) for owner/collaborator setup. 
- Adjusted acknowledgments wording to remove open-source-community framing; the only file changed was `README.md`.

### Testing
- Ran `npm run lint` and it completed successfully with no new errors (existing repository warnings remain). 
- Prettier formatting was applied as part of the commit hooks and the file was saved in repository style during the change. 
- No automated test failures were introduced by this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a47d1c54f88323a15febc4bc8f7d98)