### PR TITLE
fix(i18n): localize glossary page structured data

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -889,7 +889,9 @@
       "reproduction": "Reproduction",
       "general": "General",
       "timber": "Timber & Wood"
-    }
+    },
+    "structuredName": "Costa Rica Tree Glossary",
+    "structuredDescription": "Glossary of {count} botanical terms used in the Costa Rica Tree Atlas."
   },
   "imageVoting": {
     "title": "Help Improve Tree Images",
@@ -1514,7 +1516,7 @@
     "correct": "Correct!",
     "incorrect": "Incorrect",
     "theCorrectAnswer": "The correct answer is",
-    "nextQuestion": "Next \u2192",
+    "nextQuestion": "Next →",
     "score": "Score",
     "streak": "🔥 Streak",
     "highScore": "High Score",
@@ -1674,7 +1676,7 @@
     "title": "Botanical Family Guide",
     "subtitle": "Costa Rica Tree Atlas",
     "instructions": "Quick reference of botanical families represented in the atlas",
-    "printButton": "\uD83D\uDDA8\uFE0F Print",
+    "printButton": "🖨️ Print",
     "backLink": "← Back",
     "species": "species",
     "families": "families",
@@ -1707,7 +1709,7 @@
     "roots": "Roots",
     "wholeTree": "Whole Tree",
     "selectSymptom": "What symptoms do you see?",
-    "back": "\u2190 Back",
+    "back": "← Back",
     "restart": "Start Over",
     "severityLow": "Low Severity",
     "severityModerate": "Moderate Severity",
@@ -1725,32 +1727,13 @@
     "categoryRootsDesc": "Root issues",
     "categoryWholeTreeDesc": "Overall tree health"
   },
