### PR TITLE
fix(i18n): localize identify page with next-intl

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -447,7 +447,11 @@
     "maintenanceTitle": "Feature Temporarily Unavailable",
     "maintenanceMessage": "We're working on making this feature both usable and secure. The tree identification tool will be available again soon.",
     "maintenanceNote": "In the meantime, you can browse our tree directory or use the search feature to find trees manually.",
-    "browseTrees": "Browse Tree Directory"
+    "browseTrees": "Browse Tree Directory",
+    "metaTitle": "Identify Trees - Costa Rica Tree Atlas",
+    "metaDescription": "Upload a photo of a tree and use AI to identify Costa Rican tree species.",
+    "structuredName": "Costa Rica Tree Identifier",
+    "structuredDescription": "AI-powered tree identification tool."
   },
   "education": {
     "title": "Educational Resources",
@@ -1429,6 +1433,7 @@
     "nativeRegion": "Region",
     "confirmClearAll": "Clear all data?",
     "noTreesFound": "No trees found"
+  },
   "mapGame": {
     "metaTitle": "Map Game - Costa Rica Tree Atlas",
     "metaDescription": "Learn where Costa Rica's trees grow in this interactive game.",

--- a/messages/es.json
+++ b/messages/es.json
@@ -447,7 +447,11 @@
     "maintenanceTitle": "Función Temporalmente No Disponible",
     "maintenanceMessage": "Estamos trabajando para hacer esta función más usable y segura. La herramienta de identificación de árboles estará disponible de nuevo pronto.",
     "maintenanceNote": "Mientras tanto, puedes explorar nuestro directorio de árboles o usar la función de búsqueda para encontrar árboles manualmente.",
-    "browseTrees": "Explorar Directorio de Árboles"
+    "browseTrees": "Explorar Directorio de Árboles",
+    "metaTitle": "Identificar Árboles - Atlas de Árboles de Costa Rica",
+    "metaDescription": "Sube una foto de un árbol y usa inteligencia artificial para identificar especies de árboles de Costa Rica.",
+    "structuredName": "Identificador de Árboles de Costa Rica",
+    "structuredDescription": "Herramienta de identificación de árboles mediante inteligencia artificial."
   },
   "education": {
     "title": "Recursos Educativos",
@@ -1429,6 +1433,7 @@
     "nativeRegion": "Región",
     "confirmClearAll": "¿Borrar todos los datos?",
     "noTreesFound": "No se encontraron árboles"
+  },
   "mapGame": {
     "metaTitle": "Juego del Mapa - Atlas de Árboles de Costa Rica",
     "metaDescription": "Aprende dónde crecen los árboles de Costa Rica en este juego interactivo.",

--- a/src/app/[locale]/identify/page.tsx
+++ b/src/app/[locale]/identify/page.tsx
@@ -1,5 +1,9 @@
 import { NextIntlClientProvider } from "next-intl";
-import { setRequestLocale, getMessages } from "next-intl/server";
+import {
+  getTranslations,
+  setRequestLocale,
+  getMessages,
+} from "next-intl/server";
 import { SafeJsonLd } from "@/components/SafeJsonLd";
 import type { Metadata } from "next";
 import type { AbstractIntlMessages } from "next-intl";
@@ -13,16 +17,11 @@ export async function generateMetadata({
   params,
 }: IdentifyPageProps): Promise<Metadata> {
   const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "identify" });
 
   return {
-    title:
-      locale === "es"
-        ? "Identificar Árboles - Atlas de Árboles de Costa Rica"
-        : "Identify Trees - Costa Rica Tree Atlas",
-    description:
-      locale === "es"
-        ? "Sube una foto de un árbol y usa inteligencia artificial para identificar especies de árboles de Costa Rica."
-        : "Upload a photo of a tree and use AI to identify Costa Rican tree species.",
+    title: t("metaTitle"),
+    description: t("metaDescription"),
     alternates: {
       languages: {
         en: "/en/identify",
@@ -35,19 +34,14 @@ export async function generateMetadata({
 export default async function IdentifyPage({ params }: IdentifyPageProps) {
   const { locale } = await params;
   setRequestLocale(locale);
+  const t = await getTranslations({ locale, namespace: "identify" });
 
   // Structured data for Identify page
   const structuredData = {
     "@context": "https://schema.org",
     "@type": "WebApplication",
-    name:
-      locale === "es"
-        ? "Identificador de Árboles de Costa Rica"
-        : "Costa Rica Tree Identifier",
-    description:
-      locale === "es"
-        ? "Herramienta de identificación de árboles mediante inteligencia artificial."
-        : "AI-powered tree identification tool.",
+    name: t("structuredName"),
+    description: t("structuredDescription"),
     url: `https://costaricatreeatlas.com/${locale}/identify`,
     applicationCategory: "UtilitiesApplication",
     operatingSystem: "All",


### PR DESCRIPTION
Closing — these changes were already merged to main via PR #632 (fix/localize-map-identify-home) which covered the identify page localization.