### PR TITLE
fix: enforce single h1 by shifting MDX headings down one semantic level

### DIFF
--- a/src/components/mdx/server-components.tsx
+++ b/src/components/mdx/server-components.tsx
@@ -920,7 +920,9 @@ export function ReferencesSection({
   locale?: Locale;
 }) {
   const normalizedLocale: keyof typeof translations =
-    locale && Object.hasOwn(translations, locale) ? (locale as keyof typeof translations) : "en";
+    locale && Object.hasOwn(translations, locale)
+      ? (locale as keyof typeof translations)
+      : "en";
   // eslint-disable-next-line security/detect-object-injection -- `normalizedLocale` is constrained to supported locales.
   const t = translations[normalizedLocale].mdxChrome;
 
@@ -1213,22 +1215,16 @@ export function SimpleList({ items, ordered = false }: SimpleListProps) {
 
 // Native HTML Element Components for beautiful typography
 
-// Styled h1-h6 components for MDX
+// Styled heading components for MDX content.
+// MDX headings are shifted down one semantic level so that `#` in MDX renders
+// as `<h2>`, `##` as `<h3>`, etc.  This enforces the single-`<h1>` rule —
+// the page template owns the sole `<h1>` (tree/comparison/glossary title)
+// while MDX body sections start at `<h2>`.  Visual sizing is preserved so the
+// rendered appearance stays the same as before the semantic correction.
 function H1({ children, ...props }: React.HTMLAttributes<HTMLHeadingElement>) {
   return (
-    <h1
-      className="text-3xl md:text-4xl font-bold text-primary-dark dark:text-primary-light mt-10 mb-6 pb-3 border-b-2 border-primary/20"
-      {...props}
-    >
-      {children}
-    </h1>
-  );
-}
-
-function H2({ children, ...props }: React.HTMLAttributes<HTMLHeadingElement>) {
-  return (
     <h2
-      className="text-2xl md:text-3xl font-bold text-primary-dark dark:text-primary-light mt-10 mb-5 pb-2 border-b border-border"
+      className="text-3xl md:text-4xl font-bold text-primary-dark dark:text-primary-light mt-10 mb-6 pb-3 border-b-2 border-primary/20"
       {...props}
     >
       {children}
@@ -1236,10 +1232,10 @@ function H2({ children, ...props }: React.HTMLAttributes<HTMLHeadingElement>) {
   );
 }
 
-function H3({ children, ...props }: React.HTMLAttributes<HTMLHeadingElement>) {
+function H2({ children, ...props }: React.HTMLAttributes<HTMLHeadingElement>) {
   return (
     <h3
-      className="text-xl md:text-2xl font-semibold text-primary-dark dark:text-primary-light mt-8 mb-4"
+      className="text-2xl md:text-3xl font-bold text-primary-dark dark:text-primary-light mt-10 mb-5 pb-2 border-b border-border"
       {...props}
     >
       {children}
@@ -1247,10 +1243,10 @@ function H3({ children, ...props }: React.HTMLAttributes<HTMLHeadingElement>) {
   );
 }
 
-function H4({ children, ...props }: React.HTMLAttributes<HTMLHeadingElement>) {
+function H3({ children, ...props }: React.HTMLAttributes<HTMLHeadingElement>) {
   return (
     <h4
-      className="text-lg md:text-xl font-semibold text-foreground mt-6 mb-3"
+      className="text-xl md:text-2xl font-semibold text-primary-dark dark:text-primary-light mt-8 mb-4"
       {...props}
     >
       {children}
@@ -1258,14 +1254,25 @@ function H4({ children, ...props }: React.HTMLAttributes<HTMLHeadingElement>) {
   );
 }
 
-function H5({ children, ...props }: React.HTMLAttributes<HTMLHeadingElement>) {
+function H4({ children, ...props }: React.HTMLAttributes<HTMLHeadingElement>) {
   return (
     <h5
-      className="text-base md:text-lg font-semibold text-foreground mt-5 mb-2"
+      className="text-lg md:text-xl font-semibold text-foreground mt-6 mb-3"
       {...props}
     >
       {children}
     </h5>
+  );
+}
+
+function H5({ children, ...props }: React.HTMLAttributes<HTMLHeadingElement>) {
+  return (
+    <h6
+      className="text-base md:text-lg font-semibold text-foreground mt-5 mb-2"
+      {...props}
+    >
+      {children}
+    </h6>
   );
 }
 


### PR DESCRIPTION
## What changed
MDX heading components in `src/components/mdx/server-components.tsx` now render one semantic level lower: `#` → `<h2>`, `##` → `<h3>`, etc. Visual styling (font sizes, spacing, borders) is preserved — only the HTML element changes.

## Why
Tree detail, comparison detail, and glossary detail page templates each render a `<h1>` for the page title. MDX body content also used `#` headings that rendered as `<h1>`, producing duplicate `<h1>` elements — a P3 accessibility and SEO finding in `docs/IMPLEMENTATION_PLAN.md`.

## Evidence
- `grep` confirms 174 tree MDX files, 20 comparison MDX files, and 3 glossary MDX files use `#` (h1) headings
- Page templates in `src/app/[locale]/trees/[slug]/page.tsx`, `compare/[slug]/page.tsx`, and `glossary/[slug]/page.tsx` each have their own `<h1>`
- The `TableOfContents` component queries `h2[id], h3[id]` from the DOM — the shifted headings are still correctly picked up

## Validation
- `npx tsc --noEmit`: passes (0 errors)
- `npm run lint`: passes (0 errors, 1 pre-existing warning)
- Heading shift applies equally to EN and ES MDX content
- Visual appearance unchanged — only semantic element corrected

## Risks / follow-up
- None expected: visual styles are unchanged, TOC selector matches the new heading levels
- H5 and H6 both render as `<h6>` at the bottom of the cascade — acceptable since MDX content rarely uses 5+ heading levels