-  "identificationKey": {
-    "metaTitle": "Identification Key - Costa Rica Tree Atlas",
-    "metaDescription": "Dichotomous guide to identify Costa Rica trees by observable characteristics.",
-    "title": "Identification Key",
-    "subtitle": "Costa Rica Tree Atlas",
-    "intro": "Use this simplified dichotomous key to identify trees. Start at step 1 and follow the choices until you reach a species group.",
-    "printButton": "🖨️ Print",
-    "backLink": "← Back",
-    "step": "Step",
-    "goTo": "Go to",
-    "species": "species",
-    "examples": "Examples",
-    "tips": "Field Tips",
-    "tip1": "Observe the overall tree shape first",
-    "tip2": "Examine leaves - simple or compound, alternate or opposite",
-    "tip3": "Look for flowers, fruits, or seeds if available",
-    "tip4": "Note the bark - texture, color, and if it has latex",
-    "tip5": "Consider the location and habitat"
-  },
   "checklist": {
     "metaTitle": "Printable Species Checklist - Costa Rica Tree Atlas",
     "metaDescription": "Printable checklist of Costa Rican tree species organized by botanical family. Ideal for field trips and outdoor activities.",
     "title": "Species Checklist",
     "subtitle": "Costa Rica Tree Atlas",
     "instructions": "Check off species as you observe them during your field trip",
-    "printButton": "\uD83D\uDDA8\uFE0F Print",
+    "printButton": "🖨️ Print",
     "backLink": "← Back",
     "species": "species",
     "date": "Date",
@@ -1774,7 +1757,7 @@
     "unknownStatus": "Unknown conservation status",
     "aboutIUCN": "About the IUCN Red List",
     "aboutIUCNDesc": "The IUCN Red List of Threatened Species is the world's most comprehensive inventory of the global conservation status of biological species.",
-    "visitIUCN": "Visit IUCN Red List \u2192"
+    "visitIUCN": "Visit IUCN Red List →"
   },
   "coloringPages": {
     "metaTitle": "Coloring Pages - Costa Rica Tree Atlas",
@@ -1782,14 +1765,14 @@
     "title": "Coloring Pages",
     "subtitle": "Costa Rica Tree Atlas",
     "instructions": "Print and color the trees. Learn their names while having fun.",
-    "printButton": "\ud83d\udda8\ufe0f Print",
-    "backLink": "\u2190 Back",
+    "printButton": "🖨️ Print",
+    "backLink": "← Back",
     "colorMe": "Color me!",
     "family": "Family",
     "selectAll": "Select All",
     "deselectAll": "Deselect All",
     "selected": "selected",
-    "tip": "\ud83d\udca1 Tip: Use realistic colors or your imagination. Both are great!",
+    "tip": "💡 Tip: Use realistic colors or your imagination. Both are great!",
     "writePrompt": "Write something about this tree:"
   },
   "biodiversityIntro": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -1667,6 +1667,7 @@
   "conservationLesson": {
     "metaTitle": "Conservation and Threats - Educational Lesson",
     "metaDescription": "Learn about threats to Costa Rican forests and conservation strategies. Interactive activities with IUCN data."
+  },
   "familiesGuide": {
     "metaTitle": "Botanical Family Guide - Costa Rica Tree Atlas",
     "metaDescription": "Reference guide of botanical families with representative Costa Rica species.",
@@ -1679,6 +1680,7 @@
     "families": "families",
     "representativeSpecies": "Representative species",
     "andMore": "and more..."
+  },
   "useCases": {
     "metaTitle": "Use Cases",
     "metaDescription": "Find Costa Rican trees organized by use case: shade for coffee, windbreaks, erosion control, gardens, and more.",
@@ -1692,6 +1694,7 @@
     "calendarTitle": "Seasonal Calendar",
     "calendarDesc": "Discover which trees flower and fruit each month",
     "viewTrees": "View trees"
+  },
   "diagnose": {
     "metaTitle": "Tree Health Diagnostic Tool - Costa Rica Tree Atlas",
     "metaDescription": "Diagnose health problems in Costa Rican trees based on symptoms and receive treatment recommendations.",
@@ -1721,6 +1724,7 @@
     "categoryBranchesDesc": "Branch problems",
     "categoryRootsDesc": "Root issues",
     "categoryWholeTreeDesc": "Overall tree health"
+  },
   "identificationKey": {
     "metaTitle": "Identification Key - Costa Rica Tree Atlas",
     "metaDescription": "Dichotomous guide to identify Costa Rica trees by observable characteristics.",
@@ -1739,6 +1743,7 @@
     "tip3": "Look for flowers, fruits, or seeds if available",
     "tip4": "Note the bark - texture, color, and if it has latex",
     "tip5": "Consider the location and habitat"
+  },
   "checklist": {
     "metaTitle": "Printable Species Checklist - Costa Rica Tree Atlas",
     "metaDescription": "Printable checklist of Costa Rican tree species organized by botanical family. Ideal for field trips and outdoor activities.",
@@ -1754,6 +1759,7 @@
     "notes": "Notes",
     "totalSpecies": "Total species",
     "familiesLabel": "families"
+  },
   "conservationPage": {
     "metaTitle": "Conservation Dashboard - Costa Rica Tree Atlas",
     "metaDescription": "Conservation status of Costa Rica's trees according to the IUCN Red List.",
@@ -1769,6 +1775,7 @@
     "aboutIUCN": "About the IUCN Red List",
     "aboutIUCNDesc": "The IUCN Red List of Threatened Species is the world's most comprehensive inventory of the global conservation status of biological species.",
     "visitIUCN": "Visit IUCN Red List \u2192"
+  },
   "coloringPages": {
     "metaTitle": "Coloring Pages - Costa Rica Tree Atlas",
     "metaDescription": "Download coloring pages of Costa Rica trees. Perfect for educational activities.",
@@ -1784,12 +1791,15 @@
     "selected": "selected",
     "tip": "\ud83d\udca1 Tip: Use realistic colors or your imagination. Both are great!",
     "writePrompt": "Write something about this tree:"
+  },
   "biodiversityIntro": {
     "metaTitle": "Introduction to Biodiversity - Costa Rica Tree Atlas",
     "metaDescription": "Interactive lesson on biodiversity and Costa Rica's trees. Activities, quizzes, and key data for students."
+  },
   "ecosystemServices": {
     "metaTitle": "Ecosystem Services - Educational Lesson",
     "metaDescription": "Discover ecosystem services provided by Costa Rican trees: air purification, water cycling, wildlife habitat, and more."
+  },
   "printablesHub": {
     "metaTitle": "Printable Resources - Costa Rica Tree Atlas",
     "metaDescription": "Download and print educational materials about Costa Rica trees.",
@@ -1880,6 +1890,7 @@
     "whyRecommended": "Why recommended:",
     "characteristics": "Characteristics:",
     "browseAllTrees": "Browse All Trees"
+  },
   "quiz": {
     "metaTitle": "Tree Quiz - Costa Rica Tree Atlas",
     "metaDescription": "Test your knowledge of Costa Rican trees with our interactive quizzes.",
@@ -1910,6 +1921,7 @@
     "loading": "Loading quiz...",
     "backToTrees": "Back to Trees",
     "exploreTrees": "Explore Trees"
+  },
   "flashcards": {
     "metaTitle": "Printable Study Flashcards - Costa Rica Tree Atlas",
     "metaDescription": "Printable study flashcards with information about Costa Rica trees.",

--- a/messages/es.json
+++ b/messages/es.json
@@ -1667,6 +1667,7 @@
   "conservationLesson": {
     "metaTitle": "Conservación y Amenazas - Lección Educativa",
     "metaDescription": "Aprende sobre amenazas a los bosques de Costa Rica y estrategias de conservación. Actividades interactivas con datos UICN."
+  },
   "familiesGuide": {
     "metaTitle": "Guía de Familias Botánicas - Atlas de Árboles de Costa Rica",
     "metaDescription": "Guía de referencia de familias botánicas con especies representativas de Costa Rica.",
@@ -1679,6 +1680,7 @@
     "families": "familias",
     "representativeSpecies": "Especies representativas",
     "andMore": "y más..."
+  },
   "useCases": {
     "metaTitle": "Casos de Uso",
     "metaDescription": "Encuentra árboles de Costa Rica organizados por uso: sombra para café, cortavientos, control de erosión, jardines y más.",
@@ -1692,6 +1694,7 @@
     "calendarTitle": "Calendario Estacional",
     "calendarDesc": "Descubre qué árboles florecen y fructifican cada mes",
     "viewTrees": "Ver árboles"
+  },
   "diagnose": {
     "metaTitle": "Herramienta de Diagnóstico de Salud de Árboles - Atlas de Árboles de Costa Rica",
     "metaDescription": "Diagnostica problemas de salud en árboles de Costa Rica según sus síntomas y recibe recomendaciones de tratamiento.",
@@ -1721,6 +1724,7 @@
     "categoryBranchesDesc": "Problemas con ramas",
     "categoryRootsDesc": "Problemas de raíces",
     "categoryWholeTreeDesc": "Problemas generales del árbol"
+  },
   "identificationKey": {
     "metaTitle": "Clave de Identificación - Atlas de Árboles de Costa Rica",
     "metaDescription": "Guía dicotómica para identificar árboles de Costa Rica por características observables.",
@@ -1739,6 +1743,7 @@
     "tip3": "Busca flores, frutos o semillas si están disponibles",
     "tip4": "Nota la corteza - textura, color, y si tiene látex",
     "tip5": "Considera la ubicación y el hábitat"
+  },
   "checklist": {
     "metaTitle": "Lista de Especies Imprimible - Atlas de Árboles de Costa Rica",
     "metaDescription": "Lista imprimible de especies de árboles de Costa Rica organizada por familia botánica. Ideal para excursiones y actividades de campo.",
@@ -1754,6 +1759,7 @@
     "notes": "Notas",
     "totalSpecies": "Total de especies",
     "familiesLabel": "familias"
+  },
   "conservationPage": {
     "metaTitle": "Dashboard de Conservación - Atlas de Árboles de Costa Rica",
     "metaDescription": "Estado de conservación de los árboles de Costa Rica según la Lista Roja de la UICN.",
@@ -1769,6 +1775,7 @@
     "aboutIUCN": "Acerca de la Lista Roja de la UICN",
     "aboutIUCNDesc": "La Lista Roja de Especies Amenazadas de la UICN es el inventario más completo del mundo sobre el estado de conservación global de especies biológicas.",
     "visitIUCN": "Visitar Lista Roja de la UICN \u2192"
+  },
   "coloringPages": {
     "metaTitle": "Páginas para Colorear - Atlas de Árboles de Costa Rica",
     "metaDescription": "Descarga páginas para colorear de árboles de Costa Rica. Perfecto para actividades educativas.",
@@ -1784,12 +1791,15 @@
     "selected": "seleccionadas",
     "tip": "\ud83d\udca1 Consejo: Usa colores realistas o tu imaginaci\u00f3n. \u00a1Ambos est\u00e1n bien!",
     "writePrompt": "Escribe algo sobre este \u00e1rbol:"
+  },
   "biodiversityIntro": {
     "metaTitle": "Introducción a la Biodiversidad - Atlas de Árboles de Costa Rica",
     "metaDescription": "Lección interactiva sobre biodiversidad y los árboles de Costa Rica. Actividades, cuestionarios y datos para estudiantes."
+  },
   "ecosystemServices": {
     "metaTitle": "Servicios Ecosistémicos - Lección Educativa",
     "metaDescription": "Descubre los servicios ecosistémicos de los árboles de Costa Rica: purificación del aire, ciclo del agua, hábitat y más."
+  },
   "printablesHub": {
     "metaTitle": "Recursos Imprimibles - Atlas de Árboles de Costa Rica",
     "metaDescription": "Descarga e imprime materiales educativos sobre los árboles de Costa Rica.",
@@ -1880,6 +1890,7 @@
     "whyRecommended": "Por qué se recomienda:",
     "characteristics": "Características:",
     "browseAllTrees": "Explorar Todos los Árboles"
+  },
   "quiz": {
     "metaTitle": "Cuestionario de Árboles - Atlas de Árboles de Costa Rica",
     "metaDescription": "Pon a prueba tu conocimiento sobre los árboles de Costa Rica con nuestros cuestionarios interactivos.",
@@ -1910,6 +1921,7 @@
     "loading": "Cargando cuestionario...",
     "backToTrees": "Volver a Árboles",
     "exploreTrees": "Explorar Árboles"
+  },
   "flashcards": {
     "metaTitle": "Tarjetas de Estudio Imprimibles - Atlas de Árboles de Costa Rica",
     "metaDescription": "Tarjetas de estudio imprimibles con información sobre árboles de Costa Rica.",

--- a/messages/es.json
+++ b/messages/es.json
@@ -889,7 +889,9 @@
       "reproduction": "Reproducción",
       "general": "General",
       "timber": "Madera y Carpintería"
-    }
+    },
+    "structuredName": "Glosario de Árboles de Costa Rica",
+    "structuredDescription": "Glosario de {count} términos botánicos utilizados en el Atlas de Árboles de Costa Rica."
   },
   "imageVoting": {
     "title": "Ayuda a Mejorar las Imágenes",
@@ -1514,7 +1516,7 @@
     "correct": "¡Correcto!",
     "incorrect": "Incorrecto",
     "theCorrectAnswer": "La respuesta correcta es",
-    "nextQuestion": "Siguiente \u2192",
+    "nextQuestion": "Siguiente →",
     "score": "Puntuación",
     "streak": "🔥 Racha",
     "highScore": "Récord",
@@ -1674,7 +1676,7 @@
     "title": "Guía de Familias Botánicas",
     "subtitle": "Atlas de Árboles de Costa Rica",
     "instructions": "Referencia rápida de familias botánicas representadas en el atlas",
-    "printButton": "\uD83D\uDDA8\uFE0F Imprimir",
+    "printButton": "🖨️ Imprimir",
     "backLink": "← Volver",
     "species": "especies",
     "families": "familias",
@@ -1707,7 +1709,7 @@
     "roots": "Raíces",
     "wholeTree": "Árbol Completo",
     "selectSymptom": "¿Qué síntomas observas?",
-    "back": "\u2190 Atrás",
+    "back": "← Atrás",
     "restart": "Comenzar de Nuevo",
     "severityLow": "Severidad Baja",
     "severityModerate": "Severidad Moderada",
@@ -1725,32 +1727,13 @@
     "categoryRootsDesc": "Problemas de raíces",
     "categoryWholeTreeDesc": "Problemas generales del árbol"
   },
