### PR TITLE
fix: align manifest icon metadata

### DIFF
--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -1,7 +1,7 @@
 # Costa Rica Tree Atlas - Implementation Plan
 
-**Last Updated:** 2026-03-12  
-**Status:** Audit-driven v2.1 — first quick-win implementation slice is shipped, but P0 build hardening, deeper semantic cleanup, locale-surface parity, and factual-governance work still need focused follow-through.
+**Last Updated:** 2026-03-13  
+**Status:** Audit-driven v2.1 — early quick-win implementation slices are shipping, but P0 build hardening, deeper semantic cleanup, locale-surface parity, and factual-governance work still need focused follow-through.
 
 ---
 
@@ -35,6 +35,7 @@ Completed on 2026-03-12 in the follow-up implementation slices:
 
 - replaced the fragile optional error-tracking probe with a bundler-safe adapter boundary, removing the Turbopack warning triggered by `src/lib/error-tracking.ts`
 - added the actual `next/image` quality allowlist in `next.config.ts` to match the quality values already used across cards, galleries, and shared image components
+- corrected `public/manifest.json` so each declared PWA icon size matches the actual on-disk PNG dimensions, removing the misleading manifest metadata that triggered browser warnings
 - passed the active locale into `ServerMDXContent` where it was missing and localized shared MDX chrome (`INaturalistEmbed`, `ImageCard`, `Reference`, `ReferencesSection`) so Spanish tree/glossary routes stop falling back to English wrapper text
 
 ### Major strengths
@@ -215,7 +216,7 @@ Items deliverable in 1 day or less:
 
 ### Still remaining quick wins
 
-8. Regenerate or correct manifest icon dimensions to match declared sizes.
+8. ✅ Correct manifest icon dimensions to match the actual asset sizes served in `public/icons/`.
 9. Replace raw `LC` / `EN` / etc. display in quick facts with localized human labels plus code.
 
 ---
@@ -387,6 +388,7 @@ Items deliverable in 1 day or less:
 - Follow-up implementation slices completed on:
   - `fix/sentry-adapter-boundary` with updates to `src/lib/error-tracking.ts` and `src/instrumentation.ts`
   - `fix/next-image-qualities` with updates to `next.config.ts`
+  - `fix/pwa-icon-manifest-sizes` with updates to `public/manifest.json`
 - Browser-verified routes included:
   - `/en`
   - `/en/trees`

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -213,11 +213,11 @@ Items deliverable in 1 day or less:
 5. ✅ Remove the unused `locale` variable in `PhotoUploadClient` and clear the known lint warning.
 6. ✅ Move upload-limit fetching in `PhotoUploadClient` from a `useState` initializer into `useEffect`.
 7. ✅ Add/normalize supported `next/image` quality values in `next.config.ts`.
+8. ✅ Correct manifest icon dimensions to match the actual asset sizes served in `public/icons/`.
 
 ### Still remaining quick wins
 
