### PR TITLE
fix(i18n): localize about page with next-intl

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -338,7 +338,12 @@
     "license": {
       "title": "Licensing",
       "description": "Costa Rica Tree Atlas is privately owned. Code, content, and data are all rights reserved and governed by the repository legal documents."
-    }
+    },
+    "metaTitle": "About Us",
+    "metaDescription": "Learn more about Costa Rica Tree Atlas, an educational initiative dedicated to documenting Costa Rican trees.",
+    "structuredName": "About Costa Rica Tree Atlas",
+    "structuredDescription": "An educational initiative dedicated to documenting Costa Rican trees.",
+    "structuredOrgDescription": "A community-powered bilingual guide to Costa Rica's trees."
   },
   "favorites": {
     "addToFavorites": "Add to favorites",
@@ -1429,6 +1434,7 @@
     "nativeRegion": "Region",
     "confirmClearAll": "Clear all data?",
     "noTreesFound": "No trees found"
+  },
   "mapGame": {
     "metaTitle": "Map Game - Costa Rica Tree Atlas",
     "metaDescription": "Learn where Costa Rica's trees grow in this interactive game.",

--- a/messages/es.json
+++ b/messages/es.json
@@ -338,7 +338,12 @@
     "license": {
       "title": "Licenciamiento",
       "description": "El Atlas de Árboles de Costa Rica es de propiedad privada. El código, contenido y datos están reservados y se rigen por los documentos legales del repositorio."
-    }
+    },
+    "metaTitle": "Sobre Nosotros",
+    "metaDescription": "Conoce más sobre el Atlas de Árboles de Costa Rica, una iniciativa educativa dedicada a documentar la flora arbórea costarricense.",
+    "structuredName": "Sobre el Atlas de Árboles de Costa Rica",
+    "structuredDescription": "Una iniciativa educativa dedicada a documentar la flora arbórea costarricense.",
+    "structuredOrgDescription": "Una guía bilingüe impulsada por la comunidad para los árboles de Costa Rica."
   },
   "favorites": {
     "addToFavorites": "Añadir a favoritos",
@@ -1429,6 +1434,7 @@
     "nativeRegion": "Región",
     "confirmClearAll": "¿Borrar todos los datos?",
     "noTreesFound": "No se encontraron árboles"
+  },
   "mapGame": {
     "metaTitle": "Juego del Mapa - Atlas de Árboles de Costa Rica",
     "metaDescription": "Aprende dónde crecen los árboles de Costa Rica en este juego interactivo.",

--- a/src/app/[locale]/about/page.tsx
+++ b/src/app/[locale]/about/page.tsx
@@ -1,5 +1,5 @@
 import { useTranslations } from "next-intl";
-import { setRequestLocale } from "next-intl/server";
+import { getTranslations, setRequestLocale } from "next-intl/server";
 import { Link } from "@i18n/navigation";
 import { SafeJsonLd } from "@/components/SafeJsonLd";
 import { DataSourceCard } from "@/components/DataSourceCard";
@@ -14,13 +14,11 @@ type Props = {
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "about" });
 
   return {
-    title: locale === "es" ? "Sobre Nosotros" : "About Us",
-    description:
-      locale === "es"
-        ? "Conoce más sobre el Atlas de Árboles de Costa Rica, una iniciativa educativa dedicada a documentar la flora arbórea costarricense."
-        : "Learn more about Costa Rica Tree Atlas, an educational initiative dedicated to documenting Costa Rican trees.",
+    title: t("metaTitle"),
+    description: t("metaDescription"),
     alternates: {
       languages: {
         en: "/en/about",
@@ -34,28 +32,21 @@ export default async function AboutPage({ params }: Props) {
   const { locale } = await params;
   setRequestLocale(locale);
 
+  const t = await getTranslations({ locale, namespace: "about" });
+
   // Structured data for About page
   const structuredData = {
     "@context": "https://schema.org",
     "@type": "AboutPage",
-    name:
-      locale === "es"
-        ? "Sobre el Atlas de Árboles de Costa Rica"
-        : "About Costa Rica Tree Atlas",
-    description:
-      locale === "es"
-        ? "Una iniciativa educativa dedicada a documentar la flora arbórea costarricense."
-        : "An educational initiative dedicated to documenting Costa Rican trees.",
+    name: t("structuredName"),
+    description: t("structuredDescription"),
     url: `https://costaricatreeatlas.com/${locale}/about`,
     mainEntity: {
       "@type": "Organization",
       name: "Costa Rica Tree Atlas",
       url: "https://costaricatreeatlas.com",
       logo: "https://costaricatreeatlas.com/images/cr-tree-atlas-logo.png",
-      description:
-        locale === "es"
-          ? "Una guía bilingüe impulsada por la comunidad para los árboles de Costa Rica."
-          : "A community-powered bilingual guide to Costa Rica's trees.",
+      description: t("structuredOrgDescription"),
     },
   };
 


### PR DESCRIPTION
## Summary
Replace 5 inline `locale === "es"` ternaries in the about page with proper next-intl translation keys.

## Changes
- **about/page.tsx**: Replace 5 ternaries with `t()` / `getTranslations()` calls
  - 2 metadata (title, description)
  - 3 structured data (page name, page description, org description)
- **messages/en.json** + **messages/es.json**: Add 5 keys to existing `about` namespace; fix pre-existing missing comma before `mapGame`

## Verification
- ✅ JSON valid
- ✅ 0 remaining ternaries
- ✅ tsc clean