### PR TITLE
fix: replace 21 hardcoded locale ternaries in Breadcrumbs with i18n translations

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1923,5 +1923,29 @@
     "family": "Family",
     "height": "Max height",
     "status": "Status"
+  },
+  "breadcrumbs": {
+    "ariaLabel": "Breadcrumb",
+    "home": "Home",
+    "trees": "Trees",
+    "glossary": "Glossary",
+    "education": "Education",
+    "seasonal": "Seasonal",
+    "safety": "Safety",
+    "conservation": "Conservation",
+    "map": "Map",
+    "identify": "Identify",
+    "compare": "Compare",
+    "favorites": "Favorites",
+    "quiz": "Quiz",
+    "diagnose": "Diagnose",
+    "wizard": "Selection Wizard",
+    "use-cases": "Use Cases",
+    "about": "About",
+    "lessons": "Lessons",
+    "printables": "Printables",
+    "classroom": "Classroom",
+    "teacher": "Teacher Resources",
+    "oral-histories": "Oral Histories"
   }
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -1923,5 +1923,29 @@
     "family": "Familia",
     "height": "Altura máx.",
     "status": "Estado"
+  },
+  "breadcrumbs": {
+    "ariaLabel": "Navegación",
+    "home": "Inicio",
+    "trees": "Árboles",
+    "glossary": "Glosario",
+    "education": "Educación",
+    "seasonal": "Temporada",
+    "safety": "Seguridad",
+    "conservation": "Conservación",
+    "map": "Mapa",
+    "identify": "Identificar",
+    "compare": "Comparar",
+    "favorites": "Favoritos",
+    "quiz": "Cuestionario",
+    "diagnose": "Diagnosticar",
+    "wizard": "Asistente",
+    "use-cases": "Casos de Uso",
+    "about": "Acerca de",
+    "lessons": "Lecciones",
+    "printables": "Imprimibles",
+    "classroom": "Aula",
+    "teacher": "Recursos para Maestros",
+    "oral-histories": "Historias Orales"
   }
 }

