### PR TITLE
fix: refresh repo state — update stale docs and fix v1 API tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,36 +44,26 @@ All accepted contributions are governed by [LICENSE](LICENSE) and
 
 ### Setting Up Your Development Environment
 
-1. **Fork the repository**
-
-   Click the "Fork" button at the top right of the [repository page](https://github.com/sandgraal/Costa-Rica-Tree-Atlas).
-
-2. **Clone your fork**
+1. **Clone the repository**
 
    ```bash
-   git clone https://github.com/YOUR-USERNAME/Costa-Rica-Tree-Atlas.git
+   git clone https://github.com/sandgraal/Costa-Rica-Tree-Atlas.git
    cd Costa-Rica-Tree-Atlas
    ```
 
-3. **Add the upstream remote**
-
-   ```bash
-   git remote add upstream https://github.com/sandgraal/Costa-Rica-Tree-Atlas.git
-   ```
-
-4. **Install dependencies**
+2. **Install dependencies**
 
    ```bash
    npm install
    ```
 
-5. **Start the development server**
+3. **Start the development server**
 
    ```bash
    npm run dev
    ```
 
-6. **Open [http://localhost:3000](http://localhost:3000)** to see the site.
+4. **Open [http://localhost:3000](http://localhost:3000)** to see the site.
 
 ### Admin Access
 
@@ -120,15 +110,13 @@ To enable admin access during development:
 
 ## Development Workflow
 
-### Keeping Your Fork Updated
+### Staying Up to Date
 
-Before starting new work, sync your fork with the upstream repository:
+Before starting new work, pull the latest from main:
 
 ```bash
 git checkout main
-git fetch upstream
-git merge upstream/main
-git push origin main
+git pull origin main
 ```
 
 ### Creating a Branch
@@ -395,17 +383,17 @@ style: format components with prettier
 1. **Update your branch** with the latest from `main`:
 
    ```bash
-   git fetch upstream
-   git rebase upstream/main
+   git fetch origin
+   git rebase origin/main
    ```
 
-2. **Push your branch** to your fork:
+2. **Push your branch**:
 
    ```bash
    git push origin your-branch-name
    ```
 
-3. **Create a Pull Request** from your branch to `sandgraal/Costa-Rica-Tree-Atlas:main`
+3. **Create a Pull Request** to `main`
 
 4. **Fill out the PR template** with:
    - Clear description of changes

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -291,4 +291,4 @@ These items require human action and cannot be automated:
 ---
 
 **Last Comprehensive Review:** 2026-03-01 (LCP optimization completed, Lighthouse re-measured, plan updated)
-**Next Milestones:** Render-blocking CSS (P4.7) → Advanced search (P9.10) → Offline enhancements (P8.2)
+**Next Milestones:** Render-blocking CSS (P4.7) → Search analytics (P9.10 remaining) → Offline enhancements (P8.2)

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,16 +29,16 @@ Implementation and infrastructure documentation:
 - **[IMAGE_REVIEW_SYSTEM.md](./IMAGE_REVIEW_SYSTEM.md)** - 3-layer human-in-the-loop image quality control system (Priority 0.2)
 - **[SECURITY_SETUP.md](./SECURITY_SETUP.md)** - Security workflows, admin setup, MFA (⚠️ auth needs fixes - Priority 0.1)
 - **[SAFETY_SYSTEM.md](./SAFETY_SYSTEM.md)** - 13 safety fields, 100% coverage, component verification pending (Priority 0.3)
-- **[PERFORMANCE_OPTIMIZATION.md](./PERFORMANCE_OPTIMIZATION.md)** - Lighthouse optimization plan: 48→90+ target (Phase 1 complete)
+- **[PERFORMANCE_OPTIMIZATION.md](./PERFORMANCE_OPTIMIZATION.md)** - Lighthouse optimization: 99/100 desktop, 90/100 mobile (complete)
 
 ## 📊 Project Planning
 
 Roadmap and testing documentation:
 
-- **[IMPLEMENTATION_PLAN.md](./IMPLEMENTATION_PLAN.md)** - ⭐ Master plan: 6 priority tracks, all future work consolidated (updated 2026-01-19)
+- **[IMPLEMENTATION_PLAN.md](./IMPLEMENTATION_PLAN.md)** - ⭐ Master plan: 6 priority tracks, all future work consolidated (updated 2026-03-01)
 - **[TESTING_RESULTS.md](./TESTING_RESULTS.md)** - v1.0 external testing verification results (accessibility, performance, screen readers)
 
-## 📈 Current State (February 2026)
+## 📈 Current State (March 2026)
 
 ### Content Metrics
 
@@ -52,14 +52,15 @@ Roadmap and testing documentation:
 
 - ✅ **Build**: 1,058 static pages, zero errors, zero warnings
 - ✅ **Accessibility**: WCAG 2.1 AA compliant (externally verified)
-- ⚠️ **Performance**: Lighthouse 48/100 (Phase 1 optimizations complete, Phase 2-3 pending)
-- ✅ **Security**: Automated workflows operational (auth system needs fixes)
+- ✅ **Performance**: Lighthouse 99/100 desktop, 90/100 mobile (LCP 0.8s, TBT 0ms, SEO 100)
+- ✅ **Security**: Admin auth with MFA/JWT, automated workflows operational
 - ✅ **Bilingual**: Perfect EN/ES parity maintained
+- ✅ **Tests**: 617+ passing, 0 lint errors
 
 ### Status
 
-- 🚀 **v1.0 Production Ready** - Core features complete
-- 🔄 **Active Development** - Performance optimization and scientific accuracy audit in progress
+- 🚀 **v1.1 Production** - Core site complete, community features shipped
+- 🔄 **Remaining Work** - Render-blocking CSS, search analytics, offline enhancements
 - ✅ **Content Complete** - 175/175 species documented
 
 ## 📦 Archive

--- a/tests/api/v1-comparisons-slug.test.ts
+++ b/tests/api/v1-comparisons-slug.test.ts
@@ -57,7 +57,9 @@ vi.mock("contentlayer/generated", () => ({
 const { GET } = await import("@/app/api/v1/comparisons/[slug]/route");
 
 function createRequest(path: string): NextRequest {
-  return new NextRequest(new URL(path, "http://localhost:3000"));
+  return new NextRequest(new URL(path, "http://localhost:3000"), {
+    headers: { "X-API-Key": "test-api-key" },
+  });
 }
 
 function createParams(slug: string): { params: Promise<{ slug: string }> } {
@@ -66,6 +68,7 @@ function createParams(slug: string): { params: Promise<{ slug: string }> } {
 
 describe("GET /api/v1/comparisons/[slug]", () => {
   beforeEach(() => {
+    process.env.API_V1_KEY = "test-api-key";
     vi.clearAllMocks();
   });
 

--- a/tests/api/v1-comparisons.test.ts
+++ b/tests/api/v1-comparisons.test.ts
@@ -83,11 +83,14 @@ vi.mock("contentlayer/generated", () => ({
 const { GET } = await import("@/app/api/v1/comparisons/route");
 
 function createRequest(path: string): NextRequest {
-  return new NextRequest(new URL(path, "http://localhost:3000"));
+  return new NextRequest(new URL(path, "http://localhost:3000"), {
+    headers: { "X-API-Key": "test-api-key" },
+  });
 }
 
 describe("GET /api/v1/comparisons", () => {
   beforeEach(() => {
+    process.env.API_V1_KEY = "test-api-key";
     vi.clearAllMocks();
   });
 

--- a/tests/api/v1-families.test.ts
+++ b/tests/api/v1-families.test.ts
@@ -51,11 +51,14 @@ vi.mock("contentlayer/generated", () => ({
 const { GET } = await import("@/app/api/v1/families/route");
 
 function createRequest(url: string): NextRequest {
-  return new NextRequest(new URL(url, "http://localhost:3000"));
+  return new NextRequest(new URL(url, "http://localhost:3000"), {
+    headers: { "X-API-Key": "test-api-key" },
+  });
 }
 
 describe("GET /api/v1/families", () => {
   beforeEach(() => {
+    process.env.API_V1_KEY = "test-api-key";
     vi.clearAllMocks();
   });
 

--- a/tests/api/v1-glossary.test.ts
+++ b/tests/api/v1-glossary.test.ts
@@ -102,7 +102,9 @@ vi.mock("contentlayer/generated", () => ({
 }));
 
 function createRequest(path: string): NextRequest {
-  return new NextRequest(new URL(path, "http://localhost:3000"));
+  return new NextRequest(new URL(path, "http://localhost:3000"), {
+    headers: { "X-API-Key": "test-api-key" },
+  });
 }
 
 // ---- List route ----
@@ -111,6 +113,7 @@ const listRoute = await import("@/app/api/v1/glossary/route");
 
 describe("GET /api/v1/glossary", () => {
   beforeEach(() => {
+    process.env.API_V1_KEY = "test-api-key";
     vi.clearAllMocks();
   });
 
@@ -197,6 +200,7 @@ function createParams(slug: string): { params: Promise<{ slug: string }> } {
 
 describe("GET /api/v1/glossary/[slug]", () => {
   beforeEach(() => {
+    process.env.API_V1_KEY = "test-api-key";
     vi.clearAllMocks();
   });
 

--- a/tests/api/v1-trees-slug.test.ts
+++ b/tests/api/v1-trees-slug.test.ts
@@ -75,11 +75,14 @@ vi.mock("contentlayer/generated", () => ({
 const { GET } = await import("@/app/api/v1/trees/[slug]/route");
 
 function createRequest(url: string): NextRequest {
-  return new NextRequest(new URL(url, "http://localhost:3000"));
+  return new NextRequest(new URL(url, "http://localhost:3000"), {
+    headers: { "X-API-Key": "test-api-key" },
+  });
 }
 
 describe("GET /api/v1/trees/[slug]", () => {
   beforeEach(() => {
+    process.env.API_V1_KEY = "test-api-key";
     vi.clearAllMocks();
   });
 

--- a/tests/api/v1-trees.test.ts
+++ b/tests/api/v1-trees.test.ts
@@ -143,13 +143,14 @@ function createRequest(
   headers?: Record<string, string>
 ): NextRequest {
   const req = new NextRequest(new URL(url, "http://localhost:3000"), {
-    headers: headers ? new Headers(headers) : undefined,
+    headers: new Headers({ "X-API-Key": "test-api-key", ...headers }),
   });
   return req;
 }
 
 describe("GET /api/v1/trees", () => {
   beforeEach(() => {
+    process.env.API_V1_KEY = "test-api-key";
     vi.clearAllMocks();
   });
 


### PR DESCRIPTION
## Summary

Repo refresh after returning from another project.

### Changes
- **docs/README.md**: Update current state from Feb→Mar 2026, Lighthouse 48→99/90, add test count
- **docs/IMPLEMENTATION_PLAN.md**: Fix next milestones line (advanced search is mostly complete)
- **CONTRIBUTING.md**: Replace fork-based workflow with direct clone for private repo
- **tests/api/v1-*.test.ts**: Add `API_V1_KEY` env setup and `X-API-Key` header to 6 test files

### Results
- **694/694 tests passing** (was 617/694 — 77 v1 API tests were broken by private API access gate)
- Build passes, 0 lint errors, type-check clean
- All docs now reflect actual project state