### PR TITLE
perf: eliminate 32MB contentlayer client bundle from /map page

### DIFF
--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -1,7 +1,7 @@
 # Costa Rica Tree Atlas - Implementation Plan
 
 **Last Updated:** 2026-03-01
-**Status:** v1.1 — Core site complete. LCP image optimization shipped. Focusing on search UX, community features, and remaining performance work.
+**Status:** v1.1 — Core site complete. LCP image optimization shipped. 32MB client bundle eliminated. Focusing on search UX, community features, and remaining performance work.
 
 ---
 
@@ -37,13 +37,13 @@
 
 ### Performance Budgets
 
-| Resource          | Budget | Current                     | Status                                                               |
-| ----------------- | ------ | --------------------------- | -------------------------------------------------------------------- |
-| JavaScript        | <300KB | ~553KB (uncompressed, main) | 🔴 Over budget (~553KB > 300KB). 23KB unused JS remains to be pruned |
-| CSS               | <100KB | ~27KB (2 chunks)            | ✅ (560ms render-blocking on simulated mobile)                       |
-| Images (Hero)     | <100KB | ~52KB (mobile-lg AVIF)      | ✅ Re-compressed from 206KB (75% reduction)                          |
-| Images (Cards)    | <100KB | ~199KB largest              | 🟡 Served via next/image; quality lowered to 60                      |
-| Total Page Weight | <2MB   | ~1.8 MB                     | ✅                                                                   |
+| Resource          | Budget | Current                       | Status                                                                                         |
+| ----------------- | ------ | ----------------------------- | ---------------------------------------------------------------------------------------------- |
+| JavaScript        | <300KB | ~553KB (uncompressed, shared) | 🟡 Shared framework JS still over budget; 32MB contentlayer client bundle eliminated from /map |
+| CSS               | <100KB | ~27KB (2 chunks)              | ✅ (560ms render-blocking on simulated mobile)                                                 |
+| Images (Hero)     | <100KB | ~52KB (mobile-lg AVIF)        | ✅ Re-compressed from 206KB (75% reduction)                                                    |
+| Images (Cards)    | <100KB | ~199KB largest                | 🟡 Served via next/image; quality lowered to 60                                                |
+| Total Page Weight | <2MB   | ~1.8 MB                       | ✅                                                                                             |
 
 ---
 
@@ -223,6 +223,7 @@ These items require human action and cannot be automated:
 - CSP inline styles reduced from 54 to ~30 (irreducible runtime values)
 - SSR refactor: all 6 education pages, ScavengerHunt/TreeJournal/TreeMap client components split
 - Accessibility contrast fixes: 4 color contrast failures fixed (dark mode skip-link, subtitle, primary links, card text)
+- **P4.8 Map page bundle (Mar 2026):** Eliminated 32MB contentlayer client bundle from `/map` page by projecting only 10 required fields server-side instead of shipping all 175 tree MDX bodies to the client. Total client JS chunks reduced from 33MB to 2.1MB.
 
 ### Testing & Reliability (P5) — Complete
 
@@ -266,6 +267,7 @@ These items require human action and cannot be automated:
 - Sentry DSN not yet configured in Vercel env vars (works via console fallback)
 - `useSearchParams()` in TreeExplorer requires Suspense boundary — provided by `next/dynamic` loading fallback
 - 560ms render-blocking CSS on simulated mobile (two Tailwind chunks: 26KB + 1.3KB); marginal gains from splitting may not be worth complexity — see P4.7
+- **Never import `allTrees`/`allGlossaryTerms`/`allSpeciesComparisons` in `"use client"` components** — this ships the full contentlayer dataset (32MB+) to the browser. Always pass projected data from a server component via props.
 
 ---
 

--- a/src/app/[locale]/map/CollectionCard.tsx
+++ b/src/app/[locale]/map/CollectionCard.tsx
@@ -2,7 +2,8 @@
 
 import { ShareCollectionButton } from "@/components/ShareCollectionButton";
 import type { DiscoveryCollection } from "@/lib/geo/collections";
