### PR TITLE
fix(i18n): localize field-guide page structured data

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -429,7 +429,9 @@
   },
   "fieldGuide": {
     "title": "Field Guide Generator",
-    "metaDescription": "Generate a custom printable field guide of Costa Rican trees. Choose species with photos and key identification facts."
+    "metaDescription": "Generate a custom printable field guide of Costa Rican trees. Choose species with photos and key identification facts.",
+    "structuredName": "Field Guide Generator",
+    "structuredDescription": "Create your own custom field guide of Costa Rican trees."
   },
   "identify": {
     "title": "Identify a Tree",
@@ -1429,6 +1431,7 @@
     "nativeRegion": "Region",
     "confirmClearAll": "Clear all data?",
     "noTreesFound": "No trees found"
+  },
   "mapGame": {
     "metaTitle": "Map Game - Costa Rica Tree Atlas",
     "metaDescription": "Learn where Costa Rica's trees grow in this interactive game.",
@@ -1446,7 +1449,7 @@
     "correct": "Correct!",
     "incorrect": "Incorrect",
     "theCorrectAnswer": "The correct answer is",
-    "nextQuestion": "Next \u2192",
+    "nextQuestion": "Next →",
     "score": "Score",
     "streak": "🔥 Streak",
     "highScore": "High Score",

--- a/messages/es.json
+++ b/messages/es.json
@@ -429,7 +429,9 @@
   },
   "fieldGuide": {
     "title": "Generador de Guía de Campo",
-    "metaDescription": "Genera una guía de campo personalizada e imprimible de árboles de Costa Rica. Elige especies con fotos y datos clave de identificación."
+    "metaDescription": "Genera una guía de campo personalizada e imprimible de árboles de Costa Rica. Elige especies con fotos y datos clave de identificación.",
+    "structuredName": "Generador de Guía de Campo",
+    "structuredDescription": "Crea tu propia guía de campo personalizada de árboles de Costa Rica."
   },
   "identify": {
     "title": "Identificar un árbol",
@@ -1429,6 +1431,7 @@
     "nativeRegion": "Región",
     "confirmClearAll": "¿Borrar todos los datos?",
     "noTreesFound": "No se encontraron árboles"
+  },
   "mapGame": {
     "metaTitle": "Juego del Mapa - Atlas de Árboles de Costa Rica",
     "metaDescription": "Aprende dónde crecen los árboles de Costa Rica en este juego interactivo.",
@@ -1446,7 +1449,7 @@
     "correct": "¡Correcto!",
     "incorrect": "Incorrecto",
     "theCorrectAnswer": "La respuesta correcta es",
-    "nextQuestion": "Siguiente \u2192",
+    "nextQuestion": "Siguiente →",
     "score": "Puntuación",
     "streak": "🔥 Racha",
     "highScore": "Récord",

--- a/src/app/[locale]/field-guide/page.tsx
+++ b/src/app/[locale]/field-guide/page.tsx
@@ -65,15 +65,13 @@ export default async function FieldGuidePage({ params }: Props) {
       conservationStatus: tree.conservationStatus,
     }));
 
+  const t = await getTranslations("fieldGuide");
+
   const structuredData = {
     "@context": "https://schema.org",
     "@type": "WebPage",
-    name:
-      locale === "es" ? "Generador de Guía de Campo" : "Field Guide Generator",
-    description:
-      locale === "es"
-        ? "Crea tu propia guía de campo personalizada de árboles de Costa Rica."
-        : "Create your own custom field guide of Costa Rican trees.",
+    name: t("structuredName"),
+    description: t("structuredDescription"),
     url: `https://costaricatreeatlas.com/${locale}/field-guide`,
   };
 


### PR DESCRIPTION
## Summary
Replace 2 inline locale ternaries in the field guide page with next-intl translations.

## Changes
- **field-guide/page.tsx**: Replace structured data `name` and `description` ternaries with `t("structuredName")` and `t("structuredDescription")`
- **messages/en.json**: Add `structuredName`, `structuredDescription` to `fieldGuide` namespace
- **messages/es.json**: Add Spanish equivalents
- **JSON fix**: Fix pre-existing missing `},` before `mapGame` namespace

## Testing
- ✅ JSON valid
- ✅ 0 locale ternaries remain
- ✅ `tsc --noEmit` clean