### PR TITLE
fix: restore QuickSearch search session import

### DIFF
--- a/src/components/QuickSearch.tsx
+++ b/src/components/QuickSearch.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 import { useLocale, useTranslations } from "next-intl";
 import { ComponentErrorBoundary } from "./ComponentErrorBoundary";
 import { useDebounce } from "@/hooks/useDebounce";
+import { getSearchSessionId } from "@/lib/analytics/search-session";
 import { getLocaleSearchIndex } from "@/lib/query-contracts";
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add the missing `getSearchSessionId` import in `QuickSearch`
- restore the search analytics payload construction used by the modal search
- unblock the Vercel TypeScript build failure reported for `QuickSearch.tsx`

## Verification
- npx tsc --noEmit --pretty false
- npm run build *(the original `getSearchSessionId` error is resolved; local build then hits unrelated Google Fonts fetch failures in this environment)*