### PR TITLE
chore(security): private-repo hardening runbook and Actions workflow privacy tightening

### DIFF
--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -43,8 +43,8 @@ jobs:
         id: lighthouse
         with:
           configPath: ".lighthouserc.json"
-          uploadArtifacts: true
-          temporaryPublicStorage: true
+          uploadArtifacts: false
+          temporaryPublicStorage: false
 
       - name: Post summary
         if: always()

--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ API endpoints are protected with persistent rate limiting using Upstash Redis:
 
 See **[Contributing Guide](CONTRIBUTING.md)** for development setup instructions.
 
+For private/internal deployments, apply the hardening checklist in **[docs/PRIVATE_REPOSITORY_HARDENING.md](docs/PRIVATE_REPOSITORY_HARDENING.md)**.
+
 ## Roadmap
 
 ### Future Ideas

--- a/context/context.md
+++ b/context/context.md
@@ -1,0 +1,30 @@
+# Task Context: Private Repository Hardening
+
+## project_summary
+
+- Next.js 16 bilingual tree atlas project with extensive docs and CI workflows.
+- Current request focuses on repository governance/security settings rather than app runtime behavior.
+
+## dependency_graph (high level)
+
+- Frontend app: Next.js + React + TypeScript.
+- Content pipeline: Contentlayer2 + MDX.
+- CI/CD: GitHub Actions workflows under `.github/workflows`.
+
+## commands_map (dev, test, build, lint)
+
+- `npm run dev` — local development.
+- `npm run build` — production build.
+- `npm run lint` — lint checks.
+- `npm run test:run` — test execution.
+
+## key_paths_by_feature
+
+- Repository governance docs: `docs/`.
+- CI workflow behavior: `.github/workflows/`.
+- Contributor-facing guide: `README.md`.
+
+## known_constraints and feature_flags
+
+- No authenticated GitHub CLI context available in this environment to apply repository settings directly.
+- Repository-level controls (visibility, forking, branch protection, issues/discussions/projects) must be changed in GitHub UI by a user with admin rights.

--- a/context/links.md
+++ b/context/links.md
@@ -1,0 +1,10 @@
+# Related history lookup
+
+Unable to query live GitHub Issues/PR metadata in this environment because GitHub CLI authentication is unavailable.
+
+Suggested keywords for manual search in GitHub UI:
+
+- "private repository"
+- "branch protection"
+- "github pages"
+- "workflow artifacts"

--- a/docs/PRIVATE_REPOSITORY_HARDENING.md
+++ b/docs/PRIVATE_REPOSITORY_HARDENING.md
@@ -1,0 +1,79 @@
+# Private Repository Hardening Checklist (GitHub)
+
+This runbook documents the exact GitHub repository settings to apply when operating `sandgraal/Costa-Rica-Tree-Atlas` as a private codebase.
+
+## Recommended pinned repository description
+
+Use this repository description in **Settings → General → Repository details**:
+
+> Private internal repository for Costa Rica Tree Atlas. Access and reuse restricted to explicitly approved collaborators.
+
+## 1) Change visibility to Private
+
+Path: **Settings → General → Danger Zone → Change repository visibility**
+
+- Set visibility to **Private**.
+- Confirm the repository name to proceed.
+
+## 2) Disable or restrict forking
+
+Path: **Settings → General → Features**
+
+- Turn off **Allow forking** (recommended for internal-only repositories).
+- If organization policy requires forking, restrict to private forks only and approved members.
+
+## 3) Disable GitHub Pages
+
+Path: **Settings → Pages**
+
+- Set **Build and deployment → Source** to **None**.
+- If site hosting is still required, migrate deployment to a private platform/project and require authenticated access.
+
+## 4) Actions security posture
+
+Path: **Settings → Actions → General**
+
+Apply:
+
+- **Artifact and log retention**: lower to minimum acceptable period for internal operations.
+- **Workflow permissions**: keep to least privilege (`contents: read` by default).
+- **Allowed actions**: restrict to GitHub-owned + explicitly approved actions.
+- Disable workflows not needed for private operation (especially public-reporting automation).
+
+Repository workflow hardening included in this repo:
+
+- Lighthouse CI no longer uploads reports to temporary public storage.
+
+## 5) Collaboration channels
+
+Path: **Settings → General → Features**
+
+Decide whether to keep these enabled:
+
+- Issues
+- Discussions
+- Projects
+
+For private/internal-only mode, disable channels you do not actively use.
+
+## 6) Branch protection and collaborator review
+
+Paths:
+
+- **Settings → Branches**
+- **Settings → Collaborators and teams**
+
+Checklist:
+
+- Require pull request reviews for `main`.
+- Require status checks before merge.
+- Restrict who can push to protected branches.
+- Remove users/teams that no longer need access.
+- Confirm no outside collaborator has unintended write/admin privileges.
+
+## 7) Post-change verification
+
+- Confirm repository lock icon displays **Private** in the header.
+- Verify Pages URL is disabled/unpublished.
+- Verify Actions summary does not expose public artifacts/reports.
+- Verify only approved users remain with access.


### PR DESCRIPTION
### Motivation
- The repository is being prepared for private/internal operation and needs explicit guidance for admin changes that cannot be applied programmatically from this environment. 
- CI workflows should not expose performance/artifact reports to temporary public storage when the repo is operated privately. 

### Description
- Add `docs/PRIVATE_REPOSITORY_HARDENING.md` containing step-by-step GitHub Settings paths and a verification checklist for converting the repo to private mode. 
- Update `README.md` to link to the private-repo hardening runbook via `docs/PRIVATE_REPOSITORY_HARDENING.md`. 
- Harden the Lighthouse CI workflow by setting `uploadArtifacts: false` and `temporaryPublicStorage: false` in `.github/workflows/lighthouse-ci.yml`. 
- Add operational context artifacts `context/context.md` and `context/links.md` documenting constraints and follow-up pointers for applying repo-level changes. 

### Testing
- Ran `npm run lint`, which completed successfully with warnings only (301 warnings, 0 errors). 
- Verified the modified workflow YAML contains `uploadArtifacts: false` and `temporaryPublicStorage: false` to prevent public artifact/report uploads.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a47d0b045483238b7327b615e942db)