### PR TITLE
fix: resolve type errors in compare and conservation pages

### DIFF
--- a/src/app/[locale]/compare/page.tsx
+++ b/src/app/[locale]/compare/page.tsx
@@ -133,6 +133,8 @@ function ComparePageClient({
     },
   };
 
+  const safeLocale: Locale = locale === "es" ? "es" : "en";
+
   return (
     <div className="container mx-auto px-4 py-8">
       {/* Page Header */}
@@ -329,7 +331,7 @@ function ComparePageClient({
 
         <TreeComparison
           trees={trees}
-          locale={locale as Locale}
+          locale={safeLocale}
           translations={translations}
         />
       </section>

--- a/src/app/[locale]/compare/page.tsx
+++ b/src/app/[locale]/compare/page.tsx
@@ -329,7 +329,7 @@ function ComparePageClient({
 
         <TreeComparison
           trees={trees}
-          locale={locale}
+          locale={locale as Locale}
           translations={translations}
         />
       </section>

--- a/src/app/[locale]/conservation/page.tsx
+++ b/src/app/[locale]/conservation/page.tsx
@@ -261,24 +261,35 @@ export default async function ConservationPage({
                   <div className="text-sm text-muted-foreground italic">
                     {tree.scientificName}
                   </div>
-                  {tree.conservationStatus && (
-                    <span
-                      className={`inline-block mt-2 px-2 py-1 rounded text-xs font-semibold ${
-                        STATUS_COLORS[
-                          tree.conservationStatus as ConservationStatus
-                        ]
-                      }`}
-                    >
-                      {tree.conservationStatus}
-                      {" — "}
-                      {statusLabels[
-                        tree.conservationStatus as ConservationStatus
-                      ]?.[locale] ??
-                        (locale === "es"
+                  {tree.conservationStatus &&
+                    (() => {
+                      const status = tree.conservationStatus;
+                      const isKnownStatus = Object.hasOwn(
+                        STATUS_COLORS,
+                        status as ConservationCategory,
+                      );
+                      const colorClass = isKnownStatus
+                        ? STATUS_COLORS[status as ConservationStatus]
+                        : "bg-muted text-foreground";
+                      const localizedLabel =
+                        isKnownStatus
+                          ? statusLabels[status as ConservationStatus]?.[locale]
+                          : undefined;
+                      const fallbackLabel =
+                        locale === "es"
                           ? "Estado de conservación desconocido"
-                          : "Unknown conservation status")}
-                    </span>
-                  )}
+                          : "Unknown conservation status";
+
+                      return (
+                        <span
+                          className={`inline-block mt-2 px-2 py-1 rounded text-xs font-semibold ${colorClass}`}
+                        >
+                          {status}
+                          {" — "}
+                          {localizedLabel ?? fallbackLabel}
+                        </span>
+                      );
+                    })()}
                 </Link>
               ))}
             </div>

--- a/src/app/[locale]/conservation/page.tsx
+++ b/src/app/[locale]/conservation/page.tsx
@@ -271,7 +271,9 @@ export default async function ConservationPage({
                     >
                       {tree.conservationStatus}
                       {" — "}
-                      {statusLabels[locale]?.[tree.conservationStatus] ??
+                      {statusLabels[
+                        tree.conservationStatus as ConservationStatus
+                      ]?.[locale] ??
                         (locale === "es"
                           ? "Estado de conservación desconocido"
                           : "Unknown conservation status")}


### PR DESCRIPTION
## Summary

Fixes 2 type errors that break `npm run type-check`:

1. **compare/page.tsx:332** — `locale` is typed as `string` (from `Params`) but `TreeComparison` expects `Locale`. Fixed with `locale as Locale` cast.
2. **conservation/page.tsx:274** — `statusLabels[locale]?.[tree.conservationStatus]` had inverted index order. `statusLabels` is `Record<ConservationStatus, { en; es }>`, so the correct access is `statusLabels[status]?.[locale]`.

## Validation

- `npx tsc --noEmit` — clean (0 errors)