### PR TITLE
fix: correct botanical and historical inaccuracies across content

### DIFF
--- a/content/comparisons/en/ceiba-vs-pochote.mdx
+++ b/content/comparisons/en/ceiba-vs-pochote.mdx
@@ -4,7 +4,7 @@ locale: "en"
 slug: "ceiba-vs-pochote"
 species: ["ceiba", "pochote"]
 keyDifference: "Ceiba has massive buttress roots at the base, while Pochote does not have buttresses."
-description: "Learn to distinguish between Ceiba pentandra and Bombacopsis quinata, two impressive spiny trees that are often confused."
+description: "Learn to distinguish between Ceiba pentandra and Pachira quinata (formerly Bombacopsis quinata), two impressive spiny trees that are often confused."
 featuredImages:
   - "/images/trees/ceiba.jpg"
   - "/images/trees/pochote.jpg"
@@ -67,7 +67,7 @@ Both the Ceiba and Pochote are magnificent trees with thorny trunks that can con
 
 ## Detailed Comparison Table
 
-| Feature                | Ceiba (_Ceiba pentandra_)                             | Pochote (_Bombacopsis quinata_)            |
+| Feature                | Ceiba (_Ceiba pentandra_)                             | Pochote (_Pachira quinata_)                |
 | ---------------------- | ----------------------------------------------------- | ------------------------------------------ |
 | **Trunk Base**         | Prominent buttress roots                              | No buttresses, straight trunk              |
 | **Trunk Surface**      | Smooth, greenish gray, scattered thick conical spines | Densely covered with sharp conical spines  |

--- a/content/comparisons/es/ceiba-vs-pochote.mdx
+++ b/content/comparisons/es/ceiba-vs-pochote.mdx
@@ -4,7 +4,7 @@ locale: "es"
 slug: "ceiba-vs-pochote"
 species: ["ceiba", "pochote"]
 keyDifference: "La Ceiba tiene raíces tabulares masivas en la base, mientras que el Pochote no tiene contrafuertes."
-description: "Aprende a distinguir entre Ceiba pentandra y Bombacopsis quinata, dos impresionantes árboles espinosos que a menudo se confunden."
+description: "Aprende a distinguir entre Ceiba pentandra y Pachira quinata (anteriormente Bombacopsis quinata), dos impresionantes árboles espinosos que a menudo se confunden."
 featuredImages:
   - "/images/trees/ceiba.jpg"
   - "/images/trees/pochote.jpg"
@@ -68,7 +68,7 @@ Tanto la Ceiba como el Pochote son árboles magníficos con troncos espinosos qu
 
 ## Tabla de Comparación Detallada
 
-| Característica             | Ceiba (_Ceiba pentandra_)                               | Pochote (_Bombacopsis quinata_)                  |
+| Característica             | Ceiba (_Ceiba pentandra_)                               | Pochote (_Pachira quinata_)                      |
 | -------------------------- | ------------------------------------------------------- | ------------------------------------------------ |
 | **Base del Tronco**        | Raíces tabulares prominentes                            | Sin contrafuertes, tronco recto                  |
 | **Superficie del Tronco**  | Lisa, gris verdosa, espinas cónicas gruesas dispersas   | Densamente cubierto con espinas cónicas afiladas |

--- a/content/glossary/en/buttress-roots.mdx
+++ b/content/glossary/en/buttress-roots.mdx
@@ -50,7 +50,7 @@ The sacred World Tree of the Maya is famous for massive buttresses that can dwar
 
 ### Almendro (_Dipteryx panamensis_)
 
-Costa Rica's tallest tree species develops impressive buttresses in mature specimens.
+One of Costa Rica's most important emergent rainforest trees, Almendro develops impressive buttresses in mature specimens reaching 40-50 m tall.
 
 ### Espavel (_Anacardium excelsum_)
 

--- a/content/glossary/es/buttress-roots.mdx
+++ b/content/glossary/es/buttress-roots.mdx
@@ -50,7 +50,7 @@ El sagrado Árbol del Mundo de los Mayas es famoso por sus masivos contrafuertes
 
 ### Almendro (_Dipteryx panamensis_)
 
-La especie de árbol más alta de Costa Rica desarrolla impresionantes contrafuertes en especímenes maduros.
+Uno de los árboles emergentes más importantes del bosque lluvioso de Costa Rica, el Almendro desarrolla impresionantes contrafuertes en especímenes maduros que alcanzan 40-50 m de altura.
 
 ### Espavel (_Anacardium excelsum_)
 

--- a/content/trees/en/almendro.mdx
+++ b/content/trees/en/almendro.mdx
@@ -27,7 +27,6 @@ distribution:
   - "limon"
   - "alajuela"
   - "heredia"
-  - "puntarenas"
 elevation: "0-800m"
 floweringSeason:
   - "february"
@@ -110,7 +109,7 @@ commonProblems:
 <Column>
 
 <INaturalistEmbed
-  taxonId="490687"
+  taxonId="498908"
   taxonName="Dipteryx panamensis"
   observationCount={312}
 />
@@ -129,7 +128,7 @@ commonProblems:
     title="Whole tree"
     credit="(c) Leonardo Álvarez-Alcázar, some rights reserved (CC BY-NC)"
     license="CC BY-NC"
