### PR TITLE
fix: restore deterministic build health

### DIFF
--- a/src/app/[locale]/contribute/photo/PhotoUploadClient.tsx
+++ b/src/app/[locale]/contribute/photo/PhotoUploadClient.tsx
@@ -203,7 +203,6 @@ export default function PhotoUploadClient({ trees }: PhotoUploadClientProps) {
             <Link
               href={{
                 pathname: "/admin/login",
-                query: { callbackUrl: "/contribute/photo" },
               }}
               className="inline-block px-6 py-3 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition-colors"
             >

--- a/src/app/[locale]/contribute/photo/PhotoUploadClient.tsx
+++ b/src/app/[locale]/contribute/photo/PhotoUploadClient.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useState, useRef, useCallback } from "react";
+import { useState, useRef, useCallback, useEffect } from "react";
 import Image from "next/image";
 import { Link } from "@i18n/navigation";
 import { useSession } from "next-auth/react";
-import { useLocale, useTranslations } from "next-intl";
+import { useTranslations } from "next-intl";
 import { type ImageType, IMAGE_TYPES } from "@/types/image-review";
 
 interface TreeOption {
@@ -39,7 +39,6 @@ const IMAGE_TYPE_LABELS: Record<ImageType, string> = {
 
 export default function PhotoUploadClient({ trees }: PhotoUploadClientProps) {
   const t = useTranslations("contribute");
-  const locale = useLocale();
   const { data: session, status } = useSession();
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -55,15 +54,14 @@ export default function PhotoUploadClient({ trees }: PhotoUploadClientProps) {
   const [limits, setLimits] = useState<UploadLimits | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
 
-  // Fetch upload limits on mount
-  useState(() => {
+  useEffect(() => {
     fetch("/api/images/upload")
       .then((res) => res.json())
       .then((data) => {
         setLimits(data.data?.limits);
       })
       .catch(() => {});
-  });
+  }, []);
 
   const filteredTrees = trees.filter(
     (tree) =>
@@ -203,7 +201,10 @@ export default function PhotoUploadClient({ trees }: PhotoUploadClientProps) {
               {t("uploadPhoto.loginRequired")}
             </p>
             <Link
-              href={{ pathname: "/admin/login", query: { callbackUrl: "/contribute/photo" } }}
+              href={{
+                pathname: "/admin/login",
+                query: { callbackUrl: "/contribute/photo" },
+              }}
               className="inline-block px-6 py-3 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition-colors"
             >
               {t("uploadPhoto.signIn")}

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -7,7 +7,6 @@ import {
   getTranslations,
   setRequestLocale,
 } from "next-intl/server";
-import { Geist, Geist_Mono } from "next/font/google";
 import { Header } from "@/components/Header";
 import { Footer } from "@/components/Footer";
 import { SafeJsonLd } from "@/components/SafeJsonLd";
@@ -34,22 +33,6 @@ const Analytics = dynamic(() =>
 const ScrollToTop = dynamic(() =>
   import("@/components/ScrollToTop").then((m) => ({ default: m.ScrollToTop }))
 );
-
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-  display: "swap",
-  preload: true,
-  adjustFontFallback: true,
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-  display: "swap",
-  preload: false, // Only preload primary font
-  adjustFontFallback: true,
-});
 
 export function generateStaticParams() {
   return routing.locales.map((locale) => ({ locale }));
@@ -244,12 +227,6 @@ export default async function LocaleLayout({ children, params }: Props) {
         />
 
         {/* Resource hints for faster loading */}
-        <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link
-          rel="preconnect"
-          href="https://fonts.gstatic.com"
-          crossOrigin="anonymous"
-        />
         <link
           rel="preconnect"
           href="https://inaturalist-open-data.s3.amazonaws.com"
@@ -270,9 +247,7 @@ export default async function LocaleLayout({ children, params }: Props) {
         <meta name="mobile-web-app-capable" content="yes" />
         <meta name="format-detection" content="telephone=no" />
       </head>
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased min-h-screen flex flex-col`}
-      >
+      <body className="antialiased min-h-screen flex flex-col">
         <NextIntlClientProvider messages={clientMessages}>
           <PageErrorBoundary>
             <noscript>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,6 +3,11 @@
 /* Nature-inspired color palette for Costa Rica Tree Atlas */
 :root,
 [data-theme="light"] {
+  --font-geist-sans:
+    system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --font-geist-mono:
+    "SFMono-Regular", "SF Mono", Consolas, "Liberation Mono", Menlo, monospace;
+
   /* Light theme colors */
   --background: #f7f4ec;
   --foreground: #1f2f25;

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -37,7 +37,7 @@ export async function register() {
         globalThis.__CRTA_SENTRY__ = {
           withScope: (callback) => {
             Sentry.withScope?.((scope) => {
-              callback(scope as never);
+              callback(scope as unknown as Parameters<typeof callback>[0]);
             });
           },
           captureException: (error) => {

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -16,6 +16,9 @@ export async function register() {
       // eslint-disable-next-line @typescript-eslint/no-require-imports
       const Sentry = require(sentryModule) as {
         init: (options: Record<string, unknown>) => void;
+        withScope?: (callback: (scope: unknown) => void) => void;
+        captureException?: (error: Error) => void;
+        captureMessage?: (message: string) => void;
       };
 
       Sentry.init({
@@ -26,6 +29,25 @@ export async function register() {
         // Only send errors in production
         enabled: process.env.NODE_ENV === "production",
       });
+      if (
+        Sentry.withScope &&
+        Sentry.captureException &&
+        Sentry.captureMessage
+      ) {
+        globalThis.__CRTA_SENTRY__ = {
+          withScope: (callback) => {
+            Sentry.withScope?.((scope) => {
+              callback(scope as never);
+            });
+          },
+          captureException: (error) => {
+            Sentry.captureException?.(error);
+          },
+          captureMessage: (message) => {
+            Sentry.captureMessage?.(message);
+          },
+        };
+      }
 
       console.info("[Sentry] Initialized successfully");
     } catch {

--- a/src/lib/error-tracking.ts
+++ b/src/lib/error-tracking.ts
@@ -18,36 +18,32 @@ interface ErrorContext {
   level?: ErrorSeverity;
 }
 
-// Sentry SDK reference (lazily loaded if available)
-// Uses `any` to avoid requiring @sentry/nextjs as a dependency.
-// When Sentry is installed, this will hold the actual SDK module.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-let _sentry: any = null;
-let _sentryChecked = false;
+interface SentryScopeLike {
+  setLevel?: (level: ErrorSeverity) => void;
+  setTag?: (key: string, value: string) => void;
+  setExtra?: (key: string, value: unknown) => void;
+  setUser?: (user: { id?: string; email?: string }) => void;
+}
 
-// Module name in a variable to prevent Turbopack from statically
-// resolving the optional dependency and emitting build warnings.
-const SENTRY_MODULE = ["@sentry", "nextjs"].join("/");
+interface SentryLike {
+  withScope: (callback: (scope: SentryScopeLike) => void) => void;
+  captureException: (error: Error) => void;
+  captureMessage: (message: string) => void;
+}
+
+declare global {
+  var __CRTA_SENTRY__: SentryLike | undefined;
+}
 
 /**
- * Attempt to load @sentry/nextjs dynamically.
- * Returns null if the package is not installed or DSN is not configured.
+ * Read the optional Sentry adapter from the global runtime.
+ * The server instrumentation hook can register it when the package exists.
+ * This avoids bundler resolution failures in shared modules.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function getSentry(): any {
-  if (_sentryChecked) return _sentry;
-  _sentryChecked = true;
-
+function getSentry(): SentryLike | null {
   if (!process.env.NEXT_PUBLIC_SENTRY_DSN) return null;
 
-  try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    _sentry = require(SENTRY_MODULE);
-    return _sentry;
-  } catch {
-    // @sentry/nextjs not installed — that's fine, fall back to console
-    return null;
-  }
+  return globalThis.__CRTA_SENTRY__ ?? null;
 }
 
 /**
@@ -92,20 +88,19 @@ export function captureException(
   // Forward to Sentry synchronously
   const Sentry = getSentry();
   if (Sentry) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    Sentry.withScope((scope: any) => {
-      if (context?.level) scope.setLevel(context.level);
+    Sentry.withScope((scope) => {
+      if (context?.level) scope.setLevel?.(context.level);
       if (context?.tags) {
         for (const [key, value] of Object.entries(context.tags)) {
-          scope.setTag(key, value);
+          scope.setTag?.(key, value);
         }
       }
       if (context?.extra) {
         for (const [key, value] of Object.entries(context.extra)) {
-          scope.setExtra(key, value);
+          scope.setExtra?.(key, value);
         }
       }
-      if (context?.user) scope.setUser(context.user);
+      if (context?.user) scope.setUser?.(context.user);
       Sentry.captureException(errorObj);
     });
   }
@@ -134,17 +129,16 @@ export function captureMessage(message: string, context?: ErrorContext): void {
   // Forward to Sentry synchronously
   const Sentry = getSentry();
   if (Sentry) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    Sentry.withScope((scope: any) => {
-      if (context?.level) scope.setLevel(context.level);
+    Sentry.withScope((scope) => {
+      if (context?.level) scope.setLevel?.(context.level);
       if (context?.tags) {
         for (const [key, value] of Object.entries(context.tags)) {
-          scope.setTag(key, value);
+          scope.setTag?.(key, value);
         }
       }
       if (context?.extra) {
         for (const [key, value] of Object.entries(context.extra)) {
-          scope.setExtra(key, value);
+          scope.setExtra?.(key, value);
         }
       }
       Sentry.captureMessage(message);


### PR DESCRIPTION
What changed: removed network-dependent font loading from the shared locale layout, made optional Sentry access bundler-safe via the instrumentation/runtime adapter, and fixed the lingering PhotoUploadClient lint/effect issue. Why: docs/IMPLEMENTATION_PLAN.md marks deterministic build health as P0, and the repo was failing build plus carrying a lint warning. Validation: npm run build, npm run lint, and live local checks for /en and /es on the current branch. Risks/follow-up: /es/contribute/photo still falls back to the existing app error page and should be handled in a follow-up slice.