### PR TITLE
fix: localize shared mdx chrome

### DIFF
--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -17,7 +17,7 @@ However, the repository is not currently in a world-class operating state. As of
 - the first implementation slice shipped the footer legal-link fix, compare share-link fix, compare title fix, shared control-label localization, and the `PhotoUploadClient` effect/lint cleanup
 - `npm run build` is still **not considered green** for plan purposes because P0 build hardening remains open, especially self-hosted font work
 - audited browser sessions still show **runtime console errors/warnings** on core routes
-- Spanish UI parity is improved, but not yet complete across all high-traffic surfaces
+- Spanish UI parity is improved, including MDX-rendered tree/glossary chrome, but not yet complete across all high-traffic surfaces
 - factual remediation work remains materially unfinished
 
 ### Recent implementation progress
@@ -35,6 +35,7 @@ Completed on 2026-03-12 in the follow-up implementation slices:
 
 - replaced the fragile optional error-tracking probe with a bundler-safe adapter boundary, removing the Turbopack warning triggered by `src/lib/error-tracking.ts`
 - added the actual `next/image` quality allowlist in `next.config.ts` to match the quality values already used across cards, galleries, and shared image components
+- passed the active locale into `ServerMDXContent` where it was missing and localized shared MDX chrome (`INaturalistEmbed`, `ImageCard`, `Reference`, `ReferencesSection`) so Spanish tree/glossary routes stop falling back to English wrapper text
 
 ### Major strengths
 

