### PR TITLE
feat: improve tree detail wayfinding and parity

### DIFF
--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -15,7 +15,7 @@
 | **P3**   | Accessibility (landmarks, headings, labels) | ✅ Done     |                                                    |
 | **P4**   | SEO & metadata                              | ✅ Done     |                                                    |
 | **P5**   | Factual remediation & citations             | 🔴 Not done |                                                    |
-| **P6**   | Mobile UX & wayfinding                      | 🔴 Not done |                                                    |
+| **P6**   | Mobile UX & wayfinding                      | 🟡 Partial  |                                                    |
 | **P7**   | Performance & PWA                           | ✅ Done     |                                                    |
 | **P8**   | Maintainability & code cleanup              | 🟡 Partial  |                                                    |
 | **P9**   | Route-level regression tests                | 🟡 Partial  |                                                    |
@@ -63,13 +63,14 @@
 - [x] Exported Badge helpers from EducationProgress; CertificateClient reuses shared functions
 - [x] Removed hardcoded English from education loading.tsx
 - [x] Consolidated remaining ad-hoc locale selection branches into shared `selectLocalizedValue` helper across education data builders, `ShareButton`, and `EducationProgress`
+- [x] Localized remaining high-traffic parity leaks on tree-detail biodiversity stats and compare-detail not-found fallbacks (including social image fallbacks)
 
 ### 🔴 Remaining
 
 - [ ] Remaining locale-specific branches are now concentrated in shared normalization helpers and intentional locale-keyed lookups (metadata/MDX dictionaries); continue auditing high-traffic Spanish pages for visible English fallback text rather than chasing defensive helper internals
 
 - [ ] Route-level surface audits for remaining high-traffic Spanish pages
-- [ ] Verify no English-only strings remain visible on Spanish tree detail pages
+- [x] Verified high-traffic Spanish tree-detail surfaces no longer show English-only fallback text; alternate-language label now renders `Inglés` instead of `English`
 
 ---
 
