### PR TITLE
[DRAFT] docs(exposure): one-time review of public artifact exposure

### DIFF
--- a/context/context.md
+++ b/context/context.md
@@ -1,0 +1,33 @@
+# Context Scan (2026-03-01) — Exposure Review
+
+## project_summary
+
+- Costa Rica Tree Atlas is a bilingual Next.js 16 app for Costa Rican tree content and education resources.
+- Canonical domain references in app code and metadata point to `https://costaricatreeatlas.com`.
+- Repository appears to have previously lived at `github.com/sandgraal/Costa-Rica-Tree-Atlas` (referenced in docs/badges), but that URL currently returns 404.
+
+## dependency_graph (high-level)
+
+- Runtime: Next.js, React, next-intl, contentlayer2, Zustand, Prisma, Upstash Redis.
+- Tooling: TypeScript, ESLint, Prettier, Vitest.
+
+## commands_map
+
+- Dev: `npm run dev`
+- Build: `npm run build`
+- Lint: `npm run lint`
+- Type-check: `npm run type-check`
+- Security check bundle: `npm run security:check`
+
+## key_paths_by_feature
+
+- App routes/UI: `src/app/**`, `src/components/**`
+- Content: `content/**`
+- Automation/workflows: `.github/workflows/**`
+- Security and env defaults: `.env.example`, `src/lib/security/**`
+
+## known_constraints and feature_flags
+
+- Current clone has no Git remote configured (`git remote -v` empty).
+- GitHub API checks for `sandgraal/Costa-Rica-Tree-Atlas` return 404 (no public API visibility from this environment).
+- NPM package name from `package.json` is `costa-rica-tree-atlas`; package is not found in npm registry.

--- a/context/links.md
+++ b/context/links.md
@@ -1,0 +1,9 @@
+# External Links / History Checks (2026-03-01)
+
+- GitHub repo API (`/repos/sandgraal/Costa-Rica-Tree-Atlas`): 404 Not Found.
+- GitHub forks API (`/repos/.../forks`): 404 Not Found.
+- GitHub releases API (`/repos/.../releases`): 404 Not Found.
+- GitHub Pages API (`/repos/.../pages`): 404 Not Found.
+- Web archive lookup for `costaricatreeatlas.com/*`: no 200 snapshots returned by CDX query.
+- Web archive lookup for `github.com/sandgraal/Costa-Rica-Tree-Atlas*`: historical captures exist (Jan 2026 captures observed).
+- npm registry check (`npm view costa-rica-tree-atlas --json`): E404 (package not published).

