### PR TITLE
fix: add missing client translation namespaces to NextIntlClientProvider

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -137,10 +137,15 @@ export default async function LocaleLayout({ children, params }: Props) {
   // Only ship namespaces that client components actually use via useTranslations.
   // Server components use getTranslations() which reads from the server bundle
   // and does NOT need messages in the client-side provider.
-  // Client namespaces: nav (MobileNav), theme (ThemeToggle), language (LanguageSwitcher),
-  //   safety (SafetyBadge), glossary (GlossaryFilters), api (APIDocumentation),
-  //   identify (IdentifyClient), contribute (PhotoUploadClient),
-  //   imageVoting (VotingClient)
+  // Client namespaces: all namespaces used by client components via useTranslations().
+  // nav (MobileNav), theme (ThemeToggle), language (LanguageSwitcher),
+  // safety (SafetyBadge), glossary (GlossaryFilters), api (APIDocumentation),
+  // identify (IdentifyClient), contribute (PhotoUploadClient, ContributorProfileClient),
+  // imageVoting (VotingClient), trees (TreeExplorer), search (QuickSearch, SearchSuggestions),
+  // toc (TableOfContents), favorites (FavoriteButton), recentlyViewed (RecentlyViewedList),
+  // keyboardShortcuts (KeyboardShortcuts), rating (TreeRating), reputation (BadgeDisplay,
+  // ContributorProfileClient), education (EducationPage), error (ErrorPage),
+  // comparison (ComparePage), about (AboutPage)
   const CLIENT_NAMESPACES = [
     "nav",
     "theme",
@@ -151,6 +156,18 @@ export default async function LocaleLayout({ children, params }: Props) {
     "identify",
     "contribute",
     "imageVoting",
+    "trees",
+    "search",
+    "toc",
+    "favorites",
+    "recentlyViewed",
+    "keyboardShortcuts",
+    "rating",
+    "reputation",
+    "education",
+    "error",
+    "comparison",
+    "about",
   ] as const;
 
   type ClientNamespace = (typeof CLIENT_NAMESPACES)[number];


### PR DESCRIPTION
## Problem

The Trees page (and other client-rendered pages) displayed raw translation keys instead of translated text — e.g. `trees.title`, `trees.subtitle`, `search.button`, `trees.filters`.

Screenshot from production showing the issue:
- Page header shows `trees.title` instead of "Tree Directory"
- Search bar shows `trees.searchByNamePlaceholder` instead of actual placeholder
- View toggle shows `trees.viewGrid` / `trees.viewAlphabetical`

## Root Cause

The `CLIENT_NAMESPACES` array in `src/app/[locale]/layout.tsx` controls which translation namespaces are sent to client components via `NextIntlClientProvider`. Several namespaces used by `"use client"` components were missing from this list:

- **`trees`** — used by `TreeExplorer` (4 instances)
- **`search`** — used by `QuickSearch`, `SearchSuggestions`
- **`toc`** — used by `TableOfContents`
- **`favorites`** — used by `FavoriteButton`
- **`recentlyViewed`** — used by `RecentlyViewedList`
- **`keyboardShortcuts`** — used by `KeyboardShortcuts`
- **`rating`** — used by `TreeRating`
- **`reputation`** — used by `BadgeDisplay`, `ContributorProfileClient`
- **`education`** — used by `EducationPage`
- **`error`** — used by `ErrorPage`
- **`comparison`** — used by `ComparePage`
- **`about`** — used by `AboutPage`

## Fix

Added all 12 missing namespaces to `CLIENT_NAMESPACES` and updated the comment to document which components use each namespace.

## Testing

- `npm run build` passes cleanly
- All translation keys now resolve to proper translated strings in client components