### PR TITLE
fix(i18n): localize map page with next-intl

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1429,6 +1429,13 @@
     "nativeRegion": "Region",
     "confirmClearAll": "Clear all data?",
     "noTreesFound": "No trees found"
+  },
+  "map": {
+    "metaTitle": "Explore by Region - Costa Rica Tree Atlas",
+    "metaDescription": "Explore the distribution of Costa Rican native trees by province and region. Discover the biodiversity of each area of the country.",
+    "structuredName": "Explore Costa Rica Regions",
+    "structuredDescription": "Interactive map for exploring native tree distribution by province and region in Costa Rica."
+  },
   "mapGame": {
     "metaTitle": "Map Game - Costa Rica Tree Atlas",
     "metaDescription": "Learn where Costa Rica's trees grow in this interactive game.",

--- a/messages/es.json
+++ b/messages/es.json
@@ -1429,6 +1429,13 @@
     "nativeRegion": "Región",
     "confirmClearAll": "¿Borrar todos los datos?",
     "noTreesFound": "No se encontraron árboles"
+  },
+  "map": {
+    "metaTitle": "Explorar por Región - Atlas de Árboles de Costa Rica",
+    "metaDescription": "Explora la distribución de árboles nativos de Costa Rica por provincia y región. Descubre la biodiversidad de cada zona del país.",
+    "structuredName": "Explorar Regiones de Costa Rica",
+    "structuredDescription": "Mapa interactivo para explorar la distribución de árboles nativos por provincia y región en Costa Rica."
+  },
   "mapGame": {
     "metaTitle": "Juego del Mapa - Atlas de Árboles de Costa Rica",
     "metaDescription": "Aprende dónde crecen los árboles de Costa Rica en este juego interactivo.",

--- a/src/app/[locale]/map/page.tsx
+++ b/src/app/[locale]/map/page.tsx
@@ -1,4 +1,4 @@
-import { setRequestLocale } from "next-intl/server";
+import { getTranslations, setRequestLocale } from "next-intl/server";
 import { allTrees } from "contentlayer/generated";
 import { SafeJsonLd } from "@/components/SafeJsonLd";
 import type { Metadata } from "next";
@@ -56,16 +56,11 @@ export async function generateMetadata({
   params,
 }: MapPageProps): Promise<Metadata> {
   const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "map" });
 
   return {
-    title:
-      locale === "es"
-        ? "Explorar por Región - Atlas de Árboles de Costa Rica"
-        : "Explore by Region - Costa Rica Tree Atlas",
-    description:
-      locale === "es"
-        ? "Explora la distribución de árboles nativos de Costa Rica por provincia y región. Descubre la biodiversidad de cada zona del país."
-        : "Explore the distribution of Costa Rican native trees by province and region. Discover the biodiversity of each area of the country.",
+    title: t("metaTitle"),
+    description: t("metaDescription"),
     alternates: {
       languages: {
         en: "/en/map",
@@ -78,6 +73,7 @@ export async function generateMetadata({
 export default async function MapPage({ params }: MapPageProps) {
   const { locale } = await params;
   setRequestLocale(locale);
+  const t = await getTranslations({ locale, namespace: "map" });
 
   // Project only the fields TreeMapClient needs — avoids shipping the full
   // 32 MB contentlayer dataset (MDX bodies) to the client.
@@ -94,11 +90,11 @@ export default async function MapPage({ params }: MapPageProps) {
         (d): d is Distribution => isProvince(d) || isRegion(d)
       ),
       tags: t.tags?.filter((tag): tag is TreeTag => VALID_TAGS.has(tag)),
-      floweringSeason: t.floweringSeason?.filter(
-        (m): m is Month => VALID_MONTH_STRINGS.has(m)
+      floweringSeason: t.floweringSeason?.filter((m): m is Month =>
+        VALID_MONTH_STRINGS.has(m)
       ),
-      fruitingSeason: t.fruitingSeason?.filter(
-        (m): m is Month => VALID_MONTH_STRINGS.has(m)
+      fruitingSeason: t.fruitingSeason?.filter((m): m is Month =>
+        VALID_MONTH_STRINGS.has(m)
       ),
       featuredImage: t.featuredImage,
       conservationStatus: t.conservationStatus,
@@ -109,14 +105,8 @@ export default async function MapPage({ params }: MapPageProps) {
   const structuredData = {
     "@context": "https://schema.org",
     "@type": "WebApplication",
-    name:
-      locale === "es"
-        ? "Explorar Regiones de Costa Rica"
-        : "Explore Costa Rica Regions",
-    description:
-      locale === "es"
-        ? "Mapa interactivo para explorar la distribución de árboles nativos por provincia y región en Costa Rica."
-        : "Interactive map for exploring native tree distribution by province and region in Costa Rica.",
+    name: t("structuredName"),
+    description: t("structuredDescription"),
     url: `https://costaricatreeatlas.com/${locale}/map`,
     applicationCategory: "EducationalApplication",
     operatingSystem: "All",


### PR DESCRIPTION
Closing — these changes were already merged to main via PR #632 (fix/localize-map-identify-home) which covered the map page localization.