### PR TITLE
fix: resolve TypeScript build error and restore PWA icon paths

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -11,50 +11,50 @@
   "lang": "en",
   "icons": [
     {
-      "src": "/icons/icon-68x72.png",
-      "sizes": "68x72",
+      "src": "/icons/icon-72x72.png",
+      "sizes": "72x72",
       "type": "image/png",
       "purpose": "any maskable"
     },
     {
-      "src": "/icons/icon-91x96.png",
-      "sizes": "91x96",
+      "src": "/icons/icon-96x96.png",
+      "sizes": "96x96",
       "type": "image/png",
       "purpose": "any maskable"
     },
     {
-      "src": "/icons/icon-122x128.png",
-      "sizes": "122x128",
+      "src": "/icons/icon-128x128.png",
+      "sizes": "128x128",
       "type": "image/png",
       "purpose": "any maskable"
     },
     {
-      "src": "/icons/icon-137x144.png",
-      "sizes": "137x144",
+      "src": "/icons/icon-144x144.png",
+      "sizes": "144x144",
       "type": "image/png",
       "purpose": "any maskable"
     },
     {
-      "src": "/icons/icon-145x152.png",
-      "sizes": "145x152",
+      "src": "/icons/icon-152x152.png",
+      "sizes": "152x152",
       "type": "image/png",
       "purpose": "any maskable"
     },
     {
-      "src": "/icons/icon-183x192.png",
-      "sizes": "183x192",
+      "src": "/icons/icon-192x192.png",
+      "sizes": "192x192",
       "type": "image/png",
       "purpose": "any maskable"
     },
     {
-      "src": "/icons/icon-367x384.png",
-      "sizes": "367x384",
+      "src": "/icons/icon-384x384.png",
+      "sizes": "384x384",
       "type": "image/png",
       "purpose": "any maskable"
     },
     {
-      "src": "/icons/icon-489x512.png",
-      "sizes": "489x512",
+      "src": "/icons/icon-512x512.png",
+      "sizes": "512x512",
       "type": "image/png",
       "purpose": "any maskable"
     }

--- a/src/app/[locale]/trees/[slug]/twitter-image.tsx
+++ b/src/app/[locale]/trees/[slug]/twitter-image.tsx
@@ -48,7 +48,7 @@ export default async function Image({ params }: Props) {
   let conservationLabel: string | null = null;
 
   if (tree.conservationStatus) {
-    let label = tree.conservationStatus;
+    let label: string = tree.conservationStatus;
 
     try {
       const translated = getConservationLabel(


### PR DESCRIPTION
## What changed

1. **TypeScript build error fixed** in `src/app/[locale]/trees/[slug]/twitter-image.tsx`
   - Added explicit `string` type annotation to `label` variable
   - Without this, TypeScript narrows `label` to `ConservationCategory` from the initial assignment, then rejects the template literal reassignment on line 58

2. **PWA manifest icon paths restored** in `public/manifest.json`
   - Reverted icon `src` paths to match actual filenames on disk (`icon-72x72.png`, `icon-96x96.png`, etc.)
   - A previous update changed filenames to match actual pixel dimensions (e.g., `icon-68x72.png`) but never renamed the files, breaking all 8 icon references
   - Declared standard sizes matching the filenames

## Why

- **Build was broken** — `npm run build` failed with a type error, blocking all development
- **PWA install was broken** — none of the 8 manifest icon paths resolved to actual files

## Evidence

- `npm run build` failed before this fix (TypeScript error on line 58 of twitter-image.tsx)
- `ls public/icons/` shows files named `icon-72x72.png`, `icon-96x96.png`, etc.
- `sips` confirms actual pixel dimensions are slightly non-standard (68×72, 91×96, etc.) but filenames use standard sizes

## Validation

- [x] `npm run build` — passes
- [x] `npm run lint` — 0 errors (36 pre-existing warnings)
- [x] No changes to routing, layouts, or i18n logic
- [x] Icon files verified to exist at the declared paths

## Risks

- Icon actual pixel dimensions are slightly smaller than declared sizes. This is cosmetic — browsers handle minor size mismatches gracefully. A follow-up could regenerate icons at exact standard dimensions.
- No functional risk from the type annotation change — it only makes the existing runtime behavior compile-safe.