### PR TITLE
fix(i18n): localize quiz pages with next-intl

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1429,6 +1429,7 @@
     "nativeRegion": "Region",
     "confirmClearAll": "Clear all data?",
     "noTreesFound": "No trees found"
+  },
   "mapGame": {
     "metaTitle": "Map Game - Costa Rica Tree Atlas",
     "metaDescription": "Learn where Costa Rica's trees grow in this interactive game.",
@@ -1620,5 +1621,36 @@
     "printTip2": "Print in color when possible for images",
     "printTip3": "Laminate cards for field durability",
     "printTip4": "Use Ctrl/Cmd + P to open print dialog"
+  },
+  "quiz": {
+    "metaTitle": "Tree Quiz - Costa Rica Tree Atlas",
+    "metaDescription": "Test your knowledge of Costa Rican trees with our interactive quizzes.",
+    "title": "Tree Identification Quiz",
+    "subtitle": "Test your knowledge of Costa Rican trees",
+    "selectMode": "Select a Quiz Mode",
+    "photoMode": "Photo Identification",
+    "photoModeDesc": "Identify trees from their photos",
+    "safetyMode": "Safety Quiz",
+    "safetyModeDesc": "Learn about tree safety and toxicity",
+    "familyMode": "Family Recognition",
+    "familyModeDesc": "Match trees to their botanical families",
+    "startQuiz": "Start Quiz",
+    "question": "Question",
+    "of": "of",
+    "score": "Score",
+    "submit": "Submit Answer",
+    "next": "Next Question",
+    "complete": "Quiz Complete!",
+    "finalScore": "Your final score",
+    "restart": "Try Another Quiz",
+    "backToModes": "Back to Quiz Modes",
+    "whatTree": "What tree is this?",
+    "whichSafe": "Which tree is safe for children?",
+    "whichFamily": "Which tree belongs to the {family} family?",
+    "correct": "Correct!",
+    "incorrect": "Incorrect. The correct answer is:",
+    "loading": "Loading quiz...",
+    "backToTrees": "Back to Trees",
+    "exploreTrees": "Explore Trees"
   }
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -1429,6 +1429,7 @@
     "nativeRegion": "Región",
     "confirmClearAll": "¿Borrar todos los datos?",
     "noTreesFound": "No se encontraron árboles"
+  },
   "mapGame": {
     "metaTitle": "Juego del Mapa - Atlas de Árboles de Costa Rica",
     "metaDescription": "Aprende dónde crecen los árboles de Costa Rica en este juego interactivo.",
@@ -1620,5 +1621,36 @@
     "printTip2": "Imprima a color cuando sea posible para las imágenes",
     "printTip3": "Plastifique las tarjetas para mayor durabilidad en campo",
     "printTip4": "Use Ctrl/Cmd + P para abrir el diálogo de impresión"
+  },
+  "quiz": {
+    "metaTitle": "Cuestionario de Árboles - Atlas de Árboles de Costa Rica",
+    "metaDescription": "Pon a prueba tu conocimiento sobre los árboles de Costa Rica con nuestros cuestionarios interactivos.",
+    "title": "Cuestionario de Identificación de Árboles",
+    "subtitle": "Pon a prueba tu conocimiento sobre los árboles de Costa Rica",
+    "selectMode": "Selecciona un Modo de Cuestionario",
+    "photoMode": "Identificación por Foto",
+    "photoModeDesc": "Identifica árboles por sus fotos",
+    "safetyMode": "Cuestionario de Seguridad",
+    "safetyModeDesc": "Aprende sobre la seguridad y toxicidad de los árboles",
+    "familyMode": "Reconocimiento de Familias",
+    "familyModeDesc": "Relaciona los árboles con sus familias botánicas",
+    "startQuiz": "Comenzar Cuestionario",
+    "question": "Pregunta",
+    "of": "de",
+    "score": "Puntuación",
+    "submit": "Enviar Respuesta",
+    "next": "Siguiente Pregunta",
+    "complete": "¡Cuestionario Completado!",
+    "finalScore": "Tu puntuación final",
+    "restart": "Intentar Otro Cuestionario",
+    "backToModes": "Volver a Modos de Cuestionario",
+    "whatTree": "¿Qué árbol es este?",
+    "whichSafe": "¿Qué árbol es seguro para niños?",
+    "whichFamily": "¿Qué árbol pertenece a la familia {family}?",
+    "correct": "¡Correcto!",
+    "incorrect": "Incorrecto. La respuesta correcta es:",
+    "loading": "Cargando cuestionario...",
+    "backToTrees": "Volver a Árboles",
+    "exploreTrees": "Explorar Árboles"
   }
 }

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -155,6 +155,7 @@ export default async function LocaleLayout({ children, params }: Props) {
     "mapGame",
     "classroom",
     "lessonsHub",
+    "quiz",
   ] as const;
 
   type ClientNamespace = (typeof CLIENT_NAMESPACES)[number];