--- a/docs/internal/exposure-review-2026-03-01.md
+++ b/docs/internal/exposure-review-2026-03-01.md
@@ -1,0 +1,56 @@
+# One-Time Exposure Review (2026-03-01)
+
+## Scope
+
+Requested checks:
+
+1. Public forks, release tarballs, package publishes, mirrors.
+2. Published artifacts inventory.
+3. Decision per artifact: leave as-is, takedown, or replace terms.
+4. Internal note on what remains reachable and mitigations.
+
+## Findings
+
+### 1) Public forks / release tarballs / package publishes / mirrors
+
+- **GitHub repository endpoint currently not publicly accessible** (`https://github.com/sandgraal/Costa-Rica-Tree-Atlas` returns 404; GitHub REST endpoints return 404).
+- **Public forks:** Not enumerable from current public API visibility (repo 404).
+- **GitHub Releases / release assets:** Not enumerable from current public API visibility (repo 404).
+- **Source tarballs:** No tags in local clone (`git tag --list` empty), and no releases visible via API.
+- **npm publish:** Package name `costa-rica-tree-atlas` is **not found** in npm registry.
+- **Mirrors:** No explicit mirror endpoints found in repo docs/config. Historical public exposure is still indicated by web archives.
+
+### 2) Published artifacts inventory
+
+| Artifact                                                       | Observed status                                 | Evidence                             | Decision                                                  |
+| -------------------------------------------------------------- | ----------------------------------------------- | ------------------------------------ | --------------------------------------------------------- |
+| GitHub repo URL (`github.com/sandgraal/Costa-Rica-Tree-Atlas`) | Currently 404 (not publicly browsable)          | Direct HTTP check + API 404s         | **Leave as-is**                                           |
+| GitHub forks list                                              | Not publicly enumerable due 404 repo            | Forks API returns 404                | **Leave as-is**, monitor if repo reopens                  |
+| GitHub Releases/assets                                         | Not publicly enumerable due 404 repo            | Releases API returns 404             | **Leave as-is**, verify again if repo reopens             |
+| npm package (`costa-rica-tree-atlas`)                          | Not published                                   | `npm view` returns E404              | **Leave as-is**                                           |
+| Primary site (`https://costaricatreeatlas.com`)                | Domain resolves, endpoint currently returns 503 | Direct HTTP check                    | **Leave as-is** (availability issue, not exposure leak)   |
+| Wayback archive snapshots (GitHub repo URL)                    | Historical captures exist                       | CDX query returns Jan 2026 snapshots | **Request takedown** if private content/licensing concern |
+| Wayback archive snapshots (site URL)                           | No 200 snapshots returned by query              | CDX query empty                      | **Leave as-is**                                           |
+
+### 3) Decision rationale
+
+- Keep currently unavailable/non-published channels as-is unless business/legal wants broader suppression.
+- **Only clear externally reachable historical artifact identified:** archived copies of the formerly public GitHub repo URL in the Internet Archive index.
+- If legal/compliance requires minimizing historical exposure, file targeted archival removal requests for specific archive captures.
+
+## Internal note: what remains publicly reachable & mitigations
+
+### Publicly reachable (as of review time)
+
+- `https://costaricatreeatlas.com` hostname is publicly reachable at DNS/HTTP level but responds `503 Service Unavailable`.
+- Internet Archive lists historical captures for `https://github.com/sandgraal/Costa-Rica-Tree-Atlas`.
+
+### Mitigation actions
+
+1. **Archive takedown path (recommended):**
+   - Submit removal request to Internet Archive for the captured GitHub repository URLs if those snapshots expose material that should no longer be public.
+2. **Future hardening if repo becomes public again:**
+   - Disable/limit release generation until license/terms text is finalized.
+   - Add explicit repository metadata (`LICENSE`, `README` terms section already present) and ensure release notes include current terms.
+3. **Monitoring:**
+   - Re-run this review monthly for 3 months or after any visibility change (repo made public, domain restored, package published).


### PR DESCRIPTION
### Motivation
- Capture a point-in-time exposure assessment for public artifacts (forks, releases, package publishes, mirrors) so the project has a recorded decision and follow-ups. 
- Provide reproducible context and external endpoint checks that can be re-run if repository visibility changes. 

### Description
- Added `docs/internal/exposure-review-2026-03-01.md` containing the scope, findings, per-artifact decisions (leave/takedown), rationale, and mitigation recommendations. 
- Added `context/context.md` documenting the project summary, command map, key paths, and constraints observed during the review. 
- Added `context/links.md` recording the external endpoint and history checks performed and their outcomes. 

### Testing
- Ran external checks including `curl`/GitHub API probes, `npm view costa-rica-tree-atlas --json`, and Wayback CDX queries which showed the GitHub repo API returned `404`, the npm package is not published (E404), and Internet Archive contained historical captures for the GitHub repo. 
- Verified `curl -I` of the canonical site `https://costaricatreeatlas.com` returned `503` at the time of the review and `git tag --list` returned no tags. 
- Ran the repository-level `npm run security:check` which executed but failed due to existing TypeScript/Contentlayer type errors unrelated to this docs-only change (baseline issues were recorded and not modified by this PR).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a47d512f148323a315ad32da0af231)