-import type { Locale, Tree as TreeType } from "@/types/tree";
+import type { Locale } from "@/types/tree";
+import type { MapTreeSummary } from "./TreeMapClient";
 
 interface CollectionCardProps {
   collection: DiscoveryCollection;
@@ -10,7 +11,7 @@ interface CollectionCardProps {
   locale: Locale;
   speciesLabel: string;
   viewCollectionLabel: string;
-  getCollectionTrees: (collection: DiscoveryCollection) => TreeType[];
+  getCollectionTrees: (collection: DiscoveryCollection) => MapTreeSummary[];
   onSelect: (collection: DiscoveryCollection) => void;
 }
 

--- a/src/app/[locale]/map/CollectionDetailView.tsx
+++ b/src/app/[locale]/map/CollectionDetailView.tsx
@@ -5,7 +5,8 @@ import { OptimizedImage } from "@/components/OptimizedImage";
 import { ShareCollectionButton } from "@/components/ShareCollectionButton";
 import { DISCOVERY_COLLECTIONS } from "@/lib/geo/collections";
 import type { DiscoveryCollection } from "@/lib/geo/collections";
-import type { Locale, Tree as TreeType } from "@/types/tree";
+import type { Locale } from "@/types/tree";
+import type { MapTreeSummary } from "./TreeMapClient";
 import { CollectionCard } from "./CollectionCard";
 
 interface CollectionDetailViewProps {
@@ -17,7 +18,7 @@ interface CollectionDetailViewProps {
     species: string;
     viewCollection: string;
   };
-  getCollectionTrees: (collection: DiscoveryCollection) => TreeType[];
+  getCollectionTrees: (collection: DiscoveryCollection) => MapTreeSummary[];
   onBack: () => void;
   onSelectCollection: (collection: DiscoveryCollection) => void;
 }

--- a/src/app/[locale]/map/TreeMapClient.tsx
+++ b/src/app/[locale]/map/TreeMapClient.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState, useMemo } from "react";
-import { allTrees } from "contentlayer/generated";
 import { Link } from "@i18n/navigation";
 import {
   PROVINCES,
@@ -18,13 +17,7 @@ import {
   getCurrentMonth,
   type DiscoveryCollection,
 } from "@/lib/geo/collections";
-import type {
-  Locale,
-  Province,
-  Region,
-  Tree as TreeType,
-  TreeTag,
-} from "@/types/tree";
+import type { Locale, Province, Region, TreeTag } from "@/types/tree";
 import {
   CONSERVATION_AREAS,
   getBiodiversityColor,
@@ -33,11 +26,26 @@ import {
 import { CollectionCard } from "./CollectionCard";
 import { CollectionDetailView } from "./CollectionDetailView";
 
-interface TreeMapClientProps {
-  locale: string;
+/** Lightweight tree data for the map — only the fields needed for display and filtering */
+export interface MapTreeSummary {
+  slug: string;
+  title: string;
+  scientificName: string;
+  distribution?: string[];
+  tags?: string[];
+  floweringSeason?: string[];
+  fruitingSeason?: string[];
+  featuredImage?: string;
+  conservationStatus?: string;
+  maxHeight?: string;
 }
 
-export default function TreeMapClient({ locale }: TreeMapClientProps) {
+interface TreeMapClientProps {
+  locale: string;
+  trees: MapTreeSummary[];
+}
+
+export default function TreeMapClient({ locale, trees }: TreeMapClientProps) {
   const typedLocale = locale as Locale;
   const [selectedProvince, setSelectedProvince] = useState<Province | null>(
     null
@@ -51,14 +59,9 @@ export default function TreeMapClient({ locale }: TreeMapClientProps) {
   const [selectedCollection, setSelectedCollection] =
     useState<DiscoveryCollection | null>(null);
 
-  // Get trees for current locale
-  const trees = useMemo(() => {
-    return allTrees.filter((tree) => tree.locale === locale) as TreeType[];
-  }, [locale]);
-
   // Get trees by province
   const treesByProvince = useMemo(() => {
-    const byProvince: Record<Province, TreeType[]> = {
+    const byProvince: Record<Province, MapTreeSummary[]> = {
       guanacaste: [],
       puntarenas: [],
       alajuela: [],
@@ -88,7 +91,7 @@ export default function TreeMapClient({ locale }: TreeMapClientProps) {
 
   // Get trees by region
   const treesByRegion = useMemo(() => {
-    const byRegion: Record<Region, Set<TreeType>> = {
+    const byRegion: Record<Region, Set<MapTreeSummary>> = {
       "pacific-coast": new Set(),
       "caribbean-coast": new Set(),
       "central-valley": new Set(),
@@ -105,12 +108,12 @@ export default function TreeMapClient({ locale }: TreeMapClientProps) {
 
     return Object.fromEntries(
       Object.entries(byRegion).map(([k, v]) => [k, Array.from(v)])
-    ) as Record<Region, TreeType[]>;
+    ) as Record<Region, MapTreeSummary[]>;
   }, [treesByProvince]);
 
   // Get trees for a collection
   const getCollectionTrees = useMemo(() => {
-    return (collection: DiscoveryCollection): TreeType[] => {
+    return (collection: DiscoveryCollection): MapTreeSummary[] => {
       const currentMonth = getCurrentMonth();
 
       // Filter by province first

--- a/src/app/[locale]/map/page.tsx
+++ b/src/app/[locale]/map/page.tsx
@@ -1,7 +1,9 @@
 import { setRequestLocale } from "next-intl/server";
+import { allTrees } from "contentlayer/generated";
 import { SafeJsonLd } from "@/components/SafeJsonLd";
 import type { Metadata } from "next";
 import TreeMapClient from "./TreeMapClient";
+import type { MapTreeSummary } from "./TreeMapClient";
 
 interface MapPageProps {
   params: Promise<{ locale: string }>;
@@ -34,6 +36,23 @@ export default async function MapPage({ params }: MapPageProps) {
   const { locale } = await params;
   setRequestLocale(locale);
 
+  // Project only the fields TreeMapClient needs — avoids shipping the full
+  // 32 MB contentlayer dataset (MDX bodies) to the client.
+  const trees: MapTreeSummary[] = allTrees
+    .filter((t) => t.locale === locale)
+    .map((t) => ({
+      slug: t.slug,
+      title: t.title,
+      scientificName: t.scientificName,
+      distribution: t.distribution,
+      tags: t.tags,
+      floweringSeason: t.floweringSeason,
+      fruitingSeason: t.fruitingSeason,
+      featuredImage: t.featuredImage,
+      conservationStatus: t.conservationStatus,
+      maxHeight: t.maxHeight,
+    }));
+
   // Structured data for Map page
   const structuredData = {
     "@context": "https://schema.org",
@@ -64,7 +83,7 @@ export default async function MapPage({ params }: MapPageProps) {
   return (
     <>
       <SafeJsonLd data={structuredData} />
-      <TreeMapClient locale={locale} />
+      <TreeMapClient locale={locale} trees={trees} />
     </>
   );
 }


### PR DESCRIPTION
## Problem

`TreeMapClient.tsx` (a `"use client"` component) directly imported `allTrees` from `contentlayer/generated`, which shipped the **entire 175-tree dataset including all MDX bodies** to the browser as a single **32MB JavaScript chunk**.

This was the root cause of the 🔴 JavaScript budget violation in the implementation plan. The chunk was loaded on every visit to `/map`.

## Solution

Refactored the map page to project only the 10 fields actually needed by the client component, passed as props from the server component:

- `slug`, `title`, `scientificName` (display/links)
- `distribution`, `tags`, `floweringSeason`, `fruitingSeason` (filtering)
- `featuredImage`, `conservationStatus`, `maxHeight` (collection detail cards)

### Changes

| File | Change |
|------|--------|
| `src/app/[locale]/map/page.tsx` | Import `allTrees` server-side, project to `MapTreeSummary`, pass as prop |
| `src/app/[locale]/map/TreeMapClient.tsx` | Remove `allTrees` import, accept `trees: MapTreeSummary[]` prop, export `MapTreeSummary` type |
| `src/app/[locale]/map/CollectionDetailView.tsx` | Use `MapTreeSummary` instead of `Tree` type |
| `src/app/[locale]/map/CollectionCard.tsx` | Use `MapTreeSummary` instead of `Tree` type |
| `docs/IMPLEMENTATION_PLAN.md` | Update JS budget status, add completed work entry, add gotcha |

## Results

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| Total client JS chunks | 33 MB | 2.1 MB | **-94%** |
| 32MB contentlayer data chunk | Present | **Eliminated** | -32 MB |
| Map page functionality | ✅ | ✅ | No change |

## Verification

- ✅ `npm run build` passes
- ✅ `npm run lint` — 0 errors (301 pre-existing warnings in test files)
- ✅ No map-related test regressions
- ✅ The 32MB chunk hash (`4e9394d54dec0946`) is completely absent from the build output

## Prevention

Added a gotcha to `IMPLEMENTATION_PLAN.md`:

> **Never import `allTrees`/`allGlossaryTerms`/`allSpeciesComparisons` in `"use client"` components** — this ships the full contentlayer dataset (32MB+) to the browser. Always pass projected data from a server component via props.