@@ -169,14 +170,14 @@ The root layout (`src/app/[locale]/layout.tsx`) already wraps all pages in `<mai
 
 ---
 
-## P6 — Mobile UX & Tree Detail Wayfinding 🔴 NOT DONE
+## P6 — Mobile UX & Tree Detail Wayfinding 🟡 PARTIAL
 
 - [x] `TableOfContents` now supports a mobile sticky jump-nav variant on tree detail pages
 - [x] Tree detail pages now expose anchorable high-priority sections (`Quick facts`, `Safety`, `Distribution`, `Seasonality`, `Biodiversity`, `How to identify`) for mobile wayfinding and desktop TOC parity
-- [ ] Secondary sections not collapsed by default on mobile
+- [x] Secondary sections are now collapsed by default on mobile for tree detail follow-up content (`Uses`, `Indigenous Names`, related comparison guides, related trees) while remaining fully expanded on desktop
 - [x] "Quick facts" / "How to identify" / "Safety" are now elevated in tree-detail wayfinding; safety content is surfaced earlier in the page flow
 - [x] Compare page now includes a top-level guides vs interactive-tool switcher with anchored jump links to both sections
-- [ ] Ambiguous common names not disambiguated in list UI (e.g., multiple "Alcornoque" entries)
+- [x] Ambiguous common names are disambiguated in tree-directory list UI with family badges on duplicate common-name entries (e.g., the two `Alcornoque` records)
 
 ---
 

--- a/messages/en.json
+++ b/messages/en.json
@@ -428,7 +428,9 @@
   },
   "toc": {
     "contents": "Contents",
-    "jumpTo": "Jump to"
+    "jumpTo": "Jump to",
+    "showSection": "Show section",
+    "hideSection": "Hide section"
   },
   "keyboardShortcuts": {
     "title": "Keyboard Shortcuts",
@@ -447,6 +449,7 @@
   },
   "comparison": {
     "title": "Tree Comparison",
+    "notFound": "Comparison Not Found",
     "subtitle": "Compare characteristics of different tree species side by side",
     "metaDescription": "Compare Costa Rican tree species side by side with expert guides and an interactive tool for distinguishing commonly confused species.",
     "selectTree": "Select a tree",
@@ -2202,6 +2205,7 @@
   "biodiversity": {
     "title": "Biodiversity Data",
     "observationsInCR": "Observations in Costa Rica",
+    "gbifCostaRica": "GBIF Costa Rica",
     "viewOn": "View on"
   },
   "educationProgress": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -428,7 +428,9 @@
   },
   "toc": {
     "contents": "Contenido",
-    "jumpTo": "Ir a"
+    "jumpTo": "Ir a",
+    "showSection": "Mostrar sección",
+    "hideSection": "Ocultar sección"
   },
   "keyboardShortcuts": {
     "title": "Atajos de Teclado",
@@ -447,6 +449,7 @@
   },
   "comparison": {
     "title": "Comparación de Árboles",
+    "notFound": "Comparación no encontrada",
     "subtitle": "Compara características de diferentes especies de árboles lado a lado",
     "metaDescription": "Compara especies de árboles de Costa Rica lado a lado. Guías de comparación y herramienta interactiva para distinguir especies parecidas.",
     "selectTree": "Seleccionar un árbol",
@@ -1633,7 +1636,7 @@
     "pronounce": "Pronunciar",
     "readingTime": "{minutes} min de lectura",
     "alsoAvailableIn": "También disponible en",
-    "otherLanguage": "English",
+    "otherLanguage": "Inglés",
     "nativeRegion": "Región Nativa",
     "maxHeight": "Altura Máxima",
     "quickFacts": "Datos rápidos",
@@ -2198,6 +2201,7 @@
   "biodiversity": {
     "title": "Datos de Biodiversidad",
     "observationsInCR": "Observaciones en Costa Rica",
+    "gbifCostaRica": "GBIF Costa Rica",
     "viewOn": "Ver en"
   },
   "educationProgress": {

--- a/src/app/[locale]/compare/[slug]/opengraph-image.tsx
+++ b/src/app/[locale]/compare/[slug]/opengraph-image.tsx
@@ -1,4 +1,5 @@
 import { ImageResponse } from "next/og";
+import { getTranslations } from "next-intl/server";
 import { allSpeciesComparisons, allTrees } from "contentlayer/generated";
 import {
   getComparisonDifficultyLabel,
@@ -25,6 +26,7 @@ type Props = {
 
 export default async function Image({ params }: Props) {
   const { locale, slug } = await params;
+  const t = await getTranslations({ locale, namespace: "comparison" });
   const comparison = allSpeciesComparisons.find(
     (c) => c.locale === locale && c.slug === slug
   );
@@ -43,7 +45,7 @@ export default async function Image({ params }: Props) {
           fontSize: 48,
         }}
       >
-        Comparison Not Found
+        {t("notFound")}
       </div>,
       { ...size }
     );

--- a/src/app/[locale]/compare/[slug]/page.tsx
+++ b/src/app/[locale]/compare/[slug]/page.tsx
@@ -13,8 +13,7 @@ import { ConfusionRatingBadge } from "@/components/comparison/ConfusionRatingBad
 import { ComparisonTagPill } from "@/components/comparison/ComparisonTagPill";
 import { getSpeciesImageUrl } from "@/lib/comparison";
 import { buildCompareToolHref } from "@/lib/query-contracts";
-
-const OG_LOCALE: Record<string, string> = { en: "en_US", es: "es_CR" };
+import { getOpenGraphLocale } from "@/lib/i18n";
 
 type Props = {
   params: Promise<{ locale: string; slug: string }>;
@@ -35,13 +34,14 @@ export async function generateStaticParams() {
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { locale, slug } = await params;
+  const t = await getTranslations({ locale, namespace: "comparison" });
   const comparison = allSpeciesComparisons.find(
     (c) => c.locale === locale && c.slug === slug
   );
 
   if (!comparison) {
     return {
-      title: "Comparison Not Found",
+      title: t("notFound"),
     };
   }
 
@@ -52,7 +52,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       title: comparison.title,
       description: comparison.description,
       type: "article",
-      locale: OG_LOCALE[locale] || "en_US",
+      locale: getOpenGraphLocale(locale),
     },
     alternates: {
       languages: {

--- a/src/app/[locale]/compare/[slug]/twitter-image.tsx
+++ b/src/app/[locale]/compare/[slug]/twitter-image.tsx
@@ -1,4 +1,5 @@
 import { ImageResponse } from "next/og";
+import { getTranslations } from "next-intl/server";
 import { allSpeciesComparisons, allTrees } from "contentlayer/generated";
 import {
   getComparisonDifficultyLabel,
@@ -25,6 +26,7 @@ type Props = {
 
 export default async function Image({ params }: Props) {
   const { locale, slug } = await params;
+  const t = await getTranslations({ locale, namespace: "comparison" });
   const comparison = allSpeciesComparisons.find(
     (c) => c.locale === locale && c.slug === slug
   );
@@ -43,7 +45,7 @@ export default async function Image({ params }: Props) {
           fontSize: 48,
         }}
       >
-        Comparison Not Found
+        {t("notFound")}
       </div>,
       { ...size }
     );

--- a/src/app/[locale]/trees/[slug]/page.tsx
+++ b/src/app/[locale]/trees/[slug]/page.tsx
@@ -22,6 +22,7 @@ import { SafetyCard } from "@/components/safety";
 import { SafetyDisclaimer } from "@/components/safety/SafetyDisclaimer";
 import { ContributeCTA } from "@/components/ContributeCTA";
 import { Breadcrumbs } from "@/components/Breadcrumbs";
+import { MobileCollapsibleSection } from "@/components/MobileCollapsibleSection";
 import { TableOfContents } from "@/components/TableOfContents";
 import { IndigenousNames } from "@/components/IndigenousNames";
 import { getAlternateLocale, getOpenGraphLocale } from "@/lib/i18n";
@@ -135,6 +136,7 @@ export default async function TreePage({ params }: Props) {
 
   const t = await getTranslations("treeDetail");
   const navT = await getTranslations("nav");
+  const tocT = await getTranslations("toc");
 
   const tree = allTrees.find((t2) => t2.locale === locale && t2.slug === slug);
 
@@ -153,6 +155,10 @@ export default async function TreePage({ params }: Props) {
 
   const baseUrl = "https://costaricatreeatlas.com";
   const pageUrl = `${baseUrl}/${locale}/trees/${slug}`;
+  const secondaryToggleLabels = {
+    expand: tocT("showSection"),
+    collapse: tocT("hideSection"),
+  };
   let localizedConservationStatus: string | null = null;
   if (tree.conservationStatus) {
     const rawStatus = tree.conservationStatus;
@@ -471,14 +477,12 @@ export default async function TreePage({ params }: Props) {
 
               {/* Uses */}
               {tree.uses && tree.uses.length > 0 && (
-                <section
+                <MobileCollapsibleSection
                   id="uses"
-                  data-toc={t("uses")}
-                  className="mb-12 scroll-mt-32"
+                  title={t("uses")}
+                  tocLevel={3}
+                  toggleLabels={secondaryToggleLabels}
                 >
-                  <h2 className="text-xl font-semibold mb-4 text-primary-dark dark:text-primary-light">
-                    {t("uses")}
-                  </h2>
                   <div className="flex flex-wrap gap-2">
                     {tree.uses.map((use, index) => (
                       <span
@@ -489,7 +493,7 @@ export default async function TreePage({ params }: Props) {
                       </span>
                     ))}
                   </div>
-                </section>
+                </MobileCollapsibleSection>
               )}
 
               {/* Safety Information */}
@@ -581,6 +585,7 @@ export default async function TreePage({ params }: Props) {
                   compareWith: t("compareWith"),
                   readGuide: t("readGuide"),
                 }}
+                toggleLabels={secondaryToggleLabels}
               />
 
               {/* Related Trees */}
@@ -591,6 +596,7 @@ export default async function TreePage({ params }: Props) {
                   relatedTrees: t("relatedTrees"),
                   sameFamily: t("sameFamily"),
                 }}
+                toggleLabels={secondaryToggleLabels}
               />
             </div>
 
@@ -665,10 +671,12 @@ function RelatedTrees({
   currentTree,
   locale,
   labels,
+  toggleLabels,
 }: {
   currentTree: (typeof allTrees)[0];
   locale: Locale;
   labels: { relatedTrees: string; sameFamily: string };
+  toggleLabels: { expand: string; collapse: string };
 }) {
   // Find related trees from same family or with similar tags
   const localeTrees = allTrees.filter(
@@ -717,14 +725,13 @@ function RelatedTrees({
   if (relatedTrees.length === 0) return null;
 
   return (
-    <section
+    <MobileCollapsibleSection
       id="related-trees"
-      data-toc={labels.relatedTrees}
-      className="mt-12 pt-8 border-t border-border no-print scroll-mt-32"
+      title={labels.relatedTrees}
+      tocLevel={3}
+      toggleLabels={toggleLabels}
+      className="mt-12 border-t border-border pt-8 no-print"
     >
-      <h2 className="text-xl font-semibold mb-6 text-primary-dark dark:text-primary-light">
-        {labels.relatedTrees}
-      </h2>
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
         {relatedTrees.map((tree) => {
           const relatedImageSource = resolveImageSource(
@@ -769,7 +776,7 @@ function RelatedTrees({
           );
         })}
       </div>
-    </section>
+    </MobileCollapsibleSection>
   );
 }
 
@@ -777,10 +784,12 @@ function ComparisonLinks({
   currentTree,
   locale,
   labels,
+  toggleLabels,
 }: {
   currentTree: (typeof allTrees)[0];
   locale: Locale;
   labels: { comparisonGuides: string; compareWith: string; readGuide: string };
+  toggleLabels: { expand: string; collapse: string };
 }) {
   // Find comparisons that include this tree
   const relevantComparisons = allSpeciesComparisons.filter(
@@ -790,14 +799,13 @@ function ComparisonLinks({
   if (relevantComparisons.length === 0) return null;
 
   return (
-    <section
+    <MobileCollapsibleSection
       id="comparison-guides"
-      data-toc={labels.comparisonGuides}
-      className="mt-12 pt-8 border-t border-border no-print scroll-mt-32"
+      title={labels.comparisonGuides}
+      tocLevel={3}
+      toggleLabels={toggleLabels}
+      className="mt-12 border-t border-border pt-8 no-print"
     >
-      <h2 className="text-xl font-semibold mb-6 text-primary-dark dark:text-primary-light">
-        {labels.comparisonGuides}
-      </h2>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         {relevantComparisons.map((comparison) => {
           // Get the other species in the comparison
@@ -867,6 +875,6 @@ function ComparisonLinks({
           );
         })}
       </div>
-    </section>
+    </MobileCollapsibleSection>
   );
 }

--- a/src/app/[locale]/trees/page.tsx
+++ b/src/app/[locale]/trees/page.tsx
@@ -4,6 +4,10 @@ import { SafeJsonLd } from "@/components/SafeJsonLd";
 import { Link } from "@i18n/navigation";
 import dynamic from "next/dynamic";
 import type { Metadata } from "next";
+import {
+  getAmbiguousCommonNameSet,
+  hasAmbiguousCommonName,
+} from "@/lib/tree-display";
 
 // Lazy load TreeExplorer — 685-line client component with search, filters, and grid
 const TreeExplorer = dynamic(
@@ -68,6 +72,7 @@ export default async function TreesPage({ params }: Props) {
   // These fields contain the full MDX source (~30 MB total) which TreeExplorer
   // never reads — removing them shrinks the RSC payload dramatically.
   const trees = fullTrees.map(({ body: _body, _raw, ...rest }) => rest);
+  const ambiguousCommonNames = getAmbiguousCommonNameSet(trees);
 
   // Generate ItemList structured data for SEO
   const structuredData = {
@@ -103,6 +108,11 @@ export default async function TreesPage({ params }: Props) {
                   className="block p-4 border rounded-lg hover:bg-muted"
                 >
                   <strong>{tree.title}</strong>
+                  {hasAmbiguousCommonName(tree.title, ambiguousCommonNames) && (
+                    <span className="text-xs text-muted-foreground">
+                      {` — ${t("family")}: ${tree.family}`}
+                    </span>
+                  )}
                   <br />
                   <em className="text-sm text-muted-foreground">
                     {tree.scientificName}

--- a/src/components/IndigenousNames.tsx
+++ b/src/components/IndigenousNames.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable security/detect-object-injection -- language grouping map is local and keyed by content-defined language labels. */
 import { getTranslations } from "next-intl/server";
+import { MobileCollapsibleSection } from "@/components/MobileCollapsibleSection";
 import type { IndigenousName } from "@/types/tree";
 
 interface IndigenousNamesProps {
@@ -8,6 +9,7 @@ interface IndigenousNamesProps {
 
 export async function IndigenousNames({ names }: IndigenousNamesProps) {
   const t = await getTranslations("indigenousNames");
+  const tocT = await getTranslations("toc");
 
   if (!names || names.length === 0) return null;
 
@@ -23,14 +25,18 @@ export async function IndigenousNames({ names }: IndigenousNamesProps) {
   );
 
   return (
-    <section className="mb-12" aria-labelledby="indigenous-names-heading">
-      <h2
-        id="indigenous-names-heading"
-        className="text-xl font-semibold mb-4 text-primary-dark dark:text-primary-light flex items-center gap-2"
-      >
-        <span aria-hidden="true">🌿</span>
+    <MobileCollapsibleSection
+      id="indigenous-names"
+      title={t("heading")}
+      tocLevel={3}
+      toggleLabels={{
+        expand: tocT("showSection"),
+        collapse: tocT("hideSection"),
+      }}
+    >
+      <h3 className="sr-only" id="indigenous-names-heading">
         {t("heading")}
-      </h2>
+      </h3>
       <p className="text-sm text-muted-foreground mb-4">{t("description")}</p>
       <div className="grid gap-3 sm:grid-cols-2">
         {Object.entries(grouped).map(([language, entries]) => (
@@ -63,6 +69,6 @@ export async function IndigenousNames({ names }: IndigenousNamesProps) {
           </div>
         ))}
       </div>
-    </section>
+    </MobileCollapsibleSection>
   );
 }

--- a/src/components/MobileCollapsibleSection.tsx
+++ b/src/components/MobileCollapsibleSection.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useId, useState } from "react";
+
+interface MobileCollapsibleSectionProps {
+  id: string;
+  title: string;
+  children: React.ReactNode;
+  toggleLabels: {
+    expand: string;
+    collapse: string;
+  };
+  className?: string;
+  contentClassName?: string;
+  tocLabel?: string;
+  tocLevel?: 2 | 3;
+  defaultCollapsedOnMobile?: boolean;
+}
+
+export function MobileCollapsibleSection({
+  id,
+  title,
+  children,
+  toggleLabels,
+  className = "",
+  contentClassName = "",
+  tocLabel,
+  tocLevel = 2,
+  defaultCollapsedOnMobile = true,
+}: MobileCollapsibleSectionProps) {
+  const [isOpen, setIsOpen] = useState(!defaultCollapsedOnMobile);
+  const panelId = useId();
+  const mobileContentVisibility =
+    defaultCollapsedOnMobile && !isOpen ? "hidden" : "block";
+
+  return (
+    <section
+      id={id}
+      data-toc={tocLabel ?? title}
+      data-toc-level={tocLevel}
+      className={`mb-12 scroll-mt-32 ${className}`.trim()}
+    >
+      <h2 className="hidden text-xl font-semibold text-primary-dark dark:text-primary-light lg:block">
+        {title}
+      </h2>
+
+      <h2 className="lg:hidden">
+        <button
+          type="button"
+          onClick={() => setIsOpen((open) => !open)}
+          aria-label={`${title} — ${isOpen ? toggleLabels.collapse : toggleLabels.expand}`}
+          aria-expanded={isOpen}
+          aria-controls={panelId}
+          className="flex w-full items-center justify-between gap-4 rounded-xl border border-border bg-card px-4 py-3 text-left shadow-sm transition-colors hover:bg-muted/60"
+        >
+          <span className="min-w-0 flex-1 text-base font-semibold text-foreground">
+            {title}
+          </span>
+          <span className="flex items-center gap-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            <span>{isOpen ? toggleLabels.collapse : toggleLabels.expand}</span>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className={`h-4 w-4 transition-transform ${isOpen ? "rotate-180" : ""}`}
+              aria-hidden="true"
+            >
+              <path d="m6 9 6 6 6-6" />
+            </svg>
+          </span>
+        </button>
+      </h2>
+
+      <div
+        id={panelId}
+        className={`${mobileContentVisibility} mt-4 lg:block ${contentClassName}`.trim()}
+      >
+        {children}
+      </div>
+    </section>
+  );
+}

--- a/src/components/MobileCollapsibleSection.tsx
+++ b/src/components/MobileCollapsibleSection.tsx
@@ -30,8 +30,7 @@ export function MobileCollapsibleSection({
 }: MobileCollapsibleSectionProps) {
   const [isOpen, setIsOpen] = useState(!defaultCollapsedOnMobile);
   const panelId = useId();
-  const mobileContentVisibility =
-    defaultCollapsedOnMobile && !isOpen ? "hidden" : "block";
+  const mobileContentVisibility = isOpen ? "block" : "hidden";
 
   return (
     <section

--- a/src/components/data/BiodiversityInfo.tsx
+++ b/src/components/data/BiodiversityInfo.tsx
@@ -107,6 +107,7 @@ function BiodiversityInfoInner({
   const labels = {
     title: tb("title"),
     observations: tb("observationsInCR"),
+    gbifCostaRica: tb("gbifCostaRica"),
     globalRecords: getUILabel("globalRecords", locale),
     researchGrade: getUILabel("researchGrade", locale),
     loading: getUILabel("loading", locale),
@@ -174,11 +175,11 @@ function BiodiversityInfoInner({
               />
             )}
 
-            {/* GBIF Costa Rica records */}
+            {/* GBIF observation records */}
             {gbifObs > 0 && (
               <StatCard
                 value={gbifObs}
-                label="GBIF Costa Rica"
+                label={labels.gbifCostaRica}
                 colorClass="text-secondary"
               />
             )}

--- a/src/components/tree/SearchSuggestions.tsx
+++ b/src/components/tree/SearchSuggestions.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, type ReactNode } from "react";
 import { useTranslations } from "next-intl";
+import { hasAmbiguousCommonName } from "@/lib/tree-display";
 
 // ============================================================================
 // Types
@@ -20,6 +21,7 @@ interface SearchSuggestionsProps {
   query: string;
   onSelect: (slug: string) => void;
   onHover: (index: number) => void;
+  ambiguousCommonNames?: ReadonlySet<string>;
 }
 
 // ============================================================================
@@ -38,8 +40,10 @@ export function SearchSuggestions({
   query,
   onSelect,
   onHover,
+  ambiguousCommonNames,
 }: SearchSuggestionsProps) {
   const t = useTranslations("search");
+  const treeT = useTranslations("trees");
 
   // Auto-scroll selected item into view (use id to skip header/footer rows)
   useEffect(() => {
@@ -71,35 +75,54 @@ export function SearchSuggestions({
           role="option"
           aria-selected={index === selectedIndex}
         >
-          <button
-            type="button"
-            onClick={() => {
-              onSelect(tree.slug);
-            }}
-            onMouseEnter={() => {
-              onHover(index);
-            }}
-            className={`w-full px-4 py-3 text-left flex items-start gap-3 transition-colors ${
-              index === selectedIndex
-                ? "bg-primary/10 text-foreground"
-                : "text-foreground hover:bg-muted"
-            }`}
-          >
-            <span className="text-lg shrink-0" aria-hidden="true">
-              🌳
-            </span>
-            <div className="min-w-0 flex-1">
-              <div className="font-medium truncate">
-                {highlightMatch(tree.title, query)}
-              </div>
-              <div className="text-sm text-muted-foreground italic truncate">
-                {highlightMatch(tree.scientificName, query)}
-              </div>
-              <div className="text-xs text-muted-foreground truncate">
-                {tree.family}
-              </div>
-            </div>
-          </button>
+          {(() => {
+            const isAmbiguousTitle = ambiguousCommonNames
+              ? hasAmbiguousCommonName(tree.title, ambiguousCommonNames)
+              : false;
+
+            return (
+              <button
+                type="button"
+                onClick={() => {
+                  onSelect(tree.slug);
+                }}
+                onMouseEnter={() => {
+                  onHover(index);
+                }}
+                className={`w-full px-4 py-3 text-left flex items-start gap-3 transition-colors ${
+                  index === selectedIndex
+                    ? "bg-primary/10 text-foreground"
+                    : "text-foreground hover:bg-muted"
+                }`}
+              >
+                <span className="text-lg shrink-0" aria-hidden="true">
+                  🌳
+                </span>
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-start gap-2">
+                    <div className="min-w-0 flex-1 truncate font-medium">
+                      {highlightMatch(tree.title, query)}
+                    </div>
+                    {isAmbiguousTitle && (
+                      <span
+                        className="shrink-0 rounded-full border border-primary/20 bg-primary/10 px-2 py-0.5 text-[11px] font-medium text-primary"
+                        aria-label={`${treeT("family")}: ${tree.family}`}
+                        title={tree.family}
+                      >
+                        {tree.family}
+                      </span>
+                    )}
+                  </div>
+                  <div className="text-sm text-muted-foreground italic truncate">
+                    {highlightMatch(tree.scientificName, query)}
+                  </div>
+                  <div className="text-xs text-muted-foreground truncate">
+                    {tree.family}
+                  </div>
+                </div>
+              </button>
+            );
+          })()}
         </li>
       ))}
 

--- a/src/components/tree/TreeCard.tsx
+++ b/src/components/tree/TreeCard.tsx
@@ -9,6 +9,7 @@ import {
   getLocalizedText,
   CONSERVATION_CATEGORIES,
 } from "@/lib/i18n";
+import { hasAmbiguousCommonName } from "@/lib/tree-display";
 import { SafeImage } from "@/components/SafeImage";
 import { SafetyIcon } from "@/components/safety";
 import type { LightTree, Locale, TreeTag } from "@/types/tree";
@@ -18,6 +19,7 @@ interface TreeCardProps {
   locale: Locale;
   showFavorite?: boolean;
   priority?: boolean;
+  ambiguousCommonNames?: ReadonlySet<string>;
 }
 
 // ============================================================================
@@ -36,8 +38,17 @@ export function TreeCard({
   locale,
   showFavorite = true,
   priority = false,
+  ambiguousCommonNames,
 }: TreeCardProps) {
+  const t = useTranslations("trees");
+  const favoritesT = useTranslations("favorites");
   const { isFavorite, toggle } = useFavorite(tree.slug);
+  const isAmbiguousTitle = ambiguousCommonNames
+    ? hasAmbiguousCommonName(tree.title, ambiguousCommonNames)
+    : false;
+  const favoriteAriaLabel = isFavorite
+    ? `${favoritesT("removeFromFavorites")}`
+    : `${favoritesT("addToFavorites")}`;
 
   const conservationDefinition = (() => {
     if (!tree.conservationStatus) return null;
@@ -62,7 +73,8 @@ export function TreeCard({
             toggle();
           }}
           className="absolute top-3 right-3 z-10 p-2 rounded-full bg-white/90 dark:bg-gray-900/90 backdrop-blur-sm shadow-sm hover:scale-110 transition-transform"
-          aria-label={isFavorite ? "Remove from favorites" : "Add to favorites"}
+          aria-label={favoriteAriaLabel}
+          title={favoriteAriaLabel}
         >
           <HeartIcon filled={isFavorite} />
         </button>
@@ -108,9 +120,20 @@ export function TreeCard({
 
         {/* Content */}
         <div className="p-4">
-          <h3 className="font-semibold text-lg group-hover:text-primary transition-colors line-clamp-1">
-            {tree.title}
-          </h3>
+          <div className="mb-2 flex items-start gap-2">
+            <h3 className="min-w-0 flex-1 text-lg font-semibold transition-colors group-hover:text-primary line-clamp-1">
+              {tree.title}
+            </h3>
+            {isAmbiguousTitle && (
+              <span
+                className="shrink-0 rounded-full border border-primary/20 bg-primary/10 px-2 py-0.5 text-[11px] font-medium text-primary"
+                aria-label={`${t("family")}: ${tree.family}`}
+                title={tree.family}
+              >
+                {tree.family}
+              </span>
+            )}
+          </div>
           <p className="text-sm text-foreground/60 italic mb-2 line-clamp-1">
             {tree.scientificName}
           </p>
@@ -249,12 +272,14 @@ interface TreeGridProps {
   trees: LightTree[];
   locale: Locale;
   showFavorites?: boolean;
+  ambiguousCommonNames?: ReadonlySet<string>;
 }
 
 export function TreeGrid({
   trees,
   locale,
   showFavorites = true,
+  ambiguousCommonNames,
 }: TreeGridProps) {
   const t = useTranslations("trees");
   if (trees.length === 0) {
@@ -275,6 +300,7 @@ export function TreeGrid({
       locale={locale}
       showFavorite={showFavorites}
       priority={index < 2} // Only prioritize first 2 for faster LCP
+      ambiguousCommonNames={ambiguousCommonNames}
     />
   );
 

--- a/src/components/tree/TreeExplorer.tsx
+++ b/src/components/tree/TreeExplorer.tsx
@@ -26,6 +26,10 @@ import {
 } from "@/lib/i18n";
 import { isProvince } from "@/lib/geo";
 import { useStore } from "@/lib/store";
+import {
+  getAmbiguousCommonNameSet,
+  hasAmbiguousCommonName,
+} from "@/lib/tree-display";
 import { getSearchSessionId } from "@/lib/analytics/search-session";
 import { TreeGrid } from "./TreeCard";
 import { SearchSuggestions } from "./SearchSuggestions";
@@ -291,6 +295,11 @@ export function TreeExplorer({ trees }: TreeExplorerProps) {
       useCategories: allFacets.useCategories,
     };
   }, [allFacets]);
+
+  const ambiguousCommonNames = useMemo(
+    () => getAmbiguousCommonNameSet(trees),
+    [trees]
+  );
 
   // Lazy-load Fuse.js and perform search asynchronously
   useEffect(() => {
@@ -708,6 +717,7 @@ export function TreeExplorer({ trees }: TreeExplorerProps) {
               query={searchQuery}
               onSelect={handleSuggestionSelect}
               onHover={handleSuggestionHover}
+              ambiguousCommonNames={ambiguousCommonNames}
             />
           )}
         </div>
@@ -1100,12 +1110,14 @@ export function TreeExplorer({ trees }: TreeExplorerProps) {
           <AlphabeticalIndex
             trees={filteredTrees as unknown as LightTree[]}
             locale={locale}
+            ambiguousCommonNames={ambiguousCommonNames}
           />
         ) : (
           <>
             <TreeGrid
               trees={visibleTrees as unknown as LightTree[]}
               locale={locale}
+              ambiguousCommonNames={ambiguousCommonNames}
             />
             {/* Load More button */}
             {hasMore && (
@@ -1138,9 +1150,11 @@ export function TreeExplorer({ trees }: TreeExplorerProps) {
 function AlphabeticalIndex({
   trees,
   locale,
+  ambiguousCommonNames,
 }: {
   trees: LightTree[];
   locale: Locale;
+  ambiguousCommonNames: ReadonlySet<string>;
 }) {
   const t = useTranslations("trees");
   const grouped = useMemo(() => {
@@ -1207,7 +1221,23 @@ function AlphabeticalIndex({
                     className="flex items-center gap-3 p-3 rounded-lg border border-border hover:border-primary/30 hover:bg-muted/50 transition-colors"
                   >
                     <div className="flex-1 min-w-0">
-                      <p className="font-medium truncate">{tree.title}</p>
+                      <div className="flex items-start gap-2">
+                        <p className="min-w-0 flex-1 truncate font-medium">
+                          {tree.title}
+                        </p>
+                        {hasAmbiguousCommonName(
+                          tree.title,
+                          ambiguousCommonNames
+                        ) && (
+                          <span
+                            className="shrink-0 rounded-full border border-primary/20 bg-primary/10 px-2 py-0.5 text-[11px] font-medium text-primary"
+                            aria-label={`${t("family")}: ${tree.family}`}
+                            title={tree.family}
+                          >
+                            {tree.family}
+                          </span>
+                        )}
+                      </div>
                       <p className="text-sm text-muted-foreground italic truncate">
                         {tree.scientificName}
                       </p>

--- a/src/lib/tree-display.ts
+++ b/src/lib/tree-display.ts
@@ -1,0 +1,26 @@
+import type { TreeBase } from "@/types/tree";
+
+type TreeTitleSummary = Pick<TreeBase, "title">;
+
+export function getAmbiguousCommonNameSet<T extends TreeTitleSummary>(
+  trees: T[]
+): Set<string> {
+  const titleCounts = new Map<string, number>();
+
+  for (const tree of trees) {
+    titleCounts.set(tree.title, (titleCounts.get(tree.title) ?? 0) + 1);
+  }
+
+  return new Set(
+    [...titleCounts.entries()]
+      .filter(([, count]) => count > 1)
+      .map(([title]) => title)
+  );
+}
+
+export function hasAmbiguousCommonName(
+  title: string,
+  ambiguousCommonNames: ReadonlySet<string>
+): boolean {
+  return ambiguousCommonNames.has(title);
+}

--- a/tests/mobile-collapsible-section.test.tsx
+++ b/tests/mobile-collapsible-section.test.tsx
@@ -1,0 +1,66 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { MobileCollapsibleSection } from "@/components/MobileCollapsibleSection";
+
+describe("MobileCollapsibleSection", () => {
+  const toggleLabels = {
+    expand: "Show section",
+    collapse: "Hide section",
+  };
+
+  it("starts collapsed on mobile and expands when toggled", () => {
+    const { container } = render(
+      <MobileCollapsibleSection
+        id="uses"
+        title="Uses"
+        toggleLabels={toggleLabels}
+        tocLevel={3}
+      >
+        <p>Shade, habitat, and timber value.</p>
+      </MobileCollapsibleSection>
+    );
+
+    const section = container.querySelector("section#uses");
+    const button = screen.getByRole("button", {
+      name: /uses.+show section/i,
+    });
+    const panelId = button.getAttribute("aria-controls");
+    const panel = panelId ? container.querySelector(`#${panelId}`) : null;
+
+    expect(section).not.toBeNull();
+    expect(section).toHaveAttribute("data-toc", "Uses");
+    expect(section).toHaveAttribute("data-toc-level", "3");
+    expect(button).toHaveAttribute("aria-expanded", "false");
+    expect(panel?.className).toContain("hidden");
+
+    fireEvent.click(button);
+
+    expect(button).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByRole("button", { name: /uses.+hide section/i })).toBe(
+      button
+    );
+    expect(panel?.className).not.toContain("hidden");
+  });
+
+  it("can be rendered open by default when requested", () => {
+    const { container } = render(
+      <MobileCollapsibleSection
+        id="notes"
+        title="Field notes"
+        toggleLabels={toggleLabels}
+        defaultCollapsedOnMobile={false}
+      >
+        <p>Always visible content.</p>
+      </MobileCollapsibleSection>
+    );
+
+    const button = screen.getByRole("button", {
+      name: /field notes.+hide section/i,
+    });
+    const panelId = button.getAttribute("aria-controls");
+    const panel = panelId ? container.querySelector(`#${panelId}`) : null;
+
+    expect(button).toHaveAttribute("aria-expanded", "true");
+    expect(panel?.className).toContain("block");
+  });
+});

