### PR TITLE
fix: localize tree conservation summaries

### DIFF
--- a/src/app/[locale]/trees/[slug]/page.tsx
+++ b/src/app/[locale]/trees/[slug]/page.tsx
@@ -148,13 +148,21 @@ export default async function TreePage({ params }: Props) {
 
   const baseUrl = "https://costaricatreeatlas.com";
   const pageUrl = `${baseUrl}/${locale}/trees/${slug}`;
-  const localizedConservationStatus = tree.conservationStatus
-    ? `${tree.conservationStatus} — ${getConservationLabel(
-        tree.conservationStatus as ConservationCategory,
-        locale
-      )}`
-    : null;
+  let localizedConservationStatus: string | null = null;
+  if (tree.conservationStatus) {
+    const rawStatus = tree.conservationStatus;
+    let label: string | null = null;
 
+    try {
+      label = getConservationLabel(rawStatus as ConservationCategory, locale);
+    } catch {
+      label = null;
+    }
+
+    localizedConservationStatus = label
+      ? `${rawStatus} — ${label}`
+      : String(rawStatus);
+  }
   // Build images array for structured data
   const structuredImages: string[] = [];
   if (tree.featuredImage) {

--- a/src/app/[locale]/trees/[slug]/page.tsx
+++ b/src/app/[locale]/trees/[slug]/page.tsx
@@ -148,6 +148,12 @@ export default async function TreePage({ params }: Props) {
 
   const baseUrl = "https://costaricatreeatlas.com";
   const pageUrl = `${baseUrl}/${locale}/trees/${slug}`;
+  const localizedConservationStatus = tree.conservationStatus
+    ? `${tree.conservationStatus} — ${getConservationLabel(
+        tree.conservationStatus as ConservationCategory,
+        locale
+      )}`
+    : null;
 
   // Build images array for structured data
   const structuredImages: string[] = [];
@@ -321,9 +327,9 @@ export default async function TreePage({ params }: Props) {
                   <span className="px-3 py-1 bg-primary/10 text-primary rounded-full text-sm font-medium">
                     {tree.family}
                   </span>
-                  {tree.conservationStatus && (
+                  {localizedConservationStatus && (
                     <span className="px-3 py-1 bg-secondary/10 text-secondary rounded-full text-sm font-medium">
-                      {tree.conservationStatus}
+                      {localizedConservationStatus}
                     </span>
                   )}
                 </div>
@@ -427,12 +433,12 @@ export default async function TreePage({ params }: Props) {
                   </p>
                   <p className="font-medium">{tree.family}</p>
                 </div>
-                {tree.conservationStatus && (
+                {localizedConservationStatus && (
                   <div className="bg-muted rounded-lg p-4">
                     <p className="text-sm text-muted-foreground mb-1">
                       {locale === "es" ? "Conservación" : "Conservation"}
                     </p>
-                    <p className="font-medium">{tree.conservationStatus}</p>
+                    <p className="font-medium">{localizedConservationStatus}</p>
                   </div>
                 )}
               </div>


### PR DESCRIPTION
What changed: tree detail pages now show localized conservation labels alongside the IUCN code in the header chip and quick-facts panel. Why: the implementation plan called out raw status codes like LC and EN as too opaque for general users, and the repository already had a shared getConservationLabel helper ready to use. Validation: npm run build, npm run lint, and localized rendering verified for /en/trees/ceiba and /es/trees/ceiba. Risks/follow-up: the broader Spanish surface-parity audit is still open, especially around external resource modules and other remaining English strings on tree detail pages.