--- a/src/app/[locale]/quiz/QuizClient.tsx
+++ b/src/app/[locale]/quiz/QuizClient.tsx
@@ -2,6 +2,7 @@
 /* eslint-disable security/detect-object-injection -- quiz uses constrained locale/mode/index lookups over local in-memory dictionaries. */
 
 import { useState, useCallback } from "react";
+import { useTranslations } from "next-intl";
 import { Link } from "@i18n/navigation";
 import { ProgressBar } from "@/components/ProgressBar";
 import Image from "next/image";
@@ -20,7 +21,6 @@ interface Tree {
 
 interface QuizClientProps {
   trees: Tree[];
-  locale: string;
 }
 
 type QuizMode = "photo" | "safety" | "family";
@@ -32,7 +32,7 @@ interface Question {
   type: "photo" | "safety" | "family";
 }
 
-export default function QuizClient({ trees, locale }: QuizClientProps) {
+export default function QuizClient({ trees }: QuizClientProps) {
   const [mode, setMode] = useState<QuizMode | null>(null);
   const [currentQuestion, setCurrentQuestion] = useState(0);
   const [score, setScore] = useState(0);
@@ -41,66 +41,7 @@ export default function QuizClient({ trees, locale }: QuizClientProps) {
   const [showResult, setShowResult] = useState(false);
   const [quizComplete, setQuizComplete] = useState(false);
 
-  const t = (key: string): string => {
-    const translations: Record<string, Record<string, string>> = {
-      en: {
-        title: "Tree Identification Quiz",
-        subtitle: "Test your knowledge of Costa Rican trees",
-        selectMode: "Select a Quiz Mode",
-        photoMode: "Photo Identification",
-        photoModeDesc: "Identify trees from their photos",
-        safetyMode: "Safety Quiz",
-        safetyModeDesc: "Learn about tree safety and toxicity",
-        familyMode: "Family Recognition",
-        familyModeDesc: "Match trees to their botanical families",
-        startQuiz: "Start Quiz",
-        question: "Question",
-        of: "of",
-        score: "Score",
-        submit: "Submit Answer",
-        next: "Next Question",
-        complete: "Quiz Complete!",
-        finalScore: "Your final score",
-        restart: "Try Another Quiz",
-        backToModes: "Back to Quiz Modes",
-        whatTree: "What tree is this?",
-        whichSafe: "Which tree is safe for children?",
-        whichFamily: "Which tree belongs to the {family} family?",
-        correct: "Correct!",
-        incorrect: "Incorrect. The correct answer is:",
-        loading: "Loading quiz...",
-      },
-      es: {
-        title: "Cuestionario de Identificación de Árboles",
-        subtitle:
-          "Pon a prueba tu conocimiento sobre los árboles de Costa Rica",
-        selectMode: "Selecciona un Modo de Cuestionario",
-        photoMode: "Identificación por Foto",
-        photoModeDesc: "Identifica árboles por sus fotos",
-        safetyMode: "Cuestionario de Seguridad",
-        safetyModeDesc: "Aprende sobre la seguridad y toxicidad de los árboles",
-        familyMode: "Reconocimiento de Familias",
-        familyModeDesc: "Relaciona los árboles con sus familias botánicas",
-        startQuiz: "Comenzar Cuestionario",
-        question: "Pregunta",
-        of: "de",
-        score: "Puntuación",
-        submit: "Enviar Respuesta",
-        next: "Siguiente Pregunta",
-        complete: "¡Cuestionario Completado!",
-        finalScore: "Tu puntuación final",
-        restart: "Intentar Otro Cuestionario",
-        backToModes: "Volver a Modos de Cuestionario",
-        whatTree: "¿Qué árbol es este?",
-        whichSafe: "¿Qué árbol es seguro para niños?",
-        whichFamily: "¿Qué árbol pertenece a la familia {family}?",
-        correct: "¡Correcto!",
-        incorrect: "Incorrecto. La respuesta correcta es:",
-        loading: "Cargando cuestionario...",
-      },
-    };
-    return translations[locale][key] || key;
-  };
+  const t = useTranslations("quiz");
 
   const generatePhotoQuestions = useCallback(() => {
     const treesWithImages = trees.filter((t) => t.featuredImage);
@@ -306,7 +247,7 @@ export default function QuizClient({ trees, locale }: QuizClientProps) {
               href="/trees"
               className="text-primary hover:text-primary-dark underline"
             >
-              ← {locale === "es" ? "Volver a Árboles" : "Back to Trees"}
+              ← {t("backToTrees")}
             </Link>
           </div>
         </div>
@@ -343,7 +284,7 @@ export default function QuizClient({ trees, locale }: QuizClientProps) {
                 href="/trees"
                 className="block w-full px-6 py-3 border-2 border-border rounded-lg hover:border-primary transition-colors"
               >
-                {locale === "es" ? "Explorar Árboles" : "Explore Trees"}
+                {t("exploreTrees")}
               </Link>
             </div>
           </div>
@@ -405,7 +346,7 @@ export default function QuizClient({ trees, locale }: QuizClientProps) {
               {mode === "photo" && t("whatTree")}
               {mode === "safety" && t("whichSafe")}
               {mode === "family" &&
-                t("whichFamily").replace("{family}", question.tree.family)}
+                t("whichFamily", { family: question.tree.family })}
             </h2>
 
             {/* Options */}

--- a/src/app/[locale]/quiz/QuizClient.tsx
+++ b/src/app/[locale]/quiz/QuizClient.tsx
@@ -1,5 +1,4 @@
 "use client";
-/* eslint-disable security/detect-object-injection -- quiz uses constrained locale/mode/index lookups over local in-memory dictionaries. */
 
 import { useState, useCallback } from "react";
 import { useTranslations } from "next-intl";

--- a/src/app/[locale]/quiz/page.tsx
+++ b/src/app/[locale]/quiz/page.tsx
@@ -1,4 +1,4 @@
-import { setRequestLocale } from "next-intl/server";
+import { getTranslations, setRequestLocale } from "next-intl/server";
 import type { Metadata } from "next";
 import { allTrees } from "contentlayer/generated";
 import QuizClient from "./QuizClient";
@@ -9,16 +9,11 @@ type Props = {
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "quiz" });
 
   return {
-    title:
-      locale === "es"
-        ? "Cuestionario de Árboles - Atlas de Árboles de Costa Rica"
-        : "Tree Quiz - Costa Rica Tree Atlas",
-    description:
-      locale === "es"
-        ? "Pon a prueba tu conocimiento sobre los árboles de Costa Rica con nuestros cuestionarios interactivos."
-        : "Test your knowledge of Costa Rican trees with our interactive quizzes.",
+    title: t("metaTitle"),
+    description: t("metaDescription"),
     alternates: {
       languages: {
         en: "/en/quiz",
@@ -48,5 +43,5 @@ export default async function QuizPage({ params }: Props) {
       petSafe: t.petSafe,
     }));
 
-  return <QuizClient trees={trees} locale={locale} />;
+  return <QuizClient trees={trees} />;
 }


### PR DESCRIPTION
## Summary
Replace all inline locale ternaries and the full inline translations block in quiz pages with proper next-intl translations.

## Changes
- **QuizClient.tsx**: Replace 25-key inline translations object with `useTranslations("quiz")`, replace 2 remaining ternaries, switch `whichFamily` from `.replace()` to next-intl interpolation
- **quiz/page.tsx**: Replace 2 metadata ternaries with `getTranslations`, remove `locale` prop from `<QuizClient />`
- **layout.tsx**: Add `"quiz"` to `CLIENT_NAMESPACES`
- **messages/en.json** + **messages/es.json**: Add `quiz` namespace (29 keys); fix pre-existing missing comma before `mapGame`

## Verification
- ✅ JSON valid
- ✅ 0 remaining ternaries
- ✅ tsc clean