-    sourceUrl="https://www.inaturalist.org/taxa/490687-Dipteryx-oleifera/browse_photos"
+    sourceUrl="https://www.inaturalist.org/taxa/498908-Dipteryx-panamensis/browse_photos"
   />
   <ImageCard
     src="https://inaturalist-open-data.s3.amazonaws.com/photos/207141103/medium.jpeg"
@@ -137,7 +136,7 @@ commonProblems:
     title="Leaves"
     credit="(c) Leonardo Álvarez-Alcázar, some rights reserved (CC BY-NC)"
     license="CC BY-NC"
-    sourceUrl="https://www.inaturalist.org/taxa/490687-Dipteryx-oleifera/browse_photos"
+    sourceUrl="https://www.inaturalist.org/taxa/498908-Dipteryx-panamensis/browse_photos"
   />
   <ImageCard
     src="https://inaturalist-open-data.s3.amazonaws.com/photos/207141073/medium.jpeg"
@@ -145,7 +144,7 @@ commonProblems:
     title="Whole tree"
     credit="(c) Ruth Ripley, all rights reserved"
     license="CC BY-NC"
-    sourceUrl="https://www.inaturalist.org/taxa/490687-Dipteryx-oleifera/browse_photos"
+    sourceUrl="https://www.inaturalist.org/taxa/498908-Dipteryx-panamensis/browse_photos"
   />
   <ImageCard
     src="https://inaturalist-open-data.s3.amazonaws.com/photos/207141045/medium.jpeg"
@@ -153,7 +152,7 @@ commonProblems:
     title="Leaves"
     credit="(c) aparayil, some rights reserved (CC BY-NC)"
     license="CC BY-NC"
-    sourceUrl="https://www.inaturalist.org/taxa/490687-Dipteryx-oleifera/browse_photos"
+    sourceUrl="https://www.inaturalist.org/taxa/498908-Dipteryx-panamensis/browse_photos"
   />
   <ImageCard
     src="https://inaturalist-open-data.s3.amazonaws.com/photos/207141005/medium.jpeg"
@@ -161,14 +160,14 @@ commonProblems:
     title="Whole tree"
     credit="(c) aparayil, some rights reserved (CC BY-NC)"
     license="CC BY-NC"
-    sourceUrl="https://www.inaturalist.org/taxa/490687-Dipteryx-oleifera/browse_photos"
+    sourceUrl="https://www.inaturalist.org/taxa/498908-Dipteryx-panamensis/browse_photos"
   />
 </ImageGallery>
 
 <Callout type="info">
   Photos sourced from iNaturalist's community science database. [Browse all
   observations