-8. ✅ Correct manifest icon dimensions to match the actual asset sizes served in `public/icons/`.
-9. Replace raw `LC` / `EN` / etc. display in quick facts with localized human labels plus code.
+1. Replace raw `LC` / `EN` / etc. display in quick facts with localized human labels plus code.
 
 ---
 

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -11,49 +11,49 @@
   "lang": "en",
   "icons": [
     {
-      "src": "/icons/icon-72x72.png",
+      "src": "/icons/icon-68x72.png",
       "sizes": "68x72",
       "type": "image/png",
       "purpose": "any maskable"
     },
     {
-      "src": "/icons/icon-96x96.png",
+      "src": "/icons/icon-91x96.png",
       "sizes": "91x96",
       "type": "image/png",
       "purpose": "any maskable"
     },
     {
-      "src": "/icons/icon-128x128.png",
+      "src": "/icons/icon-122x128.png",
       "sizes": "122x128",
       "type": "image/png",
       "purpose": "any maskable"
     },
     {
-      "src": "/icons/icon-144x144.png",
+      "src": "/icons/icon-137x144.png",
       "sizes": "137x144",
       "type": "image/png",
       "purpose": "any maskable"
     },
     {
-      "src": "/icons/icon-152x152.png",
+      "src": "/icons/icon-145x152.png",
       "sizes": "145x152",
       "type": "image/png",
       "purpose": "any maskable"
     },
     {
-      "src": "/icons/icon-192x192.png",
+      "src": "/icons/icon-183x192.png",
       "sizes": "183x192",
       "type": "image/png",
       "purpose": "any maskable"
     },
     {
-      "src": "/icons/icon-384x384.png",
+      "src": "/icons/icon-367x384.png",
       "sizes": "367x384",
       "type": "image/png",
       "purpose": "any maskable"
     },
     {
-      "src": "/icons/icon-512x512.png",
+      "src": "/icons/icon-489x512.png",
       "sizes": "489x512",
       "type": "image/png",
       "purpose": "any maskable"

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -12,49 +12,49 @@
   "icons": [
     {
       "src": "/icons/icon-72x72.png",
-      "sizes": "72x72",
+      "sizes": "68x72",
       "type": "image/png",
       "purpose": "any maskable"
     },
     {
       "src": "/icons/icon-96x96.png",
-      "sizes": "96x96",
+      "sizes": "91x96",
       "type": "image/png",
       "purpose": "any maskable"
     },
     {
       "src": "/icons/icon-128x128.png",
-      "sizes": "128x128",
+      "sizes": "122x128",
       "type": "image/png",
       "purpose": "any maskable"
     },
     {
       "src": "/icons/icon-144x144.png",
-      "sizes": "144x144",
+      "sizes": "137x144",
       "type": "image/png",
       "purpose": "any maskable"
     },
     {
       "src": "/icons/icon-152x152.png",
-      "sizes": "152x152",
+      "sizes": "145x152",
       "type": "image/png",
       "purpose": "any maskable"
     },
     {
       "src": "/icons/icon-192x192.png",
-      "sizes": "192x192",
+      "sizes": "183x192",
       "type": "image/png",
       "purpose": "any maskable"
     },
     {
       "src": "/icons/icon-384x384.png",
-      "sizes": "384x384",
+      "sizes": "367x384",
       "type": "image/png",
       "purpose": "any maskable"
     },
     {
       "src": "/icons/icon-512x512.png",
-      "sizes": "512x512",
+      "sizes": "489x512",
       "type": "image/png",
       "purpose": "any maskable"
     }

--- a/src/components/mdx/server-components.tsx
+++ b/src/components/mdx/server-components.tsx
@@ -887,12 +887,7 @@ export function Reference({
   locale = "en",
 }: ReferenceProps) {
   const link = doi ? `https://doi.org/${doi}` : url;
-  const normalizedLocale: keyof typeof translations =
-    locale && locale in translations
-      ? (locale as keyof typeof translations)
-      : "en";
-  // eslint-disable-next-line security/detect-object-injection -- `normalizedLocale` is constrained to supported locales.
-  const t = translations[normalizedLocale].mdxChrome;
+  const t = translations[locale].mdxChrome;
 
   return (
     <div className="border-l-2 border-primary/30 pl-4 py-2 my-3 not-prose">

--- a/src/components/mdx/server-components.tsx
+++ b/src/components/mdx/server-components.tsx
@@ -804,6 +804,7 @@ export function INaturalistEmbed({
   locale = "en",
 }: INaturalistEmbedProps) {
   const normalizedLocale = locale === "es" ? "es" : "en";
+  // eslint-disable-next-line security/detect-object-injection -- `normalizedLocale` is constrained to the supported locales above.
   const t = translations[normalizedLocale].mdxChrome;
 
   return (
@@ -887,7 +888,9 @@ export function Reference({
 }: ReferenceProps) {
   const link = doi ? `https://doi.org/${doi}` : url;
   const normalizedLocale: keyof typeof translations =
-    locale && locale in translations ? (locale as keyof typeof translations) : "en";
+    locale && locale in translations
+      ? (locale as keyof typeof translations)
+      : "en";
   // eslint-disable-next-line security/detect-object-injection -- `normalizedLocale` is constrained to supported locales.
   const t = translations[normalizedLocale].mdxChrome;
 


### PR DESCRIPTION
## Summary
- update `public/manifest.json` so each icon entry declares the actual PNG dimensions being served
- document the shipped PWA icon metadata slice in `docs/IMPLEMENTATION_PLAN.md`
- restore a clean lint baseline with a narrow false-positive suppression for a locale-constrained MDX translation lookup

## Validation
- npm run build
- npm run lint
- verified the served `/manifest.json` reports the corrected icon sizes on port 3004