### PR TITLE
fix: remove nested main landmarks

### DIFF
--- a/src/app/[locale]/api-docs/page.tsx
+++ b/src/app/[locale]/api-docs/page.tsx
@@ -43,7 +43,7 @@ export default async function APIDocsPage({ params }: PageProps) {
   const t = await getTranslations({ locale, namespace: "api" });
 
   return (
-    <main className="min-h-screen bg-gray-50 dark:bg-gray-900">
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
       <div className="mx-auto max-w-5xl px-4 py-12 sm:px-6 lg:px-8">
         {/* Header */}
         <div className="mb-12 text-center">
@@ -57,6 +57,6 @@ export default async function APIDocsPage({ params }: PageProps) {
 
         <APIDocumentation locale={locale} />
       </div>
-    </main>
+    </div>
   );
 }

--- a/src/app/[locale]/compare/page.tsx
+++ b/src/app/[locale]/compare/page.tsx
@@ -134,7 +134,7 @@ function ComparePageClient({
   };
 
   return (
-    <main className="container mx-auto px-4 py-8">
+    <div className="container mx-auto px-4 py-8">
       {/* Page Header */}
       <div className="mb-12">
         <h1 className="text-3xl md:text-4xl font-bold text-primary-dark dark:text-primary-light mb-2">
@@ -333,6 +333,6 @@ function ComparePageClient({
           translations={translations}
         />
       </section>
-    </main>
+    </div>
   );
 }

--- a/src/app/[locale]/conservation/page.tsx
+++ b/src/app/[locale]/conservation/page.tsx
@@ -128,7 +128,7 @@ export default async function ConservationPage({
   return (
     <>
       <SafeJsonLd data={structuredData} />
-      <main className="container mx-auto px-4 py-8 max-w-6xl">
+      <div className="container mx-auto px-4 py-8 max-w-6xl">
         <div className="mb-8">
           <h1 className="text-3xl font-bold text-foreground mb-2">
             {locale === "es"
@@ -303,7 +303,7 @@ export default async function ConservationPage({
             </div>
           </div>
         </section>
-      </main>
+      </div>
     </>
   );
 }

--- a/src/app/[locale]/contribute/page.tsx
+++ b/src/app/[locale]/contribute/page.tsx
@@ -39,7 +39,7 @@ export default async function ContributePage({
     .sort((a, b) => a.title.localeCompare(b.title));
 
   return (
-    <main className="container mx-auto px-4 py-8">
+    <div className="container mx-auto px-4 py-8">
       <div className="max-w-4xl mx-auto">
         {/* Header */}
         <div className="text-center mb-12">
@@ -149,6 +149,6 @@ export default async function ContributePage({
           }}
         />
       </div>
-    </main>
+    </div>
   );
 }

--- a/src/app/[locale]/oral-histories/[slug]/page.tsx
+++ b/src/app/[locale]/oral-histories/[slug]/page.tsx
@@ -96,7 +96,7 @@ export default async function OralHistoryDetailPage({ params }: Props) {
     .filter((tr: Tree | undefined): tr is Tree => tr !== undefined);
 
   return (
-    <main className="container mx-auto px-4 py-8 max-w-3xl">
+    <div className="container mx-auto px-4 py-8 max-w-3xl">
       <div className="mb-6">
         <Breadcrumbs
           locale={locale as Locale}
@@ -180,6 +180,6 @@ export default async function OralHistoryDetailPage({ params }: Props) {
           </Link>
         </div>
       </article>
-    </main>
+    </div>
   );
 }

--- a/src/app/[locale]/oral-histories/page.tsx
+++ b/src/app/[locale]/oral-histories/page.tsx
@@ -73,7 +73,7 @@ export default async function OralHistoriesPage({
   const trees: Tree[] = allTrees.filter((tr: Tree) => tr.locale === locale);
 
   return (
-    <main className="container mx-auto px-4 py-8 max-w-4xl">
+    <div className="container mx-auto px-4 py-8 max-w-4xl">
       <div className="mb-6">
         <Breadcrumbs
           locale={locale}
@@ -178,6 +178,6 @@ export default async function OralHistoriesPage({
           })}
         </div>
       )}
-    </main>
+    </div>
   );
 }

--- a/src/app/[locale]/seasonal/page.tsx
+++ b/src/app/[locale]/seasonal/page.tsx
@@ -221,7 +221,7 @@ export default async function SeasonalPage({
   return (
     <>
       <SafeJsonLd data={structuredData} />
-      <main className="container mx-auto px-4 py-8 max-w-6xl">
+      <div className="container mx-auto px-4 py-8 max-w-6xl">
         <div className="mb-8">
           <h1 className="text-3xl font-bold text-foreground mb-2">
             {t("pageTitle")}
@@ -318,7 +318,7 @@ export default async function SeasonalPage({
             </div>
           </div>
         </section>
-      </main>
+      </div>
     </>
   );
 }


### PR DESCRIPTION
## Summary
- replace redundant page-level `<main>` wrappers on public locale routes with `<div>` containers
- rely on the existing layout-level `<main id="main-content">` landmark so each page exposes a single main region
- keep page structure, headings, and localized content unchanged while improving landmark semantics

## Validation
- npm run build
- npm run lint
- verified production renders on port 3003 for `/en|es/compare`, `/en|es/conservation`, `/en|es/seasonal`, `/en|es/contribute`, `/en|es/oral-histories`, `/en|es/oral-histories/ceiba-world-tree`, and `/en|es/api-docs`