--- a/src/app/[locale]/glossary/[slug]/page.tsx
+++ b/src/app/[locale]/glossary/[slug]/page.tsx
@@ -145,7 +145,7 @@ export default async function GlossaryTermPage({
           prose-headings:font-bold prose-h2:text-2xl prose-h3:text-xl
           prose-p:leading-relaxed prose-li:leading-relaxed"
         >
-          <ServerMDXContent source={term.body.raw} />
+          <ServerMDXContent source={term.body.raw} locale={locale} />
         </article>
 
         {/* Example Species */}

--- a/src/app/[locale]/trees/[slug]/page.tsx
+++ b/src/app/[locale]/trees/[slug]/page.tsx
@@ -506,6 +506,7 @@ export default async function TreePage({ params }: Props) {
               <div className="tree-content max-w-none">
                 <ServerMDXContent
                   source={tree.body.raw}
+                  locale={locale}
                   glossaryTerms={allGlossaryTerms.map((t) => ({
                     term: t.term,
                     slug: t.slug,

--- a/src/components/ServerMDXContent.tsx
+++ b/src/components/ServerMDXContent.tsx
@@ -29,7 +29,7 @@
 import { compileMDX } from "next-mdx-remote/rsc";
 import { mdxServerComponents } from "@/components/mdx/server-components";
 import { AccordionItem } from "@/components/mdx/client/AccordionItem";
-import { ImageCard } from "@/components/mdx/client/ImageCard";
+import { ImageCard as BaseImageCard } from "@/components/mdx/client/ImageCard";
 import { ImageGallery } from "@/components/mdx/client/ImageGallery";
 import { Tabs } from "@/components/mdx/client/Tabs";
 import { GlossaryTooltip } from "@/components/mdx/client/GlossaryTooltip";
@@ -38,6 +38,7 @@ import { SideBySideImages } from "@/components/mdx/client/SideBySideImages";
 import { FeatureAnnotation } from "@/components/mdx/client/FeatureAnnotation";
 import { AutoGlossaryLink } from "@/components/AutoGlossaryLink";
 import { TreeGallery } from "@/components/TreeGallery";
+import type { Locale } from "@/types/tree";
 
 interface GlossaryTerm {
   term: string;
@@ -122,6 +123,7 @@ export async function ServerMDXContent({
   enableGlossaryLinks = false,
 }: ServerMDXContentProps) {
   const isDevelopment = process.env.NODE_ENV === "development";
+  const resolvedLocale = locale as Locale;
 
   // Create locale-aware wrappers for legacy components that need localization
   // These components are imported from server-components and have a locale prop
@@ -145,7 +147,28 @@ export async function ServerMDXContent({
     ) =>
       mdxServerComponents.CareCalendar({
         ...props,
-        locale: locale as "en" | "es",
+        locale: resolvedLocale,
+      }),
+    INaturalistEmbed: (
+      props: React.ComponentProps<typeof mdxServerComponents.INaturalistEmbed>
+    ) =>
+      mdxServerComponents.INaturalistEmbed({
+        ...props,
+        locale: resolvedLocale,
+      }),
+    Reference: (
+      props: React.ComponentProps<typeof mdxServerComponents.Reference>
+    ) =>
+      mdxServerComponents.Reference({
+        ...props,
+        locale: resolvedLocale,
+      }),
+    ReferencesSection: (
+      props: React.ComponentProps<typeof mdxServerComponents.ReferencesSection>
+    ) =>
+      mdxServerComponents.ReferencesSection({
+        ...props,
+        locale: resolvedLocale,
       }),
   };
 
@@ -155,7 +178,9 @@ export async function ServerMDXContent({
     ...mdxServerComponents,
     ...localizedComponents,
     AccordionItem,
-    ImageCard,
+    ImageCard: (props: React.ComponentProps<typeof BaseImageCard>) => (
+      <BaseImageCard {...props} locale={resolvedLocale} />
+    ),
     ImageGallery,
     Tabs,
     GlossaryTooltip,

--- a/src/components/mdx/client/ImageCard.tsx
+++ b/src/components/mdx/client/ImageCard.tsx
@@ -10,6 +10,7 @@ export interface ImageCardProps {
   credit?: string;
   license?: string;
   sourceUrl?: string;
+  locale?: "en" | "es";
   slug?: string;
   index?: number;
   onClick?: () => void;
@@ -22,11 +23,13 @@ export function ImageCard({
   credit,
   license,
   sourceUrl,
+  locale = "en",
   slug: _slug,
   index: _index,
   onClick,
 }: ImageCardProps) {
   const isRemote = src.startsWith("http");
+  const sourceLabel = locale === "es" ? "Ver fuente ↗" : "View source ↗";
 
   const imageArea = (
     <div className="aspect-[4/3] bg-muted relative">
@@ -90,7 +93,7 @@ export function ImageCard({
             rel="noopener noreferrer"
             className="text-xs text-primary hover:underline mt-1 inline-block"
           >
-            View source ↗
+            {sourceLabel}
           </a>
         )}
       </figcaption>

--- a/src/components/mdx/server-components.tsx
+++ b/src/components/mdx/server-components.tsx
@@ -28,6 +28,17 @@ const translations = {
       populationTrend: "Population trend",
       threats: "Threats",
     },
+    mdxChrome: {
+      iNaturalistTitle: "iNaturalist Observations",
+      iNaturalistDescription: "Community-powered species data",
+      observations: "Observations",
+      observers: "Observers",
+      viewSpeciesPage: "View Species Page ↗",
+      browsePhotos: "Browse Photos ↗",
+      costaRicaOnly: "🇨🇷 Costa Rica Only ↗",
+      referenceLink: "[Link ↗]",
+      referencesHeading: "📚 Scientific References & Further Reading",
+    },
   },
   es: {
     safety: {
@@ -44,6 +55,17 @@ const translations = {
       assessed: "Evaluado",
       populationTrend: "Tendencia poblacional",
       threats: "Amenazas",
+    },
+    mdxChrome: {
+      iNaturalistTitle: "Observaciones de iNaturalist",
+      iNaturalistDescription: "Datos de especies impulsados por la comunidad",
+      observations: "Observaciones",
+      observers: "Observadores",
+      viewSpeciesPage: "Ver página de la especie ↗",
+      browsePhotos: "Explorar fotos ↗",
+      costaRicaOnly: "🇨🇷 Solo Costa Rica ↗",
+      referenceLink: "[Enlace ↗]",
+      referencesHeading: "📚 Referencias científicas y lecturas adicionales",
     },
   },
 } as const;
@@ -773,12 +795,17 @@ interface INaturalistEmbedProps {
   taxonId: string;
   taxonName: string;
   observationCount?: number;
+  locale?: Locale;
 }
 
 export function INaturalistEmbed({
   taxonId,
   observationCount,
+  locale = "en",
 }: INaturalistEmbedProps) {
+  // eslint-disable-next-line security/detect-object-injection -- `locale` is constrained to supported locales.
+  const t = translations[locale].mdxChrome;
+
   return (
     <div className="bg-gradient-to-br from-[#74AC00]/10 to-[#74AC00]/5 rounded-xl p-6 my-6 border border-[#74AC00]/20 not-prose">
       <div className="flex items-center gap-3 mb-4">
@@ -787,10 +814,10 @@ export function INaturalistEmbed({
         </div>
         <div>
           <h4 className="font-semibold text-foreground">
-            iNaturalist Observations
+            {t.iNaturalistTitle}
           </h4>
           <p className="text-sm text-muted-foreground">
-            Community-powered species data
+            {t.iNaturalistDescription}
           </p>
         </div>
       </div>
@@ -800,11 +827,11 @@ export function INaturalistEmbed({
           <p className="text-2xl font-bold text-[#74AC00]">
             {observationCount || "290+"}
           </p>
-          <p className="text-xs text-muted-foreground">Observations</p>
+          <p className="text-xs text-muted-foreground">{t.observations}</p>
         </div>
         <div className="bg-card rounded-lg p-3 text-center">
           <p className="text-2xl font-bold text-[#74AC00]">186</p>
-          <p className="text-xs text-muted-foreground">Observers</p>
+          <p className="text-xs text-muted-foreground">{t.observers}</p>
         </div>
       </div>
 
@@ -815,7 +842,7 @@ export function INaturalistEmbed({
           rel="noopener noreferrer"
           className="inline-flex items-center gap-2 px-3 py-2 bg-[#74AC00] text-white rounded-lg text-sm font-medium hover:bg-[#5a8a00] transition-colors"
         >
-          View Species Page ↗
+          {t.viewSpeciesPage}
         </a>
         <a
           href={`https://www.inaturalist.org/observations?taxon_id=${taxonId}`}
@@ -823,7 +850,7 @@ export function INaturalistEmbed({
           rel="noopener noreferrer"
           className="inline-flex items-center gap-2 px-3 py-2 bg-card border border-[#74AC00]/30 text-foreground rounded-lg text-sm font-medium hover:border-[#74AC00] transition-colors"
         >
-          Browse Photos ↗
+          {t.browsePhotos}
         </a>
         <a
           href={`https://www.inaturalist.org/observations?taxon_id=${taxonId}&place_id=6924`}
@@ -831,7 +858,7 @@ export function INaturalistEmbed({
           rel="noopener noreferrer"
           className="inline-flex items-center gap-2 px-3 py-2 bg-card border border-[#74AC00]/30 text-foreground rounded-lg text-sm font-medium hover:border-[#74AC00] transition-colors"
         >
-          🇨🇷 Costa Rica Only ↗
+          {t.costaRicaOnly}
         </a>
       </div>
     </div>
@@ -846,6 +873,7 @@ interface ReferenceProps {
   journal?: string;
   doi?: string;
   url?: string;
+  locale?: Locale;
 }
 
 export function Reference({
@@ -855,8 +883,11 @@ export function Reference({
   journal,
   doi,
   url,
+  locale = "en",
 }: ReferenceProps) {
   const link = doi ? `https://doi.org/${doi}` : url;
+  // eslint-disable-next-line security/detect-object-injection -- `locale` is constrained to supported locales.
+  const t = translations[locale].mdxChrome;
 
   return (
     <div className="border-l-2 border-primary/30 pl-4 py-2 my-3 not-prose">
@@ -872,7 +903,7 @@ export function Reference({
             rel="noopener noreferrer"
             className="ml-2 text-primary hover:underline text-xs"
           >
-            [Link ↗]
+            {t.referenceLink}
           </a>
         )}
       </p>
@@ -881,11 +912,20 @@ export function Reference({
 }
 
 // References Section
-export function ReferencesSection({ children }: { children: React.ReactNode }) {
+export function ReferencesSection({
+  children,
+  locale = "en",
+}: {
+  children: React.ReactNode;
+  locale?: Locale;
+}) {
+  // eslint-disable-next-line security/detect-object-injection -- `locale` is constrained to supported locales.
+  const t = translations[locale].mdxChrome;
+
   return (
     <div className="bg-muted/50 rounded-xl p-6 my-6 not-prose">
       <h4 className="font-semibold text-lg mb-4 text-primary-dark dark:text-primary-light">
-        📚 Scientific References & Further Reading
+        {t.referencesHeading}
       </h4>
       {children}
     </div>

--- a/src/components/mdx/server-components.tsx
+++ b/src/components/mdx/server-components.tsx
@@ -886,8 +886,10 @@ export function Reference({
   locale = "en",
 }: ReferenceProps) {
   const link = doi ? `https://doi.org/${doi}` : url;
-  // eslint-disable-next-line security/detect-object-injection -- `locale` is constrained to supported locales.
-  const t = translations[locale].mdxChrome;
+  const normalizedLocale: keyof typeof translations =
+    locale && locale in translations ? (locale as keyof typeof translations) : "en";
+  // eslint-disable-next-line security/detect-object-injection -- `normalizedLocale` is constrained to supported locales.
+  const t = translations[normalizedLocale].mdxChrome;
 
   return (
     <div className="border-l-2 border-primary/30 pl-4 py-2 my-3 not-prose">

--- a/src/components/mdx/server-components.tsx
+++ b/src/components/mdx/server-components.tsx
@@ -803,8 +803,8 @@ export function INaturalistEmbed({
   observationCount,
   locale = "en",
 }: INaturalistEmbedProps) {
-  // eslint-disable-next-line security/detect-object-injection -- `locale` is constrained to supported locales.
-  const t = translations[locale].mdxChrome;
+  const normalizedLocale = locale === "es" ? "es" : "en";
+  const t = translations[normalizedLocale].mdxChrome;
 
   return (
     <div className="bg-gradient-to-br from-[#74AC00]/10 to-[#74AC00]/5 rounded-xl p-6 my-6 border border-[#74AC00]/20 not-prose">


### PR DESCRIPTION
What changed: passed the active locale into ServerMDXContent where it was missing, localized shared MDX wrapper chrome (iNaturalist embed, image source links, reference link labels, and references section headings), and updated the implementation plan to reflect the new parity progress. Why: docs/IMPLEMENTATION_PLAN.md still called out mixed-language strings on high-traffic Spanish tree-detail surfaces, and repository inspection showed src/app/[locale]/trees/[slug]/page.tsx and src/app/[locale]/glossary/[slug]/page.tsx were rendering MDX without a locale while shared MDX chrome components still hardcoded English labels. Evidence: production verification on /es/trees/ceiba now shows 'Observaciones de iNaturalist', 'Ver página de la especie ↗', 'Ver fuente ↗', and 'Referencias científicas y lecturas adicionales', while /en/trees/ceiba retains the English equivalents. Validation: npm run build, npm run lint, production route verification on /en/trees/ceiba, /es/trees/ceiba, /en/glossary/abscission, and /es/glossary/abscission via a local next start instance on port 3002. Risks/follow-up: several Spanish content strings still live directly in MDX content or route-specific components (for example some external-resource descriptions), and the next highest-value slice is still P3 semantic cleanup for nested main landmarks and multi-h1 detail pages.