### PR TITLE
fix(i18n): localize glossary page structured data

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -822,7 +822,9 @@
       "reproduction": "Reproduction",
       "general": "General",
       "timber": "Timber & Wood"
-    }
+    },
+    "structuredName": "Costa Rica Tree Glossary",
+    "structuredDescription": "Glossary of {count} botanical terms used in the Costa Rica Tree Atlas."
   },
   "imageVoting": {
     "title": "Help Improve Tree Images",
@@ -1429,6 +1431,7 @@
     "nativeRegion": "Region",
     "confirmClearAll": "Clear all data?",
     "noTreesFound": "No trees found"
+  },
   "mapGame": {
     "metaTitle": "Map Game - Costa Rica Tree Atlas",
     "metaDescription": "Learn where Costa Rica's trees grow in this interactive game.",
@@ -1446,7 +1449,7 @@
     "correct": "Correct!",
     "incorrect": "Incorrect",
     "theCorrectAnswer": "The correct answer is",
-    "nextQuestion": "Next \u2192",
+    "nextQuestion": "Next →",
     "score": "Score",
     "streak": "🔥 Streak",
     "highScore": "High Score",

--- a/messages/es.json
+++ b/messages/es.json
@@ -822,7 +822,9 @@
       "reproduction": "Reproducción",
       "general": "General",
       "timber": "Madera y Carpintería"
-    }
+    },
+    "structuredName": "Glosario de Árboles de Costa Rica",
+    "structuredDescription": "Glosario de {count} términos botánicos utilizados en el Atlas de Árboles de Costa Rica."
   },
   "imageVoting": {
     "title": "Ayuda a Mejorar las Imágenes",
@@ -1429,6 +1431,7 @@
     "nativeRegion": "Región",
     "confirmClearAll": "¿Borrar todos los datos?",
     "noTreesFound": "No se encontraron árboles"
+  },
   "mapGame": {
     "metaTitle": "Juego del Mapa - Atlas de Árboles de Costa Rica",
     "metaDescription": "Aprende dónde crecen los árboles de Costa Rica en este juego interactivo.",
@@ -1446,7 +1449,7 @@
     "correct": "¡Correcto!",
     "incorrect": "Incorrecto",
     "theCorrectAnswer": "La respuesta correcta es",
-    "nextQuestion": "Siguiente \u2192",
+    "nextQuestion": "Siguiente →",
     "score": "Puntuación",
     "streak": "🔥 Racha",
     "highScore": "Récord",

--- a/src/app/[locale]/conservation/page.tsx
+++ b/src/app/[locale]/conservation/page.tsx
@@ -266,15 +266,14 @@ export default async function ConservationPage({
                       const status = tree.conservationStatus;
                       const isKnownStatus = Object.hasOwn(
                         STATUS_COLORS,
-                        status as ConservationCategory,
+                        status as ConservationCategory
                       );
                       const colorClass = isKnownStatus
                         ? STATUS_COLORS[status as ConservationStatus]
                         : "bg-muted text-foreground";
-                      const localizedLabel =
-                        isKnownStatus
-                          ? statusLabels[status as ConservationStatus]?.[locale]
-                          : undefined;
+                      const localizedLabel = isKnownStatus
+                        ? statusLabels[status as ConservationStatus]?.[locale]
+                        : undefined;
                       const fallbackLabel =
                         locale === "es"
                           ? "Estado de conservación desconocido"

--- a/src/app/[locale]/glossary/page.tsx
+++ b/src/app/[locale]/glossary/page.tsx
@@ -59,14 +59,8 @@ export default async function GlossaryPage({
   const structuredData = {
     "@context": "https://schema.org",
     "@type": "DefinedTermSet",
-    name:
-      locale === "es"
-        ? "Glosario de Árboles de Costa Rica"
-        : "Costa Rica Tree Glossary",
-    description:
-      locale === "es"
-        ? `Glosario de ${terms.length} términos botánicos utilizados en el Atlas de Árboles de Costa Rica.`
-        : `Glossary of ${terms.length} botanical terms used in the Costa Rica Tree Atlas.`,
+    name: t("structuredName"),
+    description: t("structuredDescription", { count: terms.length }),
     url: `https://costaricatreeatlas.com/${locale}/glossary`,
     inLanguage: locale,
     hasDefinedTerm: terms.slice(0, 50).map((term) => ({

--- a/src/app/[locale]/map/page.tsx
+++ b/src/app/[locale]/map/page.tsx
@@ -94,11 +94,11 @@ export default async function MapPage({ params }: MapPageProps) {
         (d): d is Distribution => isProvince(d) || isRegion(d)
       ),
       tags: t.tags?.filter((tag): tag is TreeTag => VALID_TAGS.has(tag)),
-      floweringSeason: t.floweringSeason?.filter(
-        (m): m is Month => VALID_MONTH_STRINGS.has(m)
+      floweringSeason: t.floweringSeason?.filter((m): m is Month =>
+        VALID_MONTH_STRINGS.has(m)
       ),
-      fruitingSeason: t.fruitingSeason?.filter(
-        (m): m is Month => VALID_MONTH_STRINGS.has(m)
+      fruitingSeason: t.fruitingSeason?.filter((m): m is Month =>
+        VALID_MONTH_STRINGS.has(m)
       ),
       featuredImage: t.featuredImage,
       conservationStatus: t.conservationStatus,


### PR DESCRIPTION
Closing — will recreate from current main. Conservation and map page changes from this PR were already merged via earlier PRs. Only glossary structured data ternaries remain.