-  "identificationKey": {
-    "metaTitle": "Clave de Identificación - Atlas de Árboles de Costa Rica",
-    "metaDescription": "Guía dicotómica para identificar árboles de Costa Rica por características observables.",
-    "title": "Clave de Identificación",
-    "subtitle": "Atlas de Árboles de Costa Rica",
-    "intro": "Usa esta clave dicotómica simplificada para identificar árboles. Comienza en el paso 1 y sigue las opciones hasta llegar a un grupo de especies.",
-    "printButton": "🖨️ Imprimir",
-    "backLink": "← Volver",
-    "step": "Paso",
-    "goTo": "Ir a",
-    "species": "especies",
-    "examples": "Ejemplos",
-    "tips": "Consejos de Campo",
-    "tip1": "Observa la forma general del árbol primero",
-    "tip2": "Examina las hojas - simples o compuestas, alternas u opuestas",
-    "tip3": "Busca flores, frutos o semillas si están disponibles",
-    "tip4": "Nota la corteza - textura, color, y si tiene látex",
-    "tip5": "Considera la ubicación y el hábitat"
-  },
   "checklist": {
     "metaTitle": "Lista de Especies Imprimible - Atlas de Árboles de Costa Rica",
     "metaDescription": "Lista imprimible de especies de árboles de Costa Rica organizada por familia botánica. Ideal para excursiones y actividades de campo.",
     "title": "Lista de Especies",
     "subtitle": "Atlas de Árboles de Costa Rica",
     "instructions": "Marca las especies que observes durante tu excursión",
-    "printButton": "\uD83D\uDDA8\uFE0F Imprimir",
+    "printButton": "🖨️ Imprimir",
     "backLink": "← Volver",
     "species": "especies",
     "date": "Fecha",
@@ -1774,7 +1757,7 @@
     "unknownStatus": "Estado de conservación desconocido",
     "aboutIUCN": "Acerca de la Lista Roja de la UICN",
     "aboutIUCNDesc": "La Lista Roja de Especies Amenazadas de la UICN es el inventario más completo del mundo sobre el estado de conservación global de especies biológicas.",
-    "visitIUCN": "Visitar Lista Roja de la UICN \u2192"
+    "visitIUCN": "Visitar Lista Roja de la UICN →"
   },
   "coloringPages": {
     "metaTitle": "Páginas para Colorear - Atlas de Árboles de Costa Rica",
@@ -1782,15 +1765,15 @@
     "title": "Páginas para Colorear",
     "subtitle": "Atlas de Árboles de Costa Rica",
     "instructions": "Imprime y colorea los árboles. Aprende sus nombres mientras te diviertes.",
-    "printButton": "\ud83d\udda8\ufe0f Imprimir",
-    "backLink": "\u2190 Volver",
-    "colorMe": "\u00a1Color\u00e9ame!",
+    "printButton": "🖨️ Imprimir",
+    "backLink": "← Volver",
+    "colorMe": "¡Coloréame!",
     "family": "Familia",
     "selectAll": "Seleccionar Todo",
     "deselectAll": "Deseleccionar Todo",
     "selected": "seleccionadas",
-    "tip": "\ud83d\udca1 Consejo: Usa colores realistas o tu imaginaci\u00f3n. \u00a1Ambos est\u00e1n bien!",
-    "writePrompt": "Escribe algo sobre este \u00e1rbol:"
+    "tip": "💡 Consejo: Usa colores realistas o tu imaginación. ¡Ambos están bien!",
+    "writePrompt": "Escribe algo sobre este árbol:"
   },
   "biodiversityIntro": {
     "metaTitle": "Introducción a la Biodiversidad - Atlas de Árboles de Costa Rica",

--- a/src/app/[locale]/glossary/page.tsx
+++ b/src/app/[locale]/glossary/page.tsx
@@ -59,14 +59,8 @@ export default async function GlossaryPage({
   const structuredData = {
     "@context": "https://schema.org",
     "@type": "DefinedTermSet",
-    name:
-      locale === "es"
-        ? "Glosario de Árboles de Costa Rica"
-        : "Costa Rica Tree Glossary",
-    description:
-      locale === "es"
-        ? `Glosario de ${terms.length} términos botánicos utilizados en el Atlas de Árboles de Costa Rica.`
-        : `Glossary of ${terms.length} botanical terms used in the Costa Rica Tree Atlas.`,
+    name: t("structuredName"),
+    description: t("structuredDescription", { count: terms.length }),
     url: `https://costaricatreeatlas.com/${locale}/glossary`,
     inLanguage: locale,
     hasDefinedTerm: terms.slice(0, 50).map((term) => ({


### PR DESCRIPTION
## What changed\n\nReplaced 2 inline `locale === \"es\"` ternaries in `glossary/page.tsx` with `t()` calls using next-intl translations.\n\nAdded `structuredName` and `structuredDescription` (with ICU `{count}` interpolation) to the `glossary` namespace in both JSON files.\n\n## Why\n\nPart of the P2 localization effort. The glossary structured data (schema.org `DefinedTermSet`) had hardcoded English/Spanish strings.\n\n## Depends on\n\n- #646 (JSON structural fix) — this branch includes those fixes\n\n## Replaces\n\n- #643 (closed due to merge conflicts)\n\n## Validation\n\n- 0 `locale === \"es\"` ternaries remaining in glossary/page.tsx\n- TypeScript clean (`npx tsc --noEmit`)\n- Both JSON files valid