### PR TITLE
fix(i18n): localize tree slug page with next-intl

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1429,6 +1429,7 @@
     "nativeRegion": "Region",
     "confirmClearAll": "Clear all data?",
     "noTreesFound": "No trees found"
+  },
   "mapGame": {
     "metaTitle": "Map Game - Costa Rica Tree Atlas",
     "metaDescription": "Learn where Costa Rica's trees grow in this interactive game.",

--- a/messages/es.json
+++ b/messages/es.json
@@ -1429,6 +1429,7 @@
     "nativeRegion": "Región",
     "confirmClearAll": "¿Borrar todos los datos?",
     "noTreesFound": "No se encontraron árboles"
+  },
   "mapGame": {
     "metaTitle": "Juego del Mapa - Atlas de Árboles de Costa Rica",
     "metaDescription": "Aprende dónde crecen los árboles de Costa Rica en este juego interactivo.",

--- a/src/app/[locale]/trees/[slug]/page.tsx
+++ b/src/app/[locale]/trees/[slug]/page.tsx
@@ -33,6 +33,8 @@ import type {
   IndigenousName,
 } from "@/types/tree";
 
+const OG_LOCALE: Record<string, string> = { en: "en_US", es: "es_CR" };
+
 // Dynamic imports for heavy below-fold components
 // DistributionMap renders static SVG from props, so SSR is beneficial for SEO
 const DistributionMap = dynamic(
@@ -112,7 +114,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       title: tree.title,
       description: tree.description,
       type: "article",
-      locale: locale === "es" ? "es_CR" : "en_US",
+      locale: OG_LOCALE[locale] || "en_US",
     },
     alternates: {
       languages: {
@@ -132,6 +134,7 @@ export default async function TreePage({ params }: Props) {
   setRequestLocale(locale);
 
   const t = await getTranslations("treeDetail");
+  const navT = await getTranslations("nav");
 
   const tree = allTrees.find((t2) => t2.locale === locale && t2.slug === slug);
 
@@ -216,7 +219,7 @@ export default async function TreePage({ params }: Props) {
       "@type": "Organization",
       name: "Costa Rica Tree Atlas",
     },
-    inLanguage: locale === "es" ? "es-CR" : "en-US",
+    inLanguage: locale,
     ...(structuredImages.length > 0 && { image: structuredImages }),
     ...(tree.publishedAt && { datePublished: tree.publishedAt }),
     ...(tree.updatedAt && { dateModified: tree.updatedAt }),
@@ -251,13 +254,13 @@ export default async function TreePage({ params }: Props) {
       {
         "@type": "ListItem",
         position: 1,
-        name: locale === "es" ? "Inicio" : "Home",
+        name: navT("home"),
         item: `${baseUrl}/${locale}`,
       },
       {
         "@type": "ListItem",
         position: 2,
-        name: locale === "es" ? "Árboles" : "Trees",
+        name: navT("trees"),
         item: `${baseUrl}/${locale}/trees`,
       },
       {

--- a/src/app/[locale]/trees/[slug]/page.tsx
+++ b/src/app/[locale]/trees/[slug]/page.tsx
@@ -33,7 +33,7 @@ import type {
   IndigenousName,
 } from "@/types/tree";
 
-const OG_LOCALE: Record<string, string> = { en: "en_US", es: "es_CR" };
+const OG_LOCALE = { en: "en_US", es: "es_CR" } as const satisfies Record<Locale, string>;
 
 // Dynamic imports for heavy below-fold components
 // DistributionMap renders static SVG from props, so SSR is beneficial for SEO


### PR DESCRIPTION
## Summary
Replace 4 inline `locale === "es"` ternaries in the tree detail page with proper i18n patterns.

## Changes
- **OG_LOCALE constant map**: Replace OpenGraph locale ternary with `Record<string, string>` lookup (`{ en: "en_US", es: "es_CR" }`)
- **`inLanguage` simplification**: Replace `locale === "es" ? "es-CR" : "en-US"` with just `locale`
- **Breadcrumb localization**: Replace hardcoded "Inicio"/"Home" and "Árboles"/"Trees" with `navT("home")` and `navT("trees")` using existing `nav` namespace
- **JSON comma fix**: Fix pre-existing comma issue before `mapGame` namespace

## Files changed (3)
- `src/app/[locale]/trees/[slug]/page.tsx` — 4 ternaries eliminated
- `messages/en.json` — comma fix
- `messages/es.json` — comma fix

## Testing
- ✅ JSON valid
- ✅ 0 locale ternaries remain
- ✅ `tsc --noEmit` clean