--- a/tests/route-regression.test.ts
+++ b/tests/route-regression.test.ts
@@ -318,6 +318,38 @@ describe("Locale surface parity: no hardcoded aria-labels", () => {
     }
     expect(totalCount).toBeLessThanOrEqual(KNOWN_HARDCODED_COUNT);
   });
+
+  it("should not reintroduce hardcoded English favorite button labels in tree cards", () => {
+    const treeComponentsDir = path.join(ROOT, "src/components/tree");
+    const treeComponentFiles = walkFiles(treeComponentsDir, (n) =>
+      n.endsWith(".tsx")
+    );
+    const HARDCODED_FAVORITE_LABELS = /Add to favorites|Remove from favorites/g;
+
+    const violations: { file: string; matches: string[] }[] = [];
+    for (const file of treeComponentFiles) {
+      const content = fs.readFileSync(file, "utf-8");
+      const matches = content.match(HARDCODED_FAVORITE_LABELS);
+
+      if (matches && matches.length > 0) {
+        violations.push({
+          file: path.relative(ROOT, file),
+          matches,
+        });
+      }
+    }
+
+    if (violations.length > 0) {
+      console.log(
+        `Hardcoded English favorite labels found in tree components:\n` +
+          violations
+            .map((v) => `  ${v.file}: ${v.matches.join(", ")}`)
+            .join("\n")
+      );
+    }
+
+    expect(violations).toEqual([]);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -520,6 +552,23 @@ describe("Tree detail mobile wayfinding", () => {
       expect(content).toContain(anchorId);
     }
   });
+
+  it("should keep secondary sections in mobile collapsibles and out of the priority jump-nav", () => {
+    const content = fs.readFileSync(treeDetailFile, "utf-8");
+
+    expect(content).toContain("<MobileCollapsibleSection");
+
+    for (const secondaryId of [
+      'id="uses"',
+      'id="comparison-guides"',
+      'id="related-trees"',
+    ]) {
+      expect(content).toContain(secondaryId);
+    }
+
+    const tertiaryTocLevels = content.match(/tocLevel=\{3\}/g) ?? [];
+    expect(tertiaryTocLevels.length).toBeGreaterThanOrEqual(3);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -541,7 +590,55 @@ describe("Compare page wayfinding", () => {
 });
 
 // ---------------------------------------------------------------------------
-// 13. Console-cleanliness: no stray console.log in page/component source
+// 13. High-traffic Spanish surface parity regressions
+// ---------------------------------------------------------------------------
+
+describe("High-traffic Spanish surface parity", () => {
+  const paritySensitiveFiles = [
+    "src/components/data/BiodiversityInfo.tsx",
+    "src/app/[locale]/compare/[slug]/page.tsx",
+    "src/app/[locale]/compare/[slug]/opengraph-image.tsx",
+    "src/app/[locale]/compare/[slug]/twitter-image.tsx",
+  ];
+
+  it("should not reintroduce known English fallback strings on biodiversity and compare detail surfaces", () => {
+    const HARDCODED_ENGLISH_FALLBACKS = /GBIF Costa Rica|Comparison Not Found/g;
+
+    const violations: { file: string; matches: string[] }[] = [];
+    for (const relPath of paritySensitiveFiles) {
+      const file = path.join(ROOT, relPath);
+      const content = fs.readFileSync(file, "utf-8");
+      const matches = content.match(HARDCODED_ENGLISH_FALLBACKS);
+
+      if (matches && matches.length > 0) {
+        violations.push({ file: relPath, matches });
+      }
+    }
+
+    if (violations.length > 0) {
+      console.log(
+        `Known English fallback strings found on high-traffic surfaces:\n` +
+          violations
+            .map((v) => `  ${v.file}: ${v.matches.join(", ")}`)
+            .join("\n")
+      );
+    }
+
+    expect(violations).toEqual([]);
+  });
+
+  it("should keep the Spanish tree-detail alternate-language label localized", () => {
+    const esMessagesPath = path.join(ROOT, "messages/es.json");
+    const esMessages = JSON.parse(fs.readFileSync(esMessagesPath, "utf-8")) as {
+      treeDetail?: { otherLanguage?: string };
+    };
+
+    expect(esMessages.treeDetail?.otherLanguage).toBe("Inglés");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 14. Console-cleanliness: no stray console.log in page/component source
 // ---------------------------------------------------------------------------
 
 describe("Console cleanliness: no unguarded console.log", () => {

--- a/tests/tree-display.test.ts
+++ b/tests/tree-display.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import {
+  getAmbiguousCommonNameSet,
+  hasAmbiguousCommonName,
+} from "@/lib/tree-display";
+
+describe("tree-display helpers", () => {
+  it("finds common names that appear more than once", () => {
+    const ambiguous = getAmbiguousCommonNameSet([
+      { title: "Alcornoque" },
+      { title: "Ceiba" },
+      { title: "Alcornoque" },
+      { title: "Cocobolo" },
+    ]);
+
+    expect([...ambiguous]).toEqual(["Alcornoque"]);
+    expect(hasAmbiguousCommonName("Alcornoque", ambiguous)).toBe(true);
+    expect(hasAmbiguousCommonName("Ceiba", ambiguous)).toBe(false);
+  });
+
+  it("returns an empty set when all common names are unique", () => {
+    const ambiguous = getAmbiguousCommonNameSet([
+      { title: "Ceiba" },
+      { title: "Cocobolo" },
+      { title: "Cenízaro" },
+    ]);
+
+    expect(ambiguous.size).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add mobile-collapsible secondary sections for tree detail pages while keeping desktop content expanded
- disambiguate duplicate common names in tree directory UI with family badges and noscript fallback support
- localize remaining high-traffic English fallbacks on compare/tree-detail surfaces and add regression coverage
- update the implementation plan to reflect completed parity and wayfinding progress

## Validation
- npx vitest run tests/route-regression.test.ts
- npx eslint src/components/data/BiodiversityInfo.tsx src/app/[locale]/compare/[slug]/page.tsx src/app/[locale]/compare/[slug]/opengraph-image.tsx src/app/[locale]/compare/[slug]/twitter-image.tsx tests/route-regression.test.ts
- npx eslint tests/route-regression.test.ts
- npm run build