### PR TITLE
fix: localize comparison detail and trees listing page strings

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -163,7 +163,9 @@
     "loadSavedFilters": "Load Saved",
     "filtersSaved": "Filters saved",
     "filtersLoaded": "Saved filters loaded",
-    "noSavedFilters": "No saved filters"
+    "noSavedFilters": "No saved filters",
+    "structuredDataName": "Costa Rica Tree Directory",
+    "structuredDataDescription": "A comprehensive collection of native Costa Rican trees"
   },
   "footer": {
     "description": "A privately maintained project dedicated to documenting the trees of Costa Rica.",
@@ -382,6 +384,17 @@
     "toolSubtitle": "Or compare any trees side-by-side using our interactive tool",
     "compareWith": "Compare with",
     "backToComparisons": "Back to Comparisons",
+    "print": "Print",
+    "printAriaLabel": "Print this page",
+    "exploreMore": "Want to explore more?",
+    "exploreMoreDescription": "Use our interactive tool to compare these species side by side.",
+    "compareInteractive": "Compare in interactive tool",
+    "comparedSpecies": "Compared Species",
+    "quickSummary": "Quick Summary",
+    "difficultyLabel": "Difficulty",
+    "difficultyEasy": "Easy",
+    "difficultyModerate": "Moderate",
+    "difficultyChallenging": "Challenging",
     "properties": {
       "image": "Image",
       "commonName": "Common Name",

--- a/messages/es.json
+++ b/messages/es.json
@@ -163,7 +163,9 @@
     "loadSavedFilters": "Cargar Guardados",
     "filtersSaved": "Filtros guardados",
     "filtersLoaded": "Filtros guardados cargados",
-    "noSavedFilters": "No hay filtros guardados"
+    "noSavedFilters": "No hay filtros guardados",
+    "structuredDataName": "Directorio de Árboles de Costa Rica",
+    "structuredDataDescription": "Una colección completa de árboles nativos de Costa Rica"
   },
   "footer": {
     "description": "Un proyecto mantenido de forma privada dedicado a documentar los árboles de Costa Rica.",
@@ -382,6 +384,17 @@
     "toolSubtitle": "O compara cualquier árbol lado a lado usando nuestra herramienta interactiva",
     "compareWith": "Comparar con",
     "backToComparisons": "Volver a Comparaciones",
+    "print": "Imprimir",
+    "printAriaLabel": "Imprimir esta página",
+    "exploreMore": "¿Quieres explorar más?",
+    "exploreMoreDescription": "Usa nuestra herramienta interactiva para comparar estas especies lado a lado.",
+    "compareInteractive": "Comparar en herramienta interactiva",
+    "comparedSpecies": "Especies Comparadas",
+    "quickSummary": "Resumen Rápido",
+    "difficultyLabel": "Dificultad",
+    "difficultyEasy": "Fácil",
+    "difficultyModerate": "Moderado",
+    "difficultyChallenging": "Desafiante",
     "properties": {
       "image": "Imagen",
       "commonName": "Nombre Común",

--- a/src/app/[locale]/compare/[slug]/page.tsx
+++ b/src/app/[locale]/compare/[slug]/page.tsx
@@ -199,12 +199,8 @@ export default async function ComparisonPage({ params }: Props) {
                     path={`/compare/${comparison.slug}`}
                   />
                   <PrintButton
-                    label={locale === "es" ? "Imprimir" : "Print"}
-                    ariaLabel={
-                      locale === "es"
-                        ? "Imprimir esta página"
-                        : "Print this page"
-                    }
+                    label={t("print")}
+                    ariaLabel={t("printAriaLabel")}
                   />
                 </div>
               </div>
@@ -261,15 +257,9 @@ export default async function ComparisonPage({ params }: Props) {
 
             {/* Interactive Tool CTA */}
             <div className="bg-gradient-to-br from-primary/10 to-secondary/10 rounded-2xl p-6 md:p-8 text-center border border-primary/20 mb-8">
-              <h3 className="text-xl font-bold mb-2">
-                {locale === "es"
-                  ? "¿Quieres explorar más?"
-                  : "Want to explore more?"}
-              </h3>
+              <h3 className="text-xl font-bold mb-2">{t("exploreMore")}</h3>
               <p className="text-muted-foreground mb-4">
-                {locale === "es"
-                  ? "Usa nuestra herramienta interactiva para comparar estas especies lado a lado."
-                  : "Use our interactive tool to compare these species side by side."}
+                {t("exploreMoreDescription")}
               </p>
               <Link
                 href={buildCompareToolHref(comparison.species)}
@@ -287,9 +277,7 @@ export default async function ComparisonPage({ params }: Props) {
                   <rect x="3" y="14" width="7" height="7" />
                   <rect x="14" y="14" width="7" height="7" />
                 </svg>
-                {locale === "es"
-                  ? "Comparar en herramienta interactiva"
-                  : "Compare in interactive tool"}
+                {t("compareInteractive")}
                 <svg
                   className="w-4 h-4"
                   viewBox="0 0 24 24"
@@ -332,7 +320,7 @@ export default async function ComparisonPage({ params }: Props) {
               {/* Species Quick Links */}
               <div className="bg-card border border-border rounded-xl p-5">
                 <h3 className="font-bold text-sm uppercase tracking-wide text-muted-foreground mb-4">
-                  {locale === "es" ? "Especies Comparadas" : "Compared Species"}
+                  {t("comparedSpecies")}
                 </h3>
                 <div className="space-y-3">
                   {speciesTrees.map((tree) => (
@@ -375,7 +363,7 @@ export default async function ComparisonPage({ params }: Props) {
               {/* Quick Summary Card */}
               <div className="bg-gradient-to-br from-primary/5 to-secondary/5 border border-border rounded-xl p-5">
                 <h3 className="font-bold text-sm uppercase tracking-wide text-primary mb-3">
-                  {locale === "es" ? "Resumen Rápido" : "Quick Summary"}
+                  {t("quickSummary")}
                 </h3>
                 <p className="text-sm text-muted-foreground leading-relaxed">
                   {comparison.description}
@@ -386,7 +374,7 @@ export default async function ComparisonPage({ params }: Props) {
               {comparison.difficulty && (
                 <div className="bg-card border border-border rounded-xl p-5">
                   <h3 className="font-bold text-sm uppercase tracking-wide text-muted-foreground mb-3">
-                    {locale === "es" ? "Dificultad" : "Difficulty"}
+                    {t("difficultyLabel")}
                   </h3>
                   <div
                     className={`inline-flex items-center gap-2 px-3 py-2 rounded-lg font-medium text-sm ${
@@ -405,14 +393,11 @@ export default async function ComparisonPage({ params }: Props) {
                           : "🔴"}
                     </span>
                     <span className="capitalize">
-                      {locale === "es"
-                        ? comparison.difficulty === "easy"
-                          ? "Fácil"
-                          : comparison.difficulty === "moderate"
-                            ? "Moderado"
-                            : "Desafiante"
-                        : comparison.difficulty.charAt(0).toUpperCase() +
-                          comparison.difficulty.slice(1)}
+                      {comparison.difficulty === "easy"
+                        ? t("difficultyEasy")
+                        : comparison.difficulty === "moderate"
+                          ? t("difficultyModerate")
+                          : t("difficultyChallenging")}
                     </span>
                   </div>
                 </div>

--- a/src/app/[locale]/trees/page.tsx
+++ b/src/app/[locale]/trees/page.tsx
@@ -59,6 +59,8 @@ export default async function TreesPage({ params }: Props) {
   const { locale } = await params;
   setRequestLocale(locale);
 
+  const t = await getTranslations({ locale, namespace: "trees" });
+
   // Get trees for current locale, sorted alphabetically for consistent first image
   const fullTrees = getTreesForLocale(locale);
 
@@ -71,14 +73,8 @@ export default async function TreesPage({ params }: Props) {
   const structuredData = {
     "@context": "https://schema.org",
     "@type": "ItemList",
-    name:
-      locale === "es"
-        ? "Directorio de Árboles de Costa Rica"
-        : "Costa Rica Tree Directory",
-    description:
-      locale === "es"
-        ? "Una colección completa de árboles nativos de Costa Rica"
-        : "A comprehensive collection of native Costa Rican trees",
+    name: t("structuredDataName"),
+    description: t("structuredDataDescription"),
     numberOfItems: trees.length,
     itemListElement: trees.slice(0, 50).map((tree, index) => ({
       "@type": "ListItem",
@@ -98,9 +94,7 @@ export default async function TreesPage({ params }: Props) {
       <TreeExplorer trees={trees} />
       <noscript>
         <div className="container mx-auto px-4 py-8">
-          <h1 className="text-3xl font-bold mb-6">
-            {locale === "es" ? "Directorio de Árboles" : "Tree Directory"}
-          </h1>
+          <h1 className="text-3xl font-bold mb-6">{t("title")}</h1>
           <ul className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
             {trees.map((tree) => (
               <li key={tree.slug}>


### PR DESCRIPTION
## Summary

Localize inline `locale === "es"` ternaries in the comparison detail page and trees listing page, continuing P2 from `docs/IMPLEMENTATION_PLAN.md`.

## Changes

### Comparison detail page (`src/app/[locale]/compare/[slug]/page.tsx`)
- Replaced 10 inline locale ternaries with `t()` calls from the existing `comparison` namespace
- Added 11 new keys: `print`, `printAriaLabel`, `exploreMore`, `exploreMoreDescription`, `compareInteractive`, `comparedSpecies`, `quickSummary`, `difficultyLabel`, `difficultyEasy`, `difficultyModerate`, `difficultyChallenging`
- Only remaining ternary is the OG locale code mapping (`es_CR`/`en_US`) — non-UI technical mapping

### Trees listing page (`src/app/[locale]/trees/page.tsx`)
- Added `getTranslations` call in `TreesPage` function
- Replaced 3 inline locale ternaries:
  - Structured data `name` and `description` → new keys `structuredDataName`, `structuredDataDescription`
  - Noscript `<h1>` heading → reuses existing `trees.title` key

### Translation files
- `messages/en.json`: 13 new keys across `comparison` and `trees` namespaces
- `messages/es.json`: 13 new keys matching EN parity

## Validation
- `npx tsc --noEmit` — 0 errors
- `npm run lint` — 0 errors (1 pre-existing warning)
- EN/ES key parity verified for both `comparison` and `trees` namespaces

## Priority
P2 from `docs/IMPLEMENTATION_PLAN.md` — Complete EN/ES surface-parity hardening