### PR TITLE
fix: localize IUCN status labels, QuickRef title, and Tree Not Found metadata for Spanish pages

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1443,6 +1443,7 @@
     }
   },
   "treeDetail": {
+    "treeNotFound": "Tree Not Found",
     "print": "Print",
     "printAriaLabel": "Print this page",
     "pronounce": "Pronounce",

--- a/messages/es.json
+++ b/messages/es.json
@@ -1443,6 +1443,7 @@
     }
   },
   "treeDetail": {
+    "treeNotFound": "Árbol No Encontrado",
     "print": "Imprimir",
     "printAriaLabel": "Imprimir esta página",
     "pronounce": "Pronunciar",

--- a/src/app/[locale]/trees/[slug]/page.tsx
+++ b/src/app/[locale]/trees/[slug]/page.tsx
@@ -90,8 +90,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const tree = allTrees.find((t) => t.locale === locale && t.slug === slug);
 
   if (!tree) {
+    const t = await getTranslations({ locale, namespace: "treeDetail" });
     return {
-      title: "Tree Not Found",
+      title: t("treeNotFound"),
     };
   }
 

--- a/src/components/ServerMDXContent.tsx
+++ b/src/components/ServerMDXContent.tsx
@@ -172,6 +172,22 @@ export async function ServerMDXContent({
         ...props,
         locale: resolvedLocale,
       }),
+    ConservationStatusBox: (
+      props: React.ComponentProps<
+        typeof mdxServerComponents.ConservationStatusBox
+      >
+    ) =>
+      mdxServerComponents.ConservationStatusBox({
+        ...props,
+        locale: resolvedLocale,
+      }),
+    QuickRef: (
+      props: React.ComponentProps<typeof mdxServerComponents.QuickRef>
+    ) =>
+      mdxServerComponents.QuickRef({
+        ...props,
+        locale: resolvedLocale,
+      }),
   };
 
   // Merge server MDX components with client components and any additional ones passed in

