### PR TITLE
fix(i18n): localize education hub page with next-intl

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -450,6 +450,11 @@
     "browseTrees": "Browse Tree Directory"
   },
   "education": {
+    "metaTitle": "Educational Resources - Costa Rica Tree Atlas",
+    "metaDescription": "Lesson plans, classroom activities, and educational materials about Costa Rica trees for teachers and students.",
+    "structuredDescription": "Lesson plans, classroom activities, and educational materials about Costa Rica trees.",
+    "courseName": "Learning About Costa Rica Trees",
+    "courseDescription": "Free educational resources to learn about Costa Rican tree flora.",
     "title": "Educational Resources",
     "subtitle": "Free lesson plans, activities, and materials for teaching about Costa Rica's trees and forest ecosystems",
     "stats": {
@@ -1429,6 +1434,7 @@
     "nativeRegion": "Region",
     "confirmClearAll": "Clear all data?",
     "noTreesFound": "No trees found"
+  },
   "mapGame": {
     "metaTitle": "Map Game - Costa Rica Tree Atlas",
     "metaDescription": "Learn where Costa Rica's trees grow in this interactive game.",

--- a/messages/es.json
+++ b/messages/es.json
@@ -450,6 +450,11 @@
     "browseTrees": "Explorar Directorio de Árboles"
   },
   "education": {
+    "metaTitle": "Recursos Educativos - Atlas de Árboles de Costa Rica",
+    "metaDescription": "Planes de lecciones, actividades de aula y materiales educativos sobre los árboles de Costa Rica para maestros y estudiantes.",
+    "structuredDescription": "Planes de lecciones, actividades de aula y materiales educativos sobre los árboles de Costa Rica.",
+    "courseName": "Aprendiendo sobre Árboles de Costa Rica",
+    "courseDescription": "Recursos educativos gratuitos para aprender sobre la flora arbórea costarricense.",
     "title": "Recursos Educativos",
     "subtitle": "Planes de lecciones, actividades y materiales gratuitos para enseñar sobre los árboles y ecosistemas forestales de Costa Rica",
     "stats": {
@@ -1429,6 +1434,7 @@
     "nativeRegion": "Región",
     "confirmClearAll": "¿Borrar todos los datos?",
     "noTreesFound": "No se encontraron árboles"
+  },
   "mapGame": {
     "metaTitle": "Juego del Mapa - Atlas de Árboles de Costa Rica",
     "metaDescription": "Aprende dónde crecen los árboles de Costa Rica en este juego interactivo.",

--- a/src/app/[locale]/education/page.tsx
+++ b/src/app/[locale]/education/page.tsx
@@ -1,5 +1,5 @@
 import { useTranslations } from "next-intl";
-import { setRequestLocale } from "next-intl/server";
+import { setRequestLocale, getTranslations } from "next-intl/server";
 import { Link } from "@i18n/navigation";
 import { SafeJsonLd } from "@/components/SafeJsonLd";
 import type { Metadata } from "next";
@@ -11,16 +11,11 @@ type Props = {
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "education" });
 
   return {
-    title:
-      locale === "es"
-        ? "Recursos Educativos - Atlas de Árboles de Costa Rica"
-        : "Educational Resources - Costa Rica Tree Atlas",
-    description:
-      locale === "es"
-        ? "Planes de lecciones, actividades de aula y materiales educativos sobre los árboles de Costa Rica para maestros y estudiantes."
-        : "Lesson plans, classroom activities, and educational materials about Costa Rica trees for teachers and students.",
+    title: t("metaTitle"),
+    description: t("metaDescription"),
     alternates: {
       languages: {
         en: "/en/education",
@@ -35,31 +30,21 @@ export default async function EducationPage({ params }: Props) {
   setRequestLocale(locale);
 
   // Get tree count for stats
-  const treeCount = allTrees.filter((t) => t.locale === locale).length;
+  const treeCount = allTrees.filter((tr) => tr.locale === locale).length;
+
+  const t = await getTranslations({ locale, namespace: "education" });
 
   // Structured data for Education page
   const structuredData = {
     "@context": "https://schema.org",
     "@type": "WebPage",
-    name:
-      locale === "es"
-        ? "Recursos Educativos - Atlas de Árboles de Costa Rica"
-        : "Educational Resources - Costa Rica Tree Atlas",
-    description:
-      locale === "es"
-        ? "Planes de lecciones, actividades de aula y materiales educativos sobre los árboles de Costa Rica."
-        : "Lesson plans, classroom activities, and educational materials about Costa Rica trees.",
+    name: t("metaTitle"),
+    description: t("structuredDescription"),
     url: `https://costaricatreeatlas.com/${locale}/education`,
     mainEntity: {
       "@type": "Course",
-      name:
-        locale === "es"
-          ? "Aprendiendo sobre Árboles de Costa Rica"
-          : "Learning About Costa Rica Trees",
-      description:
-        locale === "es"
-          ? "Recursos educativos gratuitos para aprender sobre la flora arbórea costarricense."
-          : "Free educational resources to learn about Costa Rican tree flora.",
+      name: t("courseName"),
+      description: t("courseDescription"),
       provider: {
         "@type": "Organization",
         name: "Costa Rica Tree Atlas",
@@ -71,7 +56,7 @@ export default async function EducationPage({ params }: Props) {
         educationalRole: "teacher",
       },
       educationalLevel: "K-12",
-      inLanguage: locale === "es" ? "es" : "en",
+      inLanguage: locale,
     },
   };
 


### PR DESCRIPTION
## Summary
Localize the education hub page metadata and structured data using next-intl, eliminating all 7 inline locale ternaries.

## Changes
- Add 5 metadata/structured-data keys (`metaTitle`, `metaDescription`, `structuredDescription`, `courseName`, `courseDescription`) to the existing `education` namespace in both message files
- Use `getTranslations` for metadata and structured data in page.tsx
- Replace 7 inline `locale === "es"` ternaries with translation function calls
- Simplify `inLanguage` to use `locale` directly instead of ternary
- Fix variable shadowing (`t` → `tr`) in tree filter callback
- Fix pre-existing missing comma before `mapGame` namespace

## Validation
- ✅ JSON valid (both locales)
- ✅ 0 remaining `locale === "es"` ternaries
- ✅ `npx tsc --noEmit` clean

## P2 Localization Series
Part of systematic P2 localization effort. Previous PRs: #601–#625.