### PR TITLE
fix: remove nested <main> landmarks and fix useMemo lint errors

### DIFF
--- a/src/app/[locale]/admin/admin-layout-wrapper.tsx
+++ b/src/app/[locale]/admin/admin-layout-wrapper.tsx
@@ -17,9 +17,9 @@ export function AdminLayoutWrapper({
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
       {nav}
-      <main className="lg:pl-64">
+      <div className="lg:pl-64">
         <div className="py-2">{children}</div>
-      </main>
+      </div>
     </div>
   );
 }

--- a/src/app/[locale]/admin/contributions/page.tsx
+++ b/src/app/[locale]/admin/contributions/page.tsx
@@ -29,12 +29,12 @@ export default async function AdminContributionsPage({
   }
 
   return (
-    <main className="container mx-auto px-4 py-8">
+    <section className="container mx-auto px-4 py-8">
       <div className="max-w-6xl mx-auto">
         <h1 className="text-3xl font-bold mb-2">{t("heading")}</h1>
         <p className="text-muted-foreground mb-8">{t("description")}</p>
         <ContributionsListClient />
       </div>
-    </main>
+    </section>
   );
 }

--- a/src/app/[locale]/contribute/profile/page.tsx
+++ b/src/app/[locale]/contribute/profile/page.tsx
@@ -23,7 +23,7 @@ export default async function ContributorProfilePage({ params }: PageProps) {
   const t = await getTranslations({ locale, namespace: "reputation" });
 
   return (
-    <main className="container mx-auto px-4 py-8">
+    <section className="container mx-auto px-4 py-8">
       <div className="max-w-3xl mx-auto">
         {/* Header */}
         <div className="text-center mb-10">
@@ -35,6 +35,6 @@ export default async function ContributorProfilePage({ params }: PageProps) {
 
         <ContributorProfileClient />
       </div>
-    </main>
+    </section>
   );
 }

--- a/src/app/[locale]/education/classroom/ClassroomClient.tsx
+++ b/src/app/[locale]/education/classroom/ClassroomClient.tsx
@@ -71,7 +71,7 @@ function ClassroomContent() {
         key: CLASSROOM_STORAGE_KEY,
         schema: classroomSchema,
       }),
-    [t]
+    []
   );
 
   const studentInfoStorage = useMemo(
@@ -80,7 +80,7 @@ function ClassroomContent() {
         key: STUDENT_STORAGE_KEY,
         schema: studentInfoSchema,
       }),
-    [t]
+    []
   );
 
   // Load saved data on mount


### PR DESCRIPTION
## What changed

- **Nested `<main>` landmarks removed** from 3 files that were creating invalid landmark nesting inside the layout's existing `<main id="main-content">`:
  - `src/app/[locale]/contribute/profile/page.tsx` → `<section>`
  - `src/app/[locale]/admin/contributions/page.tsx` → `<section>`
  - `src/app/[locale]/admin/admin-layout-wrapper.tsx` → `<div>`
- **Lint errors fixed** in `src/app/[locale]/education/classroom/ClassroomClient.tsx`: removed unnecessary `t` dependency from 2 `useMemo` hooks (the memo bodies only reference stable module-level constants)

## Why

- **P3 (Accessibility)**: Screen readers and landmark navigation become noisy with nested `<main>` elements. WCAG requires exactly one `<main>` landmark per page. The layout at `src/app/[locale]/layout.tsx` already provides `<main id="main-content">`.
- **P1 (Lint errors)**: The 2 `react-hooks/exhaustive-deps` errors were the only lint errors in the repo. Removing them brings lint to 0 errors (36 pre-existing security warnings remain unchanged).

## Evidence

- `grep -r '<main' src/app/` confirmed exactly 3 page files + 1 layout file had `<main>` tags
- `npm run lint` showed 2 errors in ClassroomClient.tsx, both `react-hooks/exhaustive-deps`
- The heading hierarchy issue (multiple h1s) mentioned in the plan is already resolved — `src/components/mdx/server-components.tsx` already downshifts MDX headings by one level

## Validation

- ✅ `npm run build` passes
- ✅ `npm run lint` passes with 0 errors (36 pre-existing warnings)
- ✅ EN routes unaffected (contribute/profile, admin pages, education/classroom)
- ✅ ES routes unaffected (same pages)
- ✅ No regression in layout structure — pages still render inside the layout's `<main>`

## Risks

- None. These are minimal, targeted semantic corrections with no visual or behavioral changes.