### PR TITLE
fix(i18n): localize seasonal page with next-intl

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -608,7 +608,12 @@
     "showEvents": "Show events",
     "hideEvents": "Hide events",
     "floweringNow": "Trees flowering now",
-    "fruitingNow": "Trees fruiting now"
+    "fruitingNow": "Trees fruiting now",
+    "monthDescription": "Discover which Costa Rican trees are flowering and fruiting in {monthName}.",
+    "structuredName": "Seasonal Tree Calendar",
+    "structuredDescription": "Discover when Costa Rica's trees flower and fruit",
+    "treesActiveThisMonth": "Trees active this month",
+    "treeFlowering": "{treeName} is flowering"
   },
   "safety": {
     "title": "Safety Information",
@@ -1429,6 +1434,7 @@
     "nativeRegion": "Region",
     "confirmClearAll": "Clear all data?",
     "noTreesFound": "No trees found"
+  },
   "mapGame": {
     "metaTitle": "Map Game - Costa Rica Tree Atlas",
     "metaDescription": "Learn where Costa Rica's trees grow in this interactive game.",

--- a/messages/es.json
+++ b/messages/es.json
@@ -608,7 +608,12 @@
     "showEvents": "Mostrar eventos",
     "hideEvents": "Ocultar eventos",
     "floweringNow": "Árboles floreciendo ahora",
-    "fruitingNow": "Árboles fructificando ahora"
+    "fruitingNow": "Árboles fructificando ahora",
+    "monthDescription": "Descubre qué árboles de Costa Rica están floreciendo y fructificando en {monthName}.",
+    "structuredName": "Calendario Estacional de Árboles",
+    "structuredDescription": "Descubre cuándo florecen y fructifican los árboles de Costa Rica",
+    "treesActiveThisMonth": "Árboles activos este mes",
+    "treeFlowering": "{treeName} está floreciendo"
   },
   "safety": {
     "title": "Información de Seguridad",
@@ -1429,6 +1434,7 @@
     "nativeRegion": "Región",
     "confirmClearAll": "¿Borrar todos los datos?",
     "noTreesFound": "No se encontraron árboles"
+  },
   "mapGame": {
     "metaTitle": "Juego del Mapa - Atlas de Árboles de Costa Rica",
     "metaDescription": "Aprende dónde crecen los árboles de Costa Rica en este juego interactivo.",

--- a/src/app/[locale]/seasonal/page.tsx
+++ b/src/app/[locale]/seasonal/page.tsx
@@ -102,10 +102,7 @@ export async function generateMetadata({
 
     return {
       title: `${monthName} - ${t("title")}`,
-      description:
-        locale === "es"
-          ? `Descubre qué árboles de Costa Rica están floreciendo y fructificando en ${monthName}.`
-          : `Discover which Costa Rican trees are flowering and fruiting in ${monthName}.`,
+      description: t("monthDescription", { monthName }),
       alternates: {
         canonical: `/${locale}/seasonal?month=${month}`,
         languages: {
@@ -179,20 +176,11 @@ export default async function SeasonalPage({
   const structuredData = {
     "@context": "https://schema.org",
     "@type": "WebPage",
-    name:
-      locale === "es"
-        ? "Calendario Estacional de Árboles"
-        : "Seasonal Tree Calendar",
-    description:
-      locale === "es"
-        ? "Descubre cuándo florecen y fructifican los árboles de Costa Rica"
-        : "Discover when Costa Rica's trees flower and fruit",
+    name: t("structuredName"),
+    description: t("structuredDescription"),
     mainEntity: {
       "@type": "ItemList",
-      name:
-        locale === "es"
-          ? "Árboles activos este mes"
-          : "Trees active this month",
+      name: t("treesActiveThisMonth"),
       numberOfItems:
         treesFloweringNow.length + treesFruitingNow.length + eventItems.length,
       itemListElement: [
@@ -202,10 +190,7 @@ export default async function SeasonalPage({
           item: {
             "@type": "Thing",
             name: tree.title,
-            description:
-              locale === "es"
-                ? `${tree.title} está floreciendo`
-                : `${tree.title} is flowering`,
+            description: t("treeFlowering", { treeName: tree.title }),
             url: `https://costaricatreeatlas.com/${locale}/trees/${tree.slug}`,
           },
         })),


### PR DESCRIPTION
## Summary
Replace 5 inline `locale === "es"` ternaries in the seasonal calendar page with proper next-intl translation keys.

## Changes
- **seasonal/page.tsx**: Replace 5 ternaries with `t()` calls
  - Month-specific metadata description → `t("monthDescription", { monthName })`
  - Structured data name → `t("structuredName")`
  - Structured data description → `t("structuredDescription")`
  - Main entity name → `t("treesActiveThisMonth")`
  - Tree flowering description → `t("treeFlowering", { treeName })`
- **messages/en.json** + **messages/es.json**: Add 5 keys to existing `seasonal` namespace; fix pre-existing missing comma before `mapGame`

## Verification
- ✅ JSON valid
- ✅ 0 remaining ternaries
- ✅ tsc clean