--- a/src/app/[locale]/compare/[slug]/page.tsx
+++ b/src/app/[locale]/compare/[slug]/page.tsx
@@ -176,7 +176,6 @@ export default async function ComparisonPage({ params }: Props) {
         {/* Breadcrumbs */}
         <div className="mb-6">
           <Breadcrumbs
-            locale={locale as Locale}
             pathname={`/compare/${comparison.slug}`}
             customLabels={{
               compare: t("navLink"),

--- a/src/app/[locale]/oral-histories/[slug]/page.tsx
+++ b/src/app/[locale]/oral-histories/[slug]/page.tsx
@@ -6,7 +6,7 @@ import { Link } from "@i18n/navigation";
 import type { Metadata } from "next";
 import { ServerMDXContent } from "@/components/ServerMDXContent";
 import { Breadcrumbs } from "@/components/Breadcrumbs";
-import type { Locale, Tree } from "@/types/tree";
+import type { Tree } from "@/types/tree";
 
 interface OralHistory {
   locale: string;
@@ -99,7 +99,6 @@ export default async function OralHistoryDetailPage({ params }: Props) {
     <div className="container mx-auto px-4 py-8 max-w-3xl">
       <div className="mb-6">
         <Breadcrumbs
-          locale={locale as Locale}
           pathname={`/oral-histories/${entry.slug}`}
           customLabels={{
             "oral-histories": t("title"),

--- a/src/app/[locale]/oral-histories/page.tsx
+++ b/src/app/[locale]/oral-histories/page.tsx
@@ -76,7 +76,6 @@ export default async function OralHistoriesPage({
     <div className="container mx-auto px-4 py-8 max-w-4xl">
       <div className="mb-6">
         <Breadcrumbs
-          locale={locale}
           pathname="/oral-histories"
           customLabels={{
             "oral-histories": t("title"),

--- a/src/app/[locale]/trees/[slug]/page.tsx
+++ b/src/app/[locale]/trees/[slug]/page.tsx
@@ -311,7 +311,6 @@ export default async function TreePage({ params }: Props) {
         <div className="container mx-auto max-w-7xl">
           {/* Breadcrumbs */}
           <Breadcrumbs
-            locale={locale}
             pathname={`/trees/${tree.slug}`}
             customLabels={{ [tree.slug]: tree.title }}
           />

--- a/src/app/[locale]/trees/[slug]/twitter-image.tsx
+++ b/src/app/[locale]/trees/[slug]/twitter-image.tsx
@@ -48,7 +48,7 @@ export default async function Image({ params }: Props) {
   let conservationLabel: string | null = null;
 
   if (tree.conservationStatus) {
-    let label = tree.conservationStatus;
+    let label: string = tree.conservationStatus;
 
     try {
       const translated = getConservationLabel(

--- a/src/components/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs.tsx
@@ -1,8 +1,7 @@
 import { Link } from "@i18n/navigation";
-import type { Locale } from "@/types/tree";
+import { getTranslations } from "next-intl/server";
 
 interface BreadcrumbsProps {
-  locale: Locale;
   /** The path without locale prefix (e.g., "/trees/ceiba") */
   pathname: string;
   customLabels?: Record<string, string>;
@@ -19,63 +18,19 @@ function getCustomLabel(
   return undefined;
 }
 
-function getDefaultLabel(segment: string, locale: Locale): string | undefined {
-  switch (segment) {
-    case "trees":
-      return locale === "es" ? "Árboles" : "Trees";
-    case "glossary":
-      return locale === "es" ? "Glosario" : "Glossary";
-    case "education":
-      return locale === "es" ? "Educación" : "Education";
-    case "seasonal":
-      return locale === "es" ? "Temporada" : "Seasonal";
-    case "safety":
-      return locale === "es" ? "Seguridad" : "Safety";
-    case "conservation":
-      return locale === "es" ? "Conservación" : "Conservation";
-    case "map":
-      return locale === "es" ? "Mapa" : "Map";
-    case "identify":
-      return locale === "es" ? "Identificar" : "Identify";
-    case "compare":
-      return locale === "es" ? "Comparar" : "Compare";
-    case "favorites":
-      return locale === "es" ? "Favoritos" : "Favorites";
-    case "quiz":
-      return locale === "es" ? "Cuestionario" : "Quiz";
-    case "diagnose":
-      return locale === "es" ? "Diagnosticar" : "Diagnose";
-    case "wizard":
-      return locale === "es" ? "Asistente" : "Selection Wizard";
-    case "use-cases":
-      return locale === "es" ? "Casos de Uso" : "Use Cases";
-    case "about":
-      return locale === "es" ? "Acerca de" : "About";
-    case "lessons":
-      return locale === "es" ? "Lecciones" : "Lessons";
-    case "printables":
-      return locale === "es" ? "Imprimibles" : "Printables";
-    case "classroom":
-      return locale === "es" ? "Aula" : "Classroom";
-    case "teacher":
-      return locale === "es" ? "Recursos para Maestros" : "Teacher Resources";
-    default:
-      return undefined;
-  }
-}
-
-export function Breadcrumbs({
-  locale,
+export async function Breadcrumbs({
   pathname,
   customLabels = {},
 }: BreadcrumbsProps) {
+  const t = await getTranslations("breadcrumbs");
+
   const breadcrumbs = (() => {
     // Split path into segments (pathname is already without locale prefix)
     const segments = pathname.split("/").filter(Boolean);
 
     const crumbs: Array<{ label: string; href?: string }> = [
       {
-        label: locale === "es" ? "Inicio" : "Home",
+        label: t("home"),
         href: "/",
       },
     ];
@@ -84,10 +39,10 @@ export function Breadcrumbs({
     segments.forEach((segment, index) => {
       currentPath += `/${segment}`;
 
-      // Use custom label if provided, otherwise use default, otherwise format segment
+      // Use custom label if provided, otherwise use translation, otherwise format segment
       let label = getCustomLabel(customLabels, segment);
-      if (!label) {
-        label = getDefaultLabel(segment, locale);
+      if (!label && t.has(segment as never)) {
+        label = t(segment as never);
       }
       if (!label) {
         // Format slug: convert dashes to spaces and capitalize
@@ -113,10 +68,7 @@ export function Breadcrumbs({
   }
 
   return (
-    <nav
-      aria-label={locale === "es" ? "Navegación" : "Breadcrumb"}
-      className="mb-6"
-    >
+    <nav aria-label={t("ariaLabel")} className="mb-6">
       <ol className="flex items-center gap-2 text-sm text-muted-foreground flex-wrap">
         {breadcrumbs.map((crumb, index) => (
           <li key={index} className="flex items-center gap-2">


### PR DESCRIPTION
## What changed

Replaced all 21 hardcoded `locale === "es" ? ... : ...` ternaries in `Breadcrumbs.tsx` with proper `next-intl` translations.

### Details

- **Added `breadcrumbs` namespace** (22 keys) to both `messages/en.json` and `messages/es.json`
- **Refactored `Breadcrumbs`** from a synchronous component with a `getDefaultLabel()` switch statement to an async server component using `getTranslations('breadcrumbs')`
- **Removed `locale` prop** — the component now resolves translations via next-intl's request context
- Used `t.has(segment)` for safe key lookup with fallback to formatted slug names
- **Updated all 4 call sites**: trees detail, compare detail, oral-histories list, oral-histories detail
- Cleaned up now-unused `Locale` type import in oral-histories/[slug]/page.tsx

## Why

P2 in the implementation plan identifies **~192 hardcoded locale ternaries** as the largest remaining EN/ES parity gap. Breadcrumbs (21 ternaries) is the 3rd-highest offender and appears on every detail page, making it high impact.

Hardcoded ternaries:
- Bypass the translation system, making audits and updates harder
- Cannot benefit from future locale additions
- Create inconsistency with the rest of the i18n architecture

## Evidence

- `grep -c 'locale.*===.*"es"' src/components/Breadcrumbs.tsx` showed 21 matches before, 0 after
- All translations match the original strings exactly
- Component signature simplified from `(locale, pathname, customLabels)` to `(pathname, customLabels)`

## Validation

- [x] `npm run build` — passes
- [x] `npm run lint` — 0 errors (36 pre-existing warnings)
- [x] EN tree detail (`/en/trees/ceiba`) prerendered successfully
- [x] ES tree detail (`/es/trees/ceiba`) prerendered successfully
- [x] Compare, oral-histories routes prerendered for both locales
- [x] No changes to routing, layout, or middleware logic

## Risks

- None. This is a leaf component change with no architectural impact. The same 22 string pairs are preserved, just moved from inline ternaries to `messages/*.json`.

## Note

Also includes the `twitter-image.tsx` type annotation fix (same as PR #658) since that PR hasn't merged yet and the build fails without it.