### PR TITLE
fix(i18n): simplify home page inLanguage to use locale directly

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1667,6 +1667,7 @@
   "conservationLesson": {
     "metaTitle": "Conservation and Threats - Educational Lesson",
     "metaDescription": "Learn about threats to Costa Rican forests and conservation strategies. Interactive activities with IUCN data."
+  },
   "familiesGuide": {
     "metaTitle": "Botanical Family Guide - Costa Rica Tree Atlas",
     "metaDescription": "Reference guide of botanical families with representative Costa Rica species.",
@@ -1679,6 +1680,7 @@
     "families": "families",
     "representativeSpecies": "Representative species",
     "andMore": "and more..."
+  },
   "useCases": {
     "metaTitle": "Use Cases",
     "metaDescription": "Find Costa Rican trees organized by use case: shade for coffee, windbreaks, erosion control, gardens, and more.",
@@ -1692,6 +1694,7 @@
     "calendarTitle": "Seasonal Calendar",
     "calendarDesc": "Discover which trees flower and fruit each month",
     "viewTrees": "View trees"
+  },
   "diagnose": {
     "metaTitle": "Tree Health Diagnostic Tool - Costa Rica Tree Atlas",
     "metaDescription": "Diagnose health problems in Costa Rican trees based on symptoms and receive treatment recommendations.",
@@ -1721,6 +1724,7 @@
     "categoryBranchesDesc": "Branch problems",
     "categoryRootsDesc": "Root issues",
     "categoryWholeTreeDesc": "Overall tree health"
+  },
   "identificationKey": {
     "metaTitle": "Identification Key - Costa Rica Tree Atlas",
     "metaDescription": "Dichotomous guide to identify Costa Rica trees by observable characteristics.",
@@ -1739,6 +1743,7 @@
     "tip3": "Look for flowers, fruits, or seeds if available",
     "tip4": "Note the bark - texture, color, and if it has latex",
     "tip5": "Consider the location and habitat"
+  },
   "checklist": {
     "metaTitle": "Printable Species Checklist - Costa Rica Tree Atlas",
     "metaDescription": "Printable checklist of Costa Rican tree species organized by botanical family. Ideal for field trips and outdoor activities.",
@@ -1754,6 +1759,7 @@
     "notes": "Notes",
     "totalSpecies": "Total species",
     "familiesLabel": "families"
+  },
   "conservationPage": {
     "metaTitle": "Conservation Dashboard - Costa Rica Tree Atlas",
     "metaDescription": "Conservation status of Costa Rica's trees according to the IUCN Red List.",
@@ -1769,6 +1775,7 @@
     "aboutIUCN": "About the IUCN Red List",
     "aboutIUCNDesc": "The IUCN Red List of Threatened Species is the world's most comprehensive inventory of the global conservation status of biological species.",
     "visitIUCN": "Visit IUCN Red List \u2192"
+  },
   "coloringPages": {
     "metaTitle": "Coloring Pages - Costa Rica Tree Atlas",
     "metaDescription": "Download coloring pages of Costa Rica trees. Perfect for educational activities.",
@@ -1784,12 +1791,15 @@
     "selected": "selected",
     "tip": "\ud83d\udca1 Tip: Use realistic colors or your imagination. Both are great!",
     "writePrompt": "Write something about this tree:"
+  },
   "biodiversityIntro": {
     "metaTitle": "Introduction to Biodiversity - Costa Rica Tree Atlas",
     "metaDescription": "Interactive lesson on biodiversity and Costa Rica's trees. Activities, quizzes, and key data for students."
+  },
   "ecosystemServices": {
     "metaTitle": "Ecosystem Services - Educational Lesson",
     "metaDescription": "Discover ecosystem services provided by Costa Rican trees: air purification, water cycling, wildlife habitat, and more."
+  },
   "printablesHub": {
     "metaTitle": "Printable Resources - Costa Rica Tree Atlas",
     "metaDescription": "Download and print educational materials about Costa Rica trees.",
@@ -1880,6 +1890,7 @@
     "whyRecommended": "Why recommended:",
     "characteristics": "Characteristics:",
     "browseAllTrees": "Browse All Trees"
+  },
   "quiz": {
     "metaTitle": "Tree Quiz - Costa Rica Tree Atlas",
     "metaDescription": "Test your knowledge of Costa Rican trees with our interactive quizzes.",
@@ -1910,6 +1921,7 @@
     "loading": "Loading quiz...",
     "backToTrees": "Back to Trees",
     "exploreTrees": "Explore Trees"
+  },
   "flashcards": {
     "metaTitle": "Printable Study Flashcards - Costa Rica Tree Atlas",
     "metaDescription": "Printable study flashcards with information about Costa Rica trees.",

--- a/messages/es.json
+++ b/messages/es.json
@@ -1667,6 +1667,7 @@
   "conservationLesson": {
     "metaTitle": "Conservación y Amenazas - Lección Educativa",
     "metaDescription": "Aprende sobre amenazas a los bosques de Costa Rica y estrategias de conservación. Actividades interactivas con datos UICN."
+  },
   "familiesGuide": {
     "metaTitle": "Guía de Familias Botánicas - Atlas de Árboles de Costa Rica",
     "metaDescription": "Guía de referencia de familias botánicas con especies representativas de Costa Rica.",
@@ -1679,6 +1680,7 @@
     "families": "familias",
     "representativeSpecies": "Especies representativas",
     "andMore": "y más..."
+  },
   "useCases": {
     "metaTitle": "Casos de Uso",
     "metaDescription": "Encuentra árboles de Costa Rica organizados por uso: sombra para café, cortavientos, control de erosión, jardines y más.",
@@ -1692,6 +1694,7 @@
     "calendarTitle": "Calendario Estacional",
     "calendarDesc": "Descubre qué árboles florecen y fructifican cada mes",
     "viewTrees": "Ver árboles"
+  },
   "diagnose": {
     "metaTitle": "Herramienta de Diagnóstico de Salud de Árboles - Atlas de Árboles de Costa Rica",
     "metaDescription": "Diagnostica problemas de salud en árboles de Costa Rica según sus síntomas y recibe recomendaciones de tratamiento.",
@@ -1721,6 +1724,7 @@
     "categoryBranchesDesc": "Problemas con ramas",
     "categoryRootsDesc": "Problemas de raíces",
     "categoryWholeTreeDesc": "Problemas generales del árbol"
+  },
   "identificationKey": {
     "metaTitle": "Clave de Identificación - Atlas de Árboles de Costa Rica",
     "metaDescription": "Guía dicotómica para identificar árboles de Costa Rica por características observables.",
@@ -1739,6 +1743,7 @@
     "tip3": "Busca flores, frutos o semillas si están disponibles",
     "tip4": "Nota la corteza - textura, color, y si tiene látex",
     "tip5": "Considera la ubicación y el hábitat"
+  },
   "checklist": {
     "metaTitle": "Lista de Especies Imprimible - Atlas de Árboles de Costa Rica",
     "metaDescription": "Lista imprimible de especies de árboles de Costa Rica organizada por familia botánica. Ideal para excursiones y actividades de campo.",
@@ -1754,6 +1759,7 @@
     "notes": "Notas",
     "totalSpecies": "Total de especies",
     "familiesLabel": "familias"
+  },
   "conservationPage": {
     "metaTitle": "Dashboard de Conservación - Atlas de Árboles de Costa Rica",
     "metaDescription": "Estado de conservación de los árboles de Costa Rica según la Lista Roja de la UICN.",
@@ -1769,6 +1775,7 @@
     "aboutIUCN": "Acerca de la Lista Roja de la UICN",
     "aboutIUCNDesc": "La Lista Roja de Especies Amenazadas de la UICN es el inventario más completo del mundo sobre el estado de conservación global de especies biológicas.",
     "visitIUCN": "Visitar Lista Roja de la UICN \u2192"
+  },
   "coloringPages": {
     "metaTitle": "Páginas para Colorear - Atlas de Árboles de Costa Rica",
     "metaDescription": "Descarga páginas para colorear de árboles de Costa Rica. Perfecto para actividades educativas.",
@@ -1784,12 +1791,15 @@
     "selected": "seleccionadas",
     "tip": "\ud83d\udca1 Consejo: Usa colores realistas o tu imaginaci\u00f3n. \u00a1Ambos est\u00e1n bien!",
     "writePrompt": "Escribe algo sobre este \u00e1rbol:"
+  },
   "biodiversityIntro": {
     "metaTitle": "Introducción a la Biodiversidad - Atlas de Árboles de Costa Rica",
     "metaDescription": "Lección interactiva sobre biodiversidad y los árboles de Costa Rica. Actividades, cuestionarios y datos para estudiantes."
+  },
   "ecosystemServices": {
     "metaTitle": "Servicios Ecosistémicos - Lección Educativa",
     "metaDescription": "Descubre los servicios ecosistémicos de los árboles de Costa Rica: purificación del aire, ciclo del agua, hábitat y más."
+  },
   "printablesHub": {
     "metaTitle": "Recursos Imprimibles - Atlas de Árboles de Costa Rica",
     "metaDescription": "Descarga e imprime materiales educativos sobre los árboles de Costa Rica.",
@@ -1880,6 +1890,7 @@
     "whyRecommended": "Por qué se recomienda:",
     "characteristics": "Características:",
     "browseAllTrees": "Explorar Todos los Árboles"
+  },
   "quiz": {
     "metaTitle": "Cuestionario de Árboles - Atlas de Árboles de Costa Rica",
     "metaDescription": "Pon a prueba tu conocimiento sobre los árboles de Costa Rica con nuestros cuestionarios interactivos.",
@@ -1910,6 +1921,7 @@
     "loading": "Cargando cuestionario...",
     "backToTrees": "Volver a Árboles",
     "exploreTrees": "Explorar Árboles"
+  },
   "flashcards": {
     "metaTitle": "Tarjetas de Estudio Imprimibles - Atlas de Árboles de Costa Rica",
     "metaDescription": "Tarjetas de estudio imprimibles con información sobre árboles de Costa Rica.",

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -95,7 +95,6 @@ export default async function HomePage({ params }: Props) {
   }
 
   // Structured data for homepage
-  const languageTag = locale === "es" ? "es-CR" : "en-US";
   const structuredData = {
     "@context": "https://schema.org",
     "@type": "WebSite",
@@ -103,7 +102,7 @@ export default async function HomePage({ params }: Props) {
     alternateName: "Atlas de Árboles de Costa Rica",
     url: "https://costaricatreeatlas.com",
     description: t("structuredDescription"),
-    inLanguage: languageTag,
+    inLanguage: locale,
     potentialAction: {
       "@type": "SearchAction",
       target: {


### PR DESCRIPTION
## What changed\n\nRemoved the last `locale === \"es\"` ternary in `page.tsx` (home page) by simplifying `inLanguage` to use `locale` directly instead of mapping to `es-CR`/`en-US` language tags.\n\n## Why\n\nSchema.org `inLanguage` accepts both simple language codes (`en`, `es`) and full BCP-47 tags. Using `locale` directly eliminates the ternary.\n\n## Depends on\n\n- #646 (JSON structural fix) — this branch includes those fixes\n\n## Replaces\n\n- #645 (closed due to merge conflicts)\n\n## Validation\n\n- 0 `locale === \"es\"` ternaries remaining in page.tsx\n- TypeScript clean