### PR TITLE
fix: resolve OG_LOCALE type error breaking Vercel build

### DIFF
--- a/src/app/[locale]/trees/[slug]/page.tsx
+++ b/src/app/[locale]/trees/[slug]/page.tsx
@@ -33,7 +33,7 @@ import type {
   IndigenousName,
 } from "@/types/tree";
 
-const OG_LOCALE = { en: "en_US", es: "es_CR" } as const satisfies Record<Locale, string>;
+const OG_LOCALE: Record<string, string> = { en: "en_US", es: "es_CR" };
 
 // Dynamic imports for heavy below-fold components
 // DistributionMap renders static SVG from props, so SSR is beneficial for SEO


### PR DESCRIPTION
## Problem

The Vercel build was failing with a TypeScript error:

```
Element implicitly has an 'any' type because expression of type 'string' can't be used to index type '{ readonly en: "en_US"; readonly es: "es_CR"; }'.
```

## Cause

`OG_LOCALE` was declared with `as const satisfies Record<Locale, string>`, which created a readonly object with strict literal key types (`"en" | "es"`). The `locale` parameter from the route params is typed as `string`, so TypeScript rejected the indexing operation.

## Fix

Changed the type to `Record<string, string>`, matching the pattern already used in the compare page (`src/app/[locale]/compare/[slug]/page.tsx`). This allows the string-typed `locale` to index the object.