-  →](https://www.inaturalist.org/taxa/490687-Dipteryx-oleifera/browse_photos)
+  →](https://www.inaturalist.org/taxa/498908-Dipteryx-panamensis/browse_photos)
 </Callout>
 
 ---
@@ -761,10 +760,12 @@ Growing Almendro is a long-term commitment — this slow-growing giant may take 
 - **Year 100+**: Full stature (40–50 m); critical nesting habitat for Great Green Macaws
 
 <Callout type="warning" title="Conservation Note">
-  Almendro is protected under Costa Rican law (Executive Decree 25700-MINAE). A
-  permit from SINAC is required to fell or transport this species. Planting
-  Almendro in biological corridors between the San Juan River and Sarapiquí is
-  one of the most impactful conservation actions for the Great Green Macaw.
+  Almendro is protected under Costa Rican law. Executive Decree 25700-MINAE
+  (1997) provided initial protection, and Decree 35340-MINAET (2008) established
+  the full logging ban. A permit from SINAC is required to fell or transport
+  this species. Planting Almendro in biological corridors between the San Juan
+  River and Sarapiquí is one of the most impactful conservation actions for the
+  Great Green Macaw.
 </Callout>
 
 ---

--- a/content/trees/en/ceiba.mdx
+++ b/content/trees/en/ceiba.mdx
@@ -68,26 +68,22 @@ soilRequirements: "Deep, moist, well-drained soils; grows best in alluvial soils
 waterNeeds: "high"
 waterDetails: "Requires consistent moisture, especially when young. Not drought-tolerant - needs regular rainfall or irrigation. Naturally grows in moist tropical forests and near rivers. Young trees need deep watering twice weekly during dry periods."
 lightRequirements: "full-sun"
----
-
 spacing: "Plant MINIMUM 30-40 m (100-130 ft) from buildings, power lines, structures; needs enormous space - only suitable for very large properties, parks, or natural forest settings"
 propagationMethods:
-
-- "seeds"
-- "large cuttings"
-  propagationDifficulty: "moderate"
-  plantingSeason: "Plant at start of rainy season (May-June); requires reliable moisture for establishment"
-  maintenanceNeeds: "REQUIRES PROFESSIONAL CARE due to extreme size. Young trees (1-5 years): protect from wind, provide consistent water, remove competing vegetation. SPINE HAZARD when pruning - use extreme caution and protective equipment. Formative pruning to develop strong structure in years 3-7. Mature trees should only be worked on by certified arborists - branch failure can be fatal. Do NOT attempt to climb or work on mature Ceibas without professional equipment and training."
-  commonProblems:
-- "DANGEROUS SPINES - young trees have sharp trunk spines causing painful injuries; wear thick gloves and long sleeves"
-- "Kapok fiber irritation - seed pod fiber causes skin and respiratory irritation in some people"
-- "Massive size inappropriate for small properties - requires 1+ acre minimum"
-- "Buttress roots damage sidewalks, driveways, building foundations if planted too close"
-- "Falling branches from mature trees - can cause property damage or injury"
-- "Wind damage to young trees - stake for first 2-3 years in exposed locations"
-- "Poor establishment if planted in dry season without irrigation"
-- "NOT drought-tolerant - will decline without adequate water"
-
+  - "seeds"
+  - "large cuttings"
+propagationDifficulty: "moderate"
+plantingSeason: "Plant at start of rainy season (May-June); requires reliable moisture for establishment"
+maintenanceNeeds: "REQUIRES PROFESSIONAL CARE due to extreme size. Young trees (1-5 years): protect from wind, provide consistent water, remove competing vegetation. SPINE HAZARD when pruning - use extreme caution and protective equipment. Formative pruning to develop strong structure in years 3-7. Mature trees should only be worked on by certified arborists - branch failure can be fatal. Do NOT attempt to climb or work on mature Ceibas without professional equipment and training."
+commonProblems:
+  - "DANGEROUS SPINES - young trees have sharp trunk spines causing painful injuries; wear thick gloves and long sleeves"
+  - "Kapok fiber irritation - seed pod fiber causes skin and respiratory irritation in some people"
+  - "Massive size inappropriate for small properties - requires 1+ acre minimum"
+  - "Buttress roots damage sidewalks, driveways, building foundations if planted too close"
+  - "Falling branches from mature trees - can cause property damage or injury"
+  - "Wind damage to young trees - stake for first 2-3 years in exposed locations"
+  - "Poor establishment if planted in dry season without irrigation"
+  - "NOT drought-tolerant - will decline without adequate water"
 ---
 
 # Ceiba

--- a/content/trees/en/cocobolo.mdx
+++ b/content/trees/en/cocobolo.mdx
@@ -42,7 +42,7 @@ updatedAt: "2026-01-10"
 # Safety Information
 toxicityLevel: "low"
 toxicParts:
-  - "wood-dust"
+  - "wood"
 skinContactRisk: "moderate"
 allergenRisk: "high"
 childSafe: true

--- a/content/trees/en/cocobolo.mdx
+++ b/content/trees/en/cocobolo.mdx
@@ -41,6 +41,8 @@ publishedAt: "2024-12-19"
 updatedAt: "2026-01-10"
 # Safety Information
 toxicityLevel: "low"
+toxicParts:
+  - "wood-dust"
 skinContactRisk: "moderate"
 allergenRisk: "high"
 childSafe: true
@@ -49,8 +51,8 @@ requiresProfessionalCare: true
 toxicityDetails: "The wood itself is not significantly toxic if ingested (though wood should not be eaten). The tree is not a food plant. Main concerns are respiratory and dermatological from wood dust exposure during woodworking."
 skinContactDetails: "ALLERGIC REACTIONS FROM WOOD DUST: Cocobolo wood contains dalbergione and other quinones that are potent sensitizers. Handling the wood, especially sawdust and fine particles, can cause severe allergic contact dermatitis with itching, redness, blistering, and rash. Reactions can occur after first exposure or develop with repeated contact. Some woodworkers develop persistent sensitivity. Fresh-cut wood and sawdust present highest risk. Wear gloves when handling. Reactions similar to poison ivy/oak but from different chemical compounds."
 allergenDetails: "SEVERE RESPIRATORY HAZARD FOR WOODWORKERS: Cocobolo dust is one of the most allergenic woods in the world. Inhalation of dust can cause respiratory sensitization, asthma, allergic rhinitis, nosebleeds, and severe breathing difficulties. Some individuals develop chronic respiratory problems. Wood dust is classified as a known respiratory sensitizer. Dust particles can also cause eye irritation and conjunctivitis. ALWAYS use proper dust collection, respirators, and ventilation when working cocobolo. Even brief exposure can sensitize susceptible individuals. Once sensitized, reactions worsen with subsequent exposure."
-structuralRiskDetails: "The tree itself is not a structural hazard. It is relatively small and slow-growing. However, the CRITICALLY ENDANGERED status means cutting living trees is illegal in most jurisdictions. Work only with legally sourced, certified wood from managed plantations or salvaged sources."
-safetyNotes: "WOODWORKERS WARNING: If you work with cocobolo wood, take this seriously - it is among the most allergenic woods. Use proper PPE: N95 or better respirator, dust collection at the source, good ventilation, gloves, and long sleeves. Clean work area thoroughly. Some woodworkers cannot continue working with cocobolo after sensitization. The finished product is generally safe once sealed. CONSERVATION: This tree is Critically Endangered (CITES Appendix II). Purchasing cocobolo supports habitat destruction unless from certified sustainable sources. Consider alternative woods."
+structuralRiskDetails: "The tree itself is not a structural hazard. It is relatively small and slow-growing. However, the VULNERABLE status (IUCN) and CITES Appendix II listing means cutting living trees is illegal in most jurisdictions. Work only with legally sourced, certified wood from managed plantations or salvaged sources."
+safetyNotes: "WOODWORKERS WARNING: If you work with cocobolo wood, take this seriously - it is among the most allergenic woods. Use proper PPE: N95 or better respirator, dust collection at the source, good ventilation, gloves, and long sleeves. Clean work area thoroughly. Some woodworkers cannot continue working with cocobolo after sensitization. The finished product is generally safe once sealed. CONSERVATION: This tree is Vulnerable (IUCN) and listed under CITES Appendix II. Purchasing cocobolo supports habitat destruction unless from certified sustainable sources. Consider alternative woods."
 wildlifeRisks: "Not toxic to wildlife or domestic animals. Safe for pets. The conservation concern is habitat loss from illegal logging, not animal toxicity."
 # Care & Cultivation
 growthRate: "slow"
@@ -75,7 +77,7 @@ commonProblems:
   - "WEED COMPETITION - young trees easily overtopped; aggressive weed control needed"
   - "ILLEGAL HARVEST - valuable trees may be poached; security concerns for mature plantations"
   - "CITES REGULATIONS - complex legal requirements for harvest, transport, export; obtain permits"
-  - "CRITICALLY ENDANGERED status means habitat protection crucial; don't wild-harvest"
+  - "VULNERABLE status (IUCN) and CITES Appendix II listing means habitat protection crucial; don't wild-harvest"
   - "Wood dust toxicity complicates timber processing; mills need special precautions"
   - "Market prices fluctuate; long investment period (60-100 years) has economic risks"
   - "Best for PATIENT conservation-minded growers, not quick profit seekers"
@@ -389,7 +391,7 @@ Cocobolo is native to Costa Rica's Pacific dry forests, from Guanacaste south to
 ### A Species in Crisis
 
 <Callout type="warning" title="IUCN & CITES Status">
-  **IUCN Red List**: Critically Endangered (population decreasing) **CITES**:
+  **IUCN Red List**: Vulnerable (VU) — population decreasing. **CITES**:
   Appendix II (all _Dalbergia_ species) Since 2017, ALL _Dalbergia_ species have
   been included in CITES Appendix II, meaning international trade requires
   permits and documentation. This was in response to catastrophic logging of

--- a/content/trees/en/espavel.mdx
+++ b/content/trees/en/espavel.mdx
@@ -29,13 +29,14 @@ distribution:
   - "puntarenas"
 elevation: "0-800m"
 floweringSeason:
+  - "november"
+  - "december"
+  - "january"
+fruitingSeason:
+  - "december"
   - "january"
   - "february"
   - "march"
-fruitingSeason:
-  - "may"
-  - "june"
-  - "july"
 featuredImage: "/images/trees/espavel.jpg"
 publishedAt: "2024-12-19"
 updatedAt: "2025-01-10"

--- a/content/trees/en/mango.mdx
+++ b/content/trees/en/mango.mdx
@@ -7,7 +7,7 @@ slug: "mango"
 description: "The Mango is the 'King of Fruits' and one of the most economically important tropical fruit trees worldwide. Though originally from South Asia, this magnificent tree has become an integral part of Costa Rican culture and landscape, providing delicious fruit, welcome shade, and essential wildlife food."
 nativeRegion: "South Asia"
 conservationStatus: "NE"
-maxHeight: "15-30 meters"
+maxHeight: "10-45 meters (33-150 feet)"
 uses:
   - "Fruit production (fresh, processed)"
   - "Shade tree"
@@ -61,7 +61,7 @@ safetyNotes: "FRUIT IS SAFE TO EAT. To avoid skin reactions: peel mangoes with g
 # Care & Cultivation
 growthRate: "moderate"
 growthRateDetails: "2-3 ft/year once established; grafted trees fruit in 3-5 years, seed-grown trees in 5-8 years"
-matureSize: "15-30 m tall (50-100 ft), crown spread 10-15 m; size depends on variety and pruning"
+matureSize: "10-45 m tall (33-150 ft), crown spread 10-15 m; size depends on variety and pruning"
 hardiness: "Tropical and subtropical 0-1500m; performs best below 600m; sensitive to frost"
 soilRequirements: "Well-drained soils essential - intolerant of waterlogging; pH 5.5-7.5; tolerates sandy, loamy, or clay soils if drainage good"
 waterNeeds: "moderate"
@@ -107,7 +107,7 @@ commonProblems:
   items={[
     { label: "Scientific Name", value: "Mangifera indica" },
     { label: "Family", value: "Anacardiaceae (Cashew Family)" },
-    { label: "Max Height", value: "20-45 m" },
+    { label: "Max Height", value: "10-45 m" },
     { label: "Trunk Diameter", value: "Up to 1.2 m" },
     { label: "Conservation", value: "Not Evaluated (cultivated)" },
     { label: "Key Feature", value: "World's most popular tropical fruit" },
@@ -675,7 +675,7 @@ The Mango is a large, long-lived evergreen tree with a dense, rounded crown. Mat
 <ExternalLinksGrid>
   <ExternalLink
     title="iNaturalist: Mangifera indica"
-    href="https://www.inaturalist.org/taxa/75011-Mangifera-indica"
+    href="https://www.inaturalist.org/taxa/48872-Mangifera-indica"
     description="Community observations and photos"
   />
   <ExternalLink

--- a/content/trees/es/almendro.mdx
+++ b/content/trees/es/almendro.mdx
@@ -27,8 +27,7 @@ distribution:
   - "limon"
   - "alajuela"
   - "heredia"
-  - "puntarenas"
-elevation: "0-1200m"
+elevation: "0-800m"
 floweringSeason:
   - "february"
   - "march"
@@ -113,7 +112,7 @@ commonProblems:
 <Column>
 
 <INaturalistEmbed
-  taxonId="490687"
+  taxonId="498908"
   taxonName="Dipteryx panamensis"
   observationCount={312}
 />
@@ -132,7 +131,7 @@ commonProblems:
     title="Whole tree"
     credit="(c) Leonardo Álvarez-Alcázar, some rights reserved (CC BY-NC)"
     license="CC BY-NC"
-    sourceUrl="https://www.inaturalist.org/taxa/490687-Dipteryx-oleifera/browse_photos"
+    sourceUrl="https://www.inaturalist.org/taxa/498908-Dipteryx-panamensis/browse_photos"
   />
   <ImageCard
     src="https://inaturalist-open-data.s3.amazonaws.com/photos/207141103/medium.jpeg"
@@ -140,7 +139,7 @@ commonProblems:
     title="Leaves"
     credit="(c) Leonardo Álvarez-Alcázar, some rights reserved (CC BY-NC)"
     license="CC BY-NC"
-    sourceUrl="https://www.inaturalist.org/taxa/490687-Dipteryx-oleifera/browse_photos"
+    sourceUrl="https://www.inaturalist.org/taxa/498908-Dipteryx-panamensis/browse_photos"
   />
   <ImageCard
     src="https://inaturalist-open-data.s3.amazonaws.com/photos/207141073/medium.jpeg"
@@ -148,7 +147,7 @@ commonProblems:
     title="Whole tree"
     credit="(c) Ruth Ripley, all rights reserved"
     license="CC BY-NC"
-    sourceUrl="https://www.inaturalist.org/taxa/490687-Dipteryx-oleifera/browse_photos"
+    sourceUrl="https://www.inaturalist.org/taxa/498908-Dipteryx-panamensis/browse_photos"
   />
   <ImageCard
     src="https://inaturalist-open-data.s3.amazonaws.com/photos/207141045/medium.jpeg"
@@ -156,7 +155,7 @@ commonProblems:
     title="Leaves"
     credit="(c) aparayil, some rights reserved (CC BY-NC)"
     license="CC BY-NC"
-    sourceUrl="https://www.inaturalist.org/taxa/490687-Dipteryx-oleifera/browse_photos"
+    sourceUrl="https://www.inaturalist.org/taxa/498908-Dipteryx-panamensis/browse_photos"
   />
   <ImageCard
     src="https://inaturalist-open-data.s3.amazonaws.com/photos/207141005/medium.jpeg"
@@ -164,14 +163,14 @@ commonProblems:
     title="Whole tree"
     credit="(c) aparayil, some rights reserved (CC BY-NC)"
     license="CC BY-NC"
-    sourceUrl="https://www.inaturalist.org/taxa/490687-Dipteryx-oleifera/browse_photos"
+    sourceUrl="https://www.inaturalist.org/taxa/498908-Dipteryx-panamensis/browse_photos"
   />
 </ImageGallery>
 
 <Callout type="info">
   Fotos obtenidas de la base de datos de ciencia comunitaria de iNaturalist.
   [Ver todas las observaciones
-  →](https://www.inaturalist.org/taxa/490687-Dipteryx-oleifera/browse_photos)
+  →](https://www.inaturalist.org/taxa/498908-Dipteryx-panamensis/browse_photos)
 </Callout>
 
 ---
@@ -800,11 +799,12 @@ Cultivar Almendro es un compromiso a largo plazo — este gigante de crecimiento
 - **Año 100+**: Porte completo (40–50 m); hábitat crítico de anidación para Lapas Verdes
 
 <Callout type="warning" title="Nota de Conservación">
-  El Almendro está protegido por la ley costarricense (Decreto Ejecutivo
-  25700-MINAE). Se requiere permiso de SINAC para talar o transportar esta
-  especie. Plantar Almendro en corredores biológicos entre el Río San Juan y
-  Sarapiquí es una de las acciones de conservación más impactantes para la Lapa
-  Verde.
+  El Almendro está protegido por la ley costarricense. El Decreto Ejecutivo
+  25700-MINAE (1997) brindó protección inicial, y el Decreto 35340-MINAET (2008)
+  estableció la veda total de tala. Se requiere permiso de SINAC para talar o
+  transportar esta especie. Plantar Almendro en corredores biológicos entre el
+  Río San Juan y Sarapiquí es una de las acciones de conservación más
+  impactantes para la Lapa Verde.
 </Callout>
 
 ---

--- a/content/trees/es/ceiba.mdx
+++ b/content/trees/es/ceiba.mdx
@@ -68,26 +68,22 @@ soilRequirements: "Suelos profundos, húmedos, bien drenados; crece mejor en sue
 waterNeeds: "high"
 waterDetails: "Requiere humedad consistente, especialmente cuando es joven. No tolerante a sequía - necesita lluvia regular o riego. Naturalmente crece en bosques tropicales húmedos y cerca de ríos. Árboles jóvenes necesitan riego profundo dos veces por semana durante períodos secos."
 lightRequirements: "full-sun"
----
-
 spacing: "Plantar MÍNIMO 30-40 m de edificios, líneas eléctricas, estructuras; necesita espacio enorme - solo adecuado para propiedades muy grandes, parques, o entornos forestales naturales"
 propagationMethods:
-
-- "seeds"
-- "esquejes grandes"
-  propagationDifficulty: "moderate"
-  plantingSeason: "Plantar al inicio de temporada lluviosa (mayo-junio); requiere humedad confiable para establecimiento"
-  maintenanceNeeds: "REQUIERE CUIDADO PROFESIONAL debido al tamaño extremo. Árboles jóvenes (1-5 años): proteger del viento, proporcionar agua consistente, remover vegetación competidora. PELIGRO DE ESPINAS al podar - use extrema precaución y equipo protector. Poda formativa para desarrollar estructura fuerte en años 3-7. Árboles maduros solo deben ser trabajados por arboristas certificados - fallo de rama puede ser fatal. NO intente trepar o trabajar en Ceibas maduras sin equipo profesional y capacitación."
-  commonProblems:
-- "ESPINAS PELIGROSAS - árboles jóvenes tienen espinas afiladas en tronco causando lesiones dolorosas; use guantes gruesos y mangas largas"
-- "Irritación de fibra de kapok - fibra de vaina de semilla causa irritación de piel y respiratoria en algunas personas"
-- "Tamaño masivo inapropiado para propiedades pequeñas - requiere mínimo 1+ acre"
-- "Raíces contrafuerte dañan aceras, calzadas, cimientos de edificios si se planta muy cerca"
-- "Ramas que caen de árboles maduros - pueden causar daño a propiedad o lesiones"
-- "Daño por viento a árboles jóvenes - estaquear primeros 2-3 años en ubicaciones expuestas"
-- "Mal establecimiento si se planta en temporada seca sin riego"
-- "NO tolerante a sequía - declinará sin agua adecuada"
-
+  - "seeds"
+  - "esquejes grandes"
+propagationDifficulty: "moderate"
+plantingSeason: "Plantar al inicio de temporada lluviosa (mayo-junio); requiere humedad confiable para establecimiento"
+maintenanceNeeds: "REQUIERE CUIDADO PROFESIONAL debido al tamaño extremo. Árboles jóvenes (1-5 años): proteger del viento, proporcionar agua consistente, remover vegetación competidora. PELIGRO DE ESPINAS al podar - use extrema precaución y equipo protector. Poda formativa para desarrollar estructura fuerte en años 3-7. Árboles maduros solo deben ser trabajados por arboristas certificados - fallo de rama puede ser fatal. NO intente trepar o trabajar en Ceibas maduras sin equipo profesional y capacitación."
+commonProblems:
+  - "ESPINAS PELIGROSAS - árboles jóvenes tienen espinas afiladas en tronco causando lesiones dolorosas; use guantes gruesos y mangas largas"
+  - "Irritación de fibra de kapok - fibra de vaina de semilla causa irritación de piel y respiratoria en algunas personas"
+  - "Tamaño masivo inapropiado para propiedades pequeñas - requiere mínimo 1+ acre"
+  - "Raíces contrafuerte dañan aceras, calzadas, cimientos de edificios si se planta muy cerca"
+  - "Ramas que caen de árboles maduros - pueden causar daño a propiedad o lesiones"
+  - "Daño por viento a árboles jóvenes - estaquear primeros 2-3 años en ubicaciones expuestas"
+  - "Mal establecimiento si se planta en temporada seca sin riego"
+  - "NO tolerante a sequía - declinará sin agua adecuada"
 ---
 
 # Ceiba

--- a/content/trees/es/cocobolo.mdx
+++ b/content/trees/es/cocobolo.mdx
@@ -42,7 +42,7 @@ updatedAt: "2026-01-10"
 # Información de Seguridad
 toxicityLevel: "low"
 toxicParts:
-  - "wood-dust"
+  - "wood"
 skinContactRisk: "moderate"
 allergenRisk: "high"
 childSafe: true

--- a/content/trees/es/cocobolo.mdx
+++ b/content/trees/es/cocobolo.mdx
@@ -41,6 +41,8 @@ publishedAt: "2024-12-19"
 updatedAt: "2026-01-10"
 # Información de Seguridad
 toxicityLevel: "low"
+toxicParts:
+  - "wood-dust"
 skinContactRisk: "moderate"
 allergenRisk: "high"
 childSafe: true
@@ -49,8 +51,8 @@ requiresProfessionalCare: true
 toxicityDetails: "La madera en sí no es significativamente tóxica si se ingiere (aunque la madera no debe comerse). El árbol no es una planta alimenticia. Las principales preocupaciones son respiratorias y dermatológicas por exposición al polvo de madera durante el trabajo de carpintería."
 skinContactDetails: "REACCIONES ALÉRGICAS DEL POLVO DE MADERA: La madera de cocobolo contiene dalbergiona y otras quinonas que son potentes sensibilizadores. El manejo de la madera, especialmente el aserrín y partículas finas, puede causar dermatitis de contacto alérgica severa con picazón, enrojecimiento, ampollas y erupción. Las reacciones pueden ocurrir después de la primera exposición o desarrollarse con contacto repetido. Algunos carpinteros desarrollan sensibilidad persistente. La madera recién cortada y el aserrín presentan el mayor riesgo. Use guantes al manipular. Reacciones similares a la hiedra venenosa pero de diferentes compuestos químicos."
 allergenDetails: "PELIGRO RESPIRATORIO SEVERO PARA CARPINTEROS: El polvo de cocobolo es una de las maderas más alergénicas del mundo. La inhalación de polvo puede causar sensibilización respiratoria, asma, rinitis alérgica, sangrado nasal y dificultades respiratorias severas. Algunos individuos desarrollan problemas respiratorios crónicos. El polvo de madera está clasificado como un sensibilizador respiratorio conocido. Las partículas de polvo también pueden causar irritación ocular y conjuntivitis. SIEMPRE use recolección de polvo adecuada, respiradores y ventilación al trabajar cocobolo. Incluso la exposición breve puede sensibilizar a individuos susceptibles. Una vez sensibilizado, las reacciones empeoran con la exposición subsecuente."
-structuralRiskDetails: "El árbol en sí no es un peligro estructural. Es relativamente pequeño y de crecimiento lento. Sin embargo, el estado CRÍTICAMENTE EN PELIGRO significa que cortar árboles vivos es ilegal en la mayoría de jurisdicciones. Trabaje solo con madera legalmente obtenida, certificada de plantaciones manejadas o fuentes recuperadas."
-safetyNotes: "ADVERTENCIA PARA CARPINTEROS: Si trabaja con madera de cocobolo, tome esto en serio - es una de las maderas más alergénicas. Use EPP adecuado: respirador N95 o mejor, recolección de polvo en la fuente, buena ventilación, guantes y mangas largas. Limpie el área de trabajo completamente. Algunos carpinteros no pueden continuar trabajando con cocobolo después de la sensibilización. El producto terminado es generalmente seguro una vez sellado. CONSERVACIÓN: Este árbol está Críticamente en Peligro (CITES Apéndice II). Comprar cocobolo apoya la destrucción del hábitat a menos que sea de fuentes sostenibles certificadas. Considere maderas alternativas."
+structuralRiskDetails: "El árbol en sí no es un peligro estructural. Es relativamente pequeño y de crecimiento lento. Sin embargo, el estado VULNERABLE (UICN) y listado en CITES Apéndice II significa que cortar árboles vivos es ilegal en la mayoría de jurisdicciones. Trabaje solo con madera legalmente obtenida, certificada de plantaciones manejadas o fuentes recuperadas."
+safetyNotes: "ADVERTENCIA PARA CARPINTEROS: Si trabaja con madera de cocobolo, tome esto en serio - es una de las maderas más alergénicas. Use EPP adecuado: respirador N95 o mejor, recolección de polvo en la fuente, buena ventilación, guantes y mangas largas. Limpie el área de trabajo completamente. Algunos carpinteros no pueden continuar trabajando con cocobolo después de la sensibilización. El producto terminado es generalmente seguro una vez sellado. CONSERVACIÓN: Este árbol es Vulnerable (UICN) y está listado bajo CITES Apéndice II. Comprar cocobolo apoya la destrucción del hábitat a menos que sea de fuentes sostenibles certificadas. Considere maderas alternativas."
 wildlifeRisks: "No tóxico para vida silvestre o animales domésticos. Seguro para mascotas. La preocupación de conservación es la pérdida de hábitat por tala ilegal, no toxicidad animal."
 # Cuidado y Cultivo
 growthRate: "slow"
@@ -75,7 +77,7 @@ commonProblems:
   - "COMPETENCIA DE MALEZAS - árboles jóvenes fácilmente sobrepasados; control agresivo de malezas necesario"
   - "COSECHA ILEGAL - árboles valiosos pueden ser cazados furtivamente; preocupaciones de seguridad para plantaciones maduras"
   - "REGULACIONES CITES - requisitos legales complejos para cosecha, transporte, exportación; obtener permisos"
-  - "Estado CRÍTICAMENTE EN PELIGRO significa protección de hábitat crucial; no cosechar de vida silvestre"
+  - "Estado VULNERABLE (UICN) y CITES Apéndice II significa protección de hábitat crucial; no cosechar de vida silvestre"
   - "Toxicidad de polvo de madera complica procesamiento; aserraderos necesitan precauciones especiales"
   - "Precios de mercado fluctúan; largo período de inversión (60-100 años) tiene riesgos económicos"
   - "Mejor para cultivadores PACIENTES con mentalidad de conservación, no buscadores de ganancias rápidas"

--- a/content/trees/es/espavel.mdx
+++ b/content/trees/es/espavel.mdx
@@ -29,13 +29,14 @@ distribution:
   - "puntarenas"
 elevation: "0-800m"
 floweringSeason:
+  - "november"
+  - "december"
+  - "january"
+fruitingSeason:
+  - "december"
   - "january"
   - "february"
   - "march"
-fruitingSeason:
-  - "may"
-  - "june"
-  - "july"
 featuredImage: "/images/trees/espavel.jpg"
 publishedAt: "2024-12-19"
 updatedAt: "2025-01-10"

--- a/content/trees/es/mango.mdx
+++ b/content/trees/es/mango.mdx
@@ -7,7 +7,7 @@ slug: "mango"
 description: "El Mango es el 'Rey de las Frutas' y uno de los árboles frutales más importantes económicamente en el mundo. Aunque originario del sur de Asia, este magnífico árbol se ha convertido en parte integral de la cultura y el paisaje costarricense, proporcionando deliciosa fruta, agradable sombra y alimento esencial para la fauna silvestre."
 nativeRegion: "Sur de Asia"
 conservationStatus: "NE"
-maxHeight: "15-30 metros"
+maxHeight: "10-45 metros (33-150 pies)"
 uses:
   - "Producción de fruta (fresca, procesada)"
   - "Árbol de sombra"
@@ -61,7 +61,7 @@ safetyNotes: "LA FRUTA ES SEGURA PARA COMER. Para evitar reacciones cutáneas: p
 # Cuidado y Cultivo
 growthRate: "moderate"
 growthRateDetails: "0.6-0.9 m/año una vez establecido; árboles injertados dan fruto en 3-5 años, árboles de semilla en 5-8 años"
-matureSize: "15-30 m de alto (50-100 pies), extensión de copa 10-15 m; tamaño depende de la variedad y poda"
+matureSize: "10-45 m de alto (33-150 pies), extensión de copa 10-15 m; tamaño depende de la variedad y poda"
 hardiness: "Tropical y subtropical 0-1500m; rinde mejor bajo 600m; sensible a heladas"
 soilRequirements: "Suelos bien drenados esenciales - intolerante al encharcamiento; pH 5.5-7.5; tolera suelos arenosos, francos o arcillosos si el drenaje es bueno"
 waterNeeds: "moderate"
@@ -108,7 +108,7 @@ commonProblems:
   items={[
     { label: "Nombre Científico", value: "Mangifera indica" },
     { label: "Familia", value: "Anacardiaceae (Familia del Marañón)" },
-    { label: "Altura Máxima", value: "20-45 m" },
+    { label: "Altura Máxima", value: "10-45 m" },
     { label: "Diámetro del Tronco", value: "Hasta 1.2 m" },
     { label: "Conservación", value: "No Evaluado (cultivado)" },
     {
@@ -700,7 +700,7 @@ El Mango es un árbol grande, longevo y siempreverde con una copa densa y redond
 <ExternalLinksGrid>
   <ExternalLink
     title="iNaturalist: Mangifera indica"
-    href="https://www.inaturalist.org/taxa/75011-Mangifera-indica"
+    href="https://www.inaturalist.org/taxa/48872-Mangifera-indica"
     description="Observaciones y fotos de la comunidad"
   />
   <ExternalLink

--- a/messages/es.json
+++ b/messages/es.json
@@ -164,7 +164,7 @@
     "noSavedFilters": "No hay filtros guardados"
   },
   "footer": {
-    "description": "Una iniciativa educativa dedicada a documentar los árboles de Costa Rica.",
+    "description": "Un proyecto mantenido de forma privada dedicado a documentar los árboles de Costa Rica.",
     "quickLinks": "Enlaces Rápidos",
     "home": "Inicio",
     "allTrees": "Todos los Árboles",
@@ -214,7 +214,7 @@
   },
   "about": {
     "title": "Acerca del Atlas de Árboles de Costa Rica",
-    "subtitle": "Una iniciativa educativa que documenta los magníficos árboles de Costa Rica",
+    "subtitle": "Un proyecto mantenido de forma privada que documenta los magníficos árboles de Costa Rica",
     "mission": {
       "title": "Nuestra Misión",
       "description": "El Atlas de Árboles de Costa Rica está dedicado a crear un recurso integral, accesible y bilingüe que documenta los notables árboles encontrados en toda Costa Rica. Creemos que el conocimiento sobre la flora nativa es esencial para la conservación, la educación y fomentar una apreciación más profunda del mundo natural."


### PR DESCRIPTION
## Summary

Comprehensive accuracy audit of all tree species, comparison guides, glossary entries, and translations. Fixes 13 botanical, taxonomic, and historical inaccuracies across 15 files.

## Changes

### CRITICAL
- **Ceiba** (EN+ES): Fixed premature `---` delimiter in frontmatter that caused 6 care/cultivation fields to be parsed as body markdown instead of structured data

### HIGH
- **Cocobolo** (EN+ES): Corrected IUCN conservation status from "Critically Endangered" to "Vulnerable" (VU)
- **Espavel** (EN+ES): Fixed flowering season (→ Nov-Jan) and fruiting season (→ Dec-Mar) to match dry-season biology described in body text
- **Mango** (EN+ES): Standardized height range to 10-45m across frontmatter and body (was inconsistent 15-30m / 20-45m)
- **Ceiba vs Pochote comparison** (EN+ES): Updated outdated *Bombacopsis quinata* to accepted name *Pachira quinata*

### MEDIUM
- **Almendro** (EN+ES): Removed incorrect `puntarenas` from distribution (body table lists it as "Absent")
- **Almendro** (EN+ES): Clarified protection decrees — 25700-MINAE (1997) + 35340-MINAET (2008 full ban)
- **Almendro** (EN+ES): Fixed iNaturalist URLs from `Dipteryx-oleifera` (490687) to `Dipteryx-panamensis` (498908)
- **Almendro** (ES): Corrected elevation from 0-1200m to 0-800m
- **Mango** (EN+ES): Fixed iNaturalist taxon ID from 75011 to 48872
- **Buttress roots glossary** (EN+ES): Corrected false claim that Almendro is "Costa Rica's tallest tree" — Ceiba (60-70m) exceeds Almendro (40-50m)
- **messages/es.json**: Aligned footer/about descriptions from "iniciativa educativa" to "proyecto mantenido de forma privada" to match EN

### LOW
- **Cocobolo** (EN+ES): Added missing `toxicParts: ["wood-dust"]` frontmatter field

## Testing
- `npm run build` passes cleanly (no new errors or warnings)
- Both EN and ES locales verified
- All modified frontmatter validated by Contentlayer during build