--- a/src/components/mdx/server-components.tsx
+++ b/src/components/mdx/server-components.tsx
@@ -746,7 +746,7 @@ export function QuickRef({ title, items = [], locale = "en" }: QuickRefProps) {
   const safeItems = Array.isArray(items) ? items : [];
   // eslint-disable-next-line security/detect-object-injection -- `locale` is constrained to "en" | "es".
   const defaultTitle = translations[locale].iucn.quickReference;
-  const displayTitle = title || defaultTitle;
+  const displayTitle = title ?? defaultTitle;
 
   return (
     <div className="bg-card border-2 border-primary/20 rounded-xl overflow-hidden my-6 not-prose">

--- a/src/components/mdx/server-components.tsx
+++ b/src/components/mdx/server-components.tsx
@@ -39,6 +39,21 @@ const translations = {
       referenceLink: "[Link ↗]",
       referencesHeading: "📚 Scientific References & Further Reading",
     },
+    iucn: {
+      NE: "Not Evaluated",
+      DD: "Data Deficient",
+      LC: "Least Concern",
+      NT: "Near Threatened",
+      VU: "Vulnerable",
+      EN: "Endangered",
+      CR: "Critically Endangered",
+      EW: "Extinct in Wild",
+      EX: "Extinct",
+      redListStatus: "IUCN Red List Status",
+      criteria: "Criteria: ",
+      assessed: "Assessed: ",
+      quickReference: "Quick Reference",
+    },
   },
   es: {
     safety: {
@@ -66,6 +81,21 @@ const translations = {
       costaRicaOnly: "🇨🇷 Solo Costa Rica ↗",
       referenceLink: "[Enlace ↗]",
       referencesHeading: "📚 Referencias científicas y lecturas adicionales",
+    },
+    iucn: {
+      NE: "No Evaluado",
+      DD: "Datos Insuficientes",
+      LC: "Preocupación Menor",
+      NT: "Casi Amenazado",
+      VU: "Vulnerable",
+      EN: "En Peligro",
+      CR: "En Peligro Crítico",
+      EW: "Extinto en Estado Silvestre",
+      EX: "Extinto",
+      redListStatus: "Estado en la Lista Roja de la UICN",
+      criteria: "Criterios: ",
+      assessed: "Evaluado: ",
+      quickReference: "Referencia Rápida",
     },
   },
 } as const;
@@ -709,19 +739,20 @@ export function DistributionMap({
 interface QuickRefProps {
   title?: string;
   items?: { label: string; value: string }[];
+  locale?: "en" | "es";
 }
 
-export function QuickRef({
-  title = "Quick Reference",
-  items = [],
-}: QuickRefProps) {
+export function QuickRef({ title, items = [], locale = "en" }: QuickRefProps) {
   const safeItems = Array.isArray(items) ? items : [];
+  // eslint-disable-next-line security/detect-object-injection -- `locale` is constrained to "en" | "es".
+  const defaultTitle = translations[locale].iucn.quickReference;
+  const displayTitle = title || defaultTitle;
 
   return (
     <div className="bg-card border-2 border-primary/20 rounded-xl overflow-hidden my-6 not-prose">
       <div className="bg-primary/10 px-4 py-2 border-b border-primary/20">
         <h4 className="font-semibold text-primary-dark dark:text-primary-light">
-          {title}
+          {displayTitle}
         </h4>
       </div>
       <div className="p-4">
@@ -975,6 +1006,7 @@ interface ConservationStatusBoxProps {
   status: string;
   criteria?: string;
   assessmentYear?: number;
+  locale?: "en" | "es";
 }
 
 const IUCN_STATUS_CONFIG: Record<
@@ -1036,9 +1068,14 @@ export function ConservationStatusBox({
   status,
   criteria,
   assessmentYear,
+  locale = "en",
 }: ConservationStatusBoxProps) {
   // eslint-disable-next-line security/detect-object-injection -- Fallback to known key ensures safe read from static IUCN map.
   const config = IUCN_STATUS_CONFIG[status] || IUCN_STATUS_CONFIG.NE;
+  // eslint-disable-next-line security/detect-object-injection -- `locale` is constrained to "en" | "es".
+  const t = translations[locale].iucn;
+  // eslint-disable-next-line security/detect-object-injection -- `status` is validated via fallback above.
+  const localizedName = (t as Record<string, string>)[status] || config.name;
 
   return (
     <div className="rounded-xl border border-border p-5 my-6 bg-muted/50">
@@ -1056,10 +1093,10 @@ export function ConservationStatusBox({
           <div className="flex items-center gap-2">
             <span className="text-xl">{config.icon}</span>
             <h4 className="font-semibold text-lg text-foreground">
-              {config.name}
+              {localizedName}
             </h4>
           </div>
-          <p className="text-sm text-muted-foreground">IUCN Red List Status</p>
+          <p className="text-sm text-muted-foreground">{t.redListStatus}</p>
         </div>
       </div>
 
@@ -1067,13 +1104,13 @@ export function ConservationStatusBox({
         <div className="mt-4 pt-4 border-t border-border flex flex-wrap gap-4 text-sm">
           {criteria && (
             <div>
-              <span className="text-muted-foreground">Criteria: </span>
+              <span className="text-muted-foreground">{t.criteria}</span>
               <span className="font-medium text-foreground">{criteria}</span>
             </div>
           )}
           {assessmentYear && (
             <div>
-              <span className="text-muted-foreground">Assessed: </span>
+              <span className="text-muted-foreground">{t.assessed}</span>
               <span className="font-medium text-foreground">
                 {assessmentYear}
               </span>

--- a/src/components/mdx/server-components.tsx
+++ b/src/components/mdx/server-components.tsx
@@ -47,7 +47,7 @@ const translations = {
       VU: "Vulnerable",
       EN: "Endangered",
       CR: "Critically Endangered",
-      EW: "Extinct in Wild",
+      EW: "Extinct in the Wild",
       EX: "Extinct",
       redListStatus: "IUCN Red List Status",
       criteria: "Criteria: ",


### PR DESCRIPTION
## What changed

Localized hardcoded English strings that were visible on all Spanish tree detail pages (`/es/trees/*`):

- **IUCN Conservation Status Box**: Added bilingual translations for all 9 IUCN status names (Not Evaluated → No Evaluado, Least Concern → Preocupación Menor, etc.), plus labels "IUCN Red List Status" → "Estado en la Lista Roja de la UICN", "Criteria:" → "Criterios:", "Assessed:" → "Evaluado:"
- **QuickRef component**: Default title "Quick Reference" now shows "Referencia Rápida" on Spanish pages
- **Tree Not Found metadata**: Added `treeNotFound` translation key so `/es/trees/invalid-slug` returns "Árbol No Encontrado" instead of English

### Files changed
- `src/components/mdx/server-components.tsx` — Added `iucn` namespace to translations dict, added `locale` prop to `ConservationStatusBox` and `QuickRef`
- `src/components/ServerMDXContent.tsx` — Added locale-aware wrappers for `ConservationStatusBox` and `QuickRef`
- `src/app/[locale]/trees/[slug]/page.tsx` — Use `getTranslations` for "Tree Not Found" metadata
- `messages/en.json` / `messages/es.json` — Added `treeDetail.treeNotFound` key

## Why

**P2 (EN/ES surface parity)**: Spanish tree detail pages displayed English strings for IUCN conservation status labels, the QuickRef default title, and the "Tree Not Found" metadata fallback. These are high-traffic pages (175 species × Spanish locale) and the English text breaks immersion for Spanish users.

## Evidence

- `ConservationStatusBox` had no locale prop — it used a hardcoded English `IUCN_STATUS_CONFIG` name map and English labels for "IUCN Red List Status", "Criteria:", "Assessed:"
- `QuickRef` had a hardcoded `title = "Quick Reference"` default
- Tree detail `generateMetadata` had `title: "Tree Not Found"` without locale awareness
- The existing `translations` dict pattern in `server-components.tsx` already handles other components (SafetyCard, INaturalistEmbed, etc.) — this PR extends the same pattern

## Validation

- ✅ `npm run build` passes (1600/1600 pages generated)
- ✅ `npm run lint` — no new errors (2 pre-existing ClassroomClient errors remain on main)
- ✅ EN tree detail pages render correctly with English IUCN labels
- ✅ ES tree detail pages now show Spanish IUCN labels
- ✅ Translation key parity maintained in both message files

## Risks

- None. The translation dict pattern is already established and tested for other components. The `locale` prop defaults to `"en"` for backward compatibility.