### PR TITLE
fix: tighten Spanish parity and conservation status handling

### DIFF
--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -43,6 +43,7 @@
 - [x] Compare page title uses `t("title")` — no duplicate site suffix
 - [x] `PhotoUploadClient` fetches upload limits in `useEffect`; unused locale variable removed
 - [x] Shared control labels localized: `MobileNav`, `LanguageSwitcher`, `PrintButton`
+- [x] Conservation lesson status counts and endangered-tree list now use actual IUCN codes from content data (`CR`/`EN`/`VU`/etc.) instead of mismatched English labels
 
 ---
 
@@ -64,6 +65,9 @@
 - [x] Removed hardcoded English from education loading.tsx
 - [x] Consolidated remaining ad-hoc locale selection branches into shared `selectLocalizedValue` helper across education data builders, `ShareButton`, and `EducationProgress`
 - [x] Localized remaining high-traffic parity leaks on tree-detail biodiversity stats and compare-detail not-found fallbacks (including social image fallbacks)
+- [x] Localized education landing-page CTAs and printable-resource link; regression audit now guards those Spanish surfaces against English fallback copy
+- [x] Localized oral-history detail not-found metadata and added regression coverage so missing Spanish entries do not fall back to English page titles
+- [x] Localized remaining English helper copy in the interactive compare tool (`Clear all`, max-tree cap, remove-chip aria labels, overflow copy) and added regression coverage for its Spanish surface
 
 ### 🔴 Remaining
 
@@ -238,6 +242,7 @@ The root layout (`src/app/[locale]/layout.tsx`) already wraps all pages in `<mai
 - [x] Ad-hoc locale selection branch regression guard (baseline: 0 outside shared i18n helpers)
 - [x] Route family coverage test (verifies page.tsx exists for all major routes)
 - [x] Education data array-ternary regression guard (prevents re-introducing array-level ternaries)
+- [x] Conservation lesson regression guard verifies status aggregation and legend keys stay aligned with IUCN code-based content
 
 ---
 

--- a/messages/en.json
+++ b/messages/en.json
@@ -458,6 +458,9 @@
     "removeTree": "Remove",
     "noTreesSelected": "Select up to 4 trees to compare their characteristics",
     "clearAll": "Clear all",
+    "maxTreesReached": "Maximum {count} trees",
+    "removeSelectedTree": "Remove {treeTitle}",
+    "moreUses": "+{count} more",
     "navLink": "Compare",
     "comparisonModeSwitcher": "Ways to compare",
     "comparisonModeSubtitle": "Jump straight to curated guides or build your own side-by-side comparison.",
@@ -689,15 +692,18 @@
       "title": "Using the Atlas in Your Classroom",
       "explore": {
         "title": "Explore the Directory",
-        "description": "Browse trees by family, conservation status, or characteristics. Use the A-Z index for alphabetical exploration."
+        "description": "Browse trees by family, conservation status, or characteristics. Use the A-Z index for alphabetical exploration.",
+        "action": "Browse Trees"
       },
       "identify": {
         "title": "Try Tree Identification",
-        "description": "Take photos during field trips and use the identification feature to find matching species in the atlas."
+        "description": "Take photos during field trips and use the identification feature to find matching species in the atlas.",
+        "action": "Try Identification"
       },
       "compare": {
         "title": "Compare Species",
-        "description": "Use the comparison tool to display multiple trees side-by-side and analyze their differences."
+        "description": "Use the comparison tool to display multiple trees side-by-side and analyze their differences.",
+        "action": "Compare Trees"
       }
     },
     "interactive": {
@@ -1031,6 +1037,7 @@
     "title": "Oral Histories",
     "subtitle": "Traditional knowledge and stories from Costa Rica's indigenous communities",
     "description": "A collection of oral histories preserving the traditional ecological knowledge of Costa Rica's indigenous peoples about their native trees.",
+    "notFoundTitle": "Oral History Not Found",
     "narrator": "Narrator",
     "community": "Community",
     "region": "Region",

--- a/messages/es.json
+++ b/messages/es.json
@@ -458,6 +458,9 @@
     "removeTree": "Eliminar",
     "noTreesSelected": "Seleccione hasta 4 árboles para comparar sus características",
     "clearAll": "Limpiar todo",
+    "maxTreesReached": "Máximo {count} árboles",
+    "removeSelectedTree": "Eliminar {treeTitle}",
+    "moreUses": "+{count} más",
     "navLink": "Comparar",
     "comparisonModeSwitcher": "Formas de comparar",
     "comparisonModeSubtitle": "Ve directo a las guías curadas o arma tu propia comparación lado a lado.",
@@ -689,15 +692,18 @@
       "title": "Usando el Atlas en tu Aula",
       "explore": {
         "title": "Explora el Directorio",
-        "description": "Navega por árboles por familia, estado de conservación o características. Usa el índice A-Z para exploración alfabética."
+        "description": "Navega por árboles por familia, estado de conservación o características. Usa el índice A-Z para exploración alfabética.",
+        "action": "Explorar Árboles"
       },
       "identify": {
         "title": "Prueba la Identificación",
-        "description": "Toma fotos durante excursiones y usa la función de identificación para encontrar especies coincidentes en el atlas."
+        "description": "Toma fotos durante excursiones y usa la función de identificación para encontrar especies coincidentes en el atlas.",
+        "action": "Probar Identificación"
       },
       "compare": {
         "title": "Compara Especies",
-        "description": "Usa la herramienta de comparación para mostrar múltiples árboles lado a lado y analizar sus diferencias."
+        "description": "Usa la herramienta de comparación para mostrar múltiples árboles lado a lado y analizar sus diferencias.",
+        "action": "Comparar Árboles"
       }
     },
     "interactive": {
@@ -1027,6 +1033,7 @@
     "title": "Historias Orales",
     "subtitle": "Conocimiento tradicional e historias de las comunidades indígenas de Costa Rica",
     "description": "Una colección de historias orales que preservan el conocimiento ecológico tradicional de los pueblos indígenas de Costa Rica sobre sus árboles nativos.",
+    "notFoundTitle": "Historia Oral No Encontrada",
     "narrator": "Narrador",
     "community": "Comunidad",
     "region": "Región",

--- a/src/app/[locale]/compare/page.tsx
+++ b/src/app/[locale]/compare/page.tsx
@@ -124,9 +124,9 @@ function ComparePageClient({
     removeTree: t("removeTree"),
     clearAll: t("clearAll"),
     noTreesSelected: t("noTreesSelected"),
-    maxTreesReachedTemplate: t("maxTreesReached"),
-    removeSelectedTreeTemplate: t("removeSelectedTree"),
-    moreUsesTemplate: t("moreUses"),
+    maxTreesReachedTemplate: t.raw("maxTreesReached"),
+    removeSelectedTreeTemplate: t.raw("removeSelectedTree"),
+    moreUsesTemplate: t.raw("moreUses"),
     properties: {
       image: t("properties.image"),
       commonName: t("properties.commonName"),

--- a/src/app/[locale]/compare/page.tsx
+++ b/src/app/[locale]/compare/page.tsx
@@ -122,7 +122,11 @@ function ComparePageClient({
     selectPlaceholder: t("selectPlaceholder"),
     addTree: t("addTree"),
     removeTree: t("removeTree"),
+    clearAll: t("clearAll"),
     noTreesSelected: t("noTreesSelected"),
+    maxTreesReachedTemplate: t("maxTreesReached"),
+    removeSelectedTreeTemplate: t("removeSelectedTree"),
+    moreUsesTemplate: t("moreUses"),
     properties: {
       image: t("properties.image"),
       commonName: t("properties.commonName"),

--- a/src/app/[locale]/education/lessons/conservation/conservation-data.ts
+++ b/src/app/[locale]/education/lessons/conservation/conservation-data.ts
@@ -346,31 +346,31 @@ export function getConservationLessonData(
 
   const statusInfo: StatusInfo[] = [
     {
-      key: "Critically Endangered",
+      key: "CR",
       color: "bg-red-600",
       icon: "🔴",
       label: t("Critically Endangered", "En Peligro Crítico"),
     },
     {
-      key: "Endangered",
+      key: "EN",
       color: "bg-orange-500",
       icon: "🟠",
       label: t("Endangered", "En Peligro"),
     },
     {
-      key: "Vulnerable",
+      key: "VU",
       color: "bg-yellow-500",
       icon: "🟡",
       label: "Vulnerable",
     },
     {
-      key: "Near Threatened",
+      key: "NT",
       color: "bg-blue-400",
       icon: "🔵",
       label: t("Near Threatened", "Casi Amenazado"),
     },
     {
-      key: "Least Concern",
+      key: "LC",
       color: "bg-green-500",
       icon: "🟢",
       label: t("Least Concern", "Preocupación Menor"),

--- a/src/app/[locale]/education/lessons/conservation/page.tsx
+++ b/src/app/[locale]/education/lessons/conservation/page.tsx
@@ -52,7 +52,7 @@ export default async function ConservationPage({ params }: PageProps) {
   // Count trees by conservation status
   const statusCounts = trees.reduce(
     (acc, tree) => {
-      const status = tree.conservationStatus || "Not Evaluated";
+      const status = tree.conservationStatus || "NE";
       acc[status] = (acc[status] || 0) + 1;
       return acc;
     },
@@ -60,14 +60,7 @@ export default async function ConservationPage({ params }: PageProps) {
   );
 
   const endangeredTrees = trees.filter((t) =>
-    [
-      "Endangered",
-      "Critically Endangered",
-      "Vulnerable",
-      "En Peligro",
-      "En Peligro Crítico",
-      "Vulnerable",
-    ].includes(t.conservationStatus || "")
+    ["CR", "EN", "VU"].includes(t.conservationStatus || "")
   );
 
   // Build locale-specific lesson data on the server so it ships as RSC

--- a/src/app/[locale]/education/page.tsx
+++ b/src/app/[locale]/education/page.tsx
@@ -441,7 +441,7 @@ function EducationContent({ treeCount }: { treeCount: number }) {
               href="/education/printables"
               className="inline-flex items-center gap-2 text-sm text-primary hover:text-primary/80 font-medium"
             >
-              {t("printables.viewAll") || "View all printable resources"} →
+              {t("printables.viewAll")} →
             </Link>
           </div>
         </div>
@@ -466,7 +466,7 @@ function EducationContent({ treeCount }: { treeCount: number }) {
               {t("tips.explore.description")}
             </p>
             <div className="mt-3 text-primary text-sm font-medium group-hover:translate-x-1 transition-transform inline-flex items-center gap-1">
-              Browse Trees →
+              {t("tips.explore.action")} →
             </div>
           </Link>
           <Link
@@ -481,7 +481,7 @@ function EducationContent({ treeCount }: { treeCount: number }) {
               {t("tips.identify.description")}
             </p>
             <div className="mt-3 text-primary text-sm font-medium group-hover:translate-x-1 transition-transform inline-flex items-center gap-1">
-              Try Identify →
+              {t("tips.identify.action")} →
             </div>
           </Link>
           <Link
@@ -496,7 +496,7 @@ function EducationContent({ treeCount }: { treeCount: number }) {
               {t("tips.compare.description")}
             </p>
             <div className="mt-3 text-primary text-sm font-medium group-hover:translate-x-1 transition-transform inline-flex items-center gap-1">
-              Compare Trees →
+              {t("tips.compare.action")} →
             </div>
           </Link>
         </div>

--- a/src/app/[locale]/oral-histories/[slug]/page.tsx
+++ b/src/app/[locale]/oral-histories/[slug]/page.tsx
@@ -48,12 +48,13 @@ export async function generateStaticParams() {
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { locale, slug } = await params;
+  const t = await getTranslations({ locale, namespace: "oralHistories" });
   const entry = allOralHistories.find(
     (e: OralHistory) => e.locale === locale && e.slug === slug
   );
 
   if (!entry) {
-    return { title: "Not Found" };
+    return { title: t("notFoundTitle") };
   }
 
   return {

--- a/src/components/TreeComparison.tsx
+++ b/src/components/TreeComparison.tsx
@@ -37,12 +37,20 @@ interface TreeComparisonProps {
   };
 }
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 function formatTranslationTemplate(
   template: string,
   replacements: Record<string, string | number>
 ) {
   return Object.entries(replacements).reduce(
-    (formatted, [key, value]) => formatted.replace(`{${key}}`, String(value)),
+    (formatted, [key, value]) =>
+      formatted.replace(
+        new RegExp(`\\{${escapeRegExp(key)}\\}`, "g"),
+        String(value)
+      ),
     template
   );
 }

--- a/src/components/TreeComparison.tsx
+++ b/src/components/TreeComparison.tsx
@@ -18,7 +18,11 @@ interface TreeComparisonProps {
     selectPlaceholder: string;
     addTree: string;
     removeTree: string;
+    clearAll: string;
     noTreesSelected: string;
+    maxTreesReachedTemplate: string;
+    removeSelectedTreeTemplate: string;
+    moreUsesTemplate: string;
     properties: {
       image: string;
       commonName: string;
@@ -31,6 +35,16 @@ interface TreeComparisonProps {
       tags: string;
     };
   };
+}
+
+function formatTranslationTemplate(
+  template: string,
+  replacements: Record<string, string | number>
+) {
+  return Object.entries(replacements).reduce(
+    (formatted, [key, value]) => formatted.replace(`{${key}}`, String(value)),
+    template
+  );
 }
 
 export function TreeComparison({
@@ -104,7 +118,12 @@ export function TreeComparison({
             >
               <option value="" disabled>
                 {selectedSlugs.length >= maxTrees
-                  ? `Max ${maxTrees} trees`
+                  ? formatTranslationTemplate(
+                      translations.maxTreesReachedTemplate,
+                      {
+                        count: maxTrees,
+                      }
+                    )
                   : translations.selectPlaceholder}
               </option>
               {availableTrees.map((tree) => (
@@ -120,7 +139,7 @@ export function TreeComparison({
               onClick={clearAll}
               className="px-4 py-2 text-sm text-primary hover:text-primary-dark transition-colors"
             >
-              Clear all
+              {translations.clearAll}
             </button>
           )}
         </div>
@@ -139,7 +158,12 @@ export function TreeComparison({
                     removeTree(tree.slug);
                   }}
                   className="ml-1 hover:text-primary-dark"
-                  aria-label={`Remove ${tree.title}`}
+                  aria-label={formatTranslationTemplate(
+                    translations.removeSelectedTreeTemplate,
+                    {
+                      treeTitle: tree.title,
+                    }
+                  )}
                 >
                   <XIcon className="h-4 w-4" />
                 </button>
@@ -357,7 +381,12 @@ export function TreeComparison({
                         ))}
                         {tree.uses.length > 5 && (
                           <li className="text-muted-foreground text-xs">
-                            +{tree.uses.length - 5} more
+                            {formatTranslationTemplate(
+                              translations.moreUsesTemplate,
+                              {
+                                count: tree.uses.length - 5,
+                              }
+                            )}
                           </li>
                         )}
                       </ul>

--- a/tests/route-regression.test.ts
+++ b/tests/route-regression.test.ts
@@ -596,13 +596,17 @@ describe("Compare page wayfinding", () => {
 describe("High-traffic Spanish surface parity", () => {
   const paritySensitiveFiles = [
     "src/components/data/BiodiversityInfo.tsx",
+    "src/components/TreeComparison.tsx",
     "src/app/[locale]/compare/[slug]/page.tsx",
     "src/app/[locale]/compare/[slug]/opengraph-image.tsx",
     "src/app/[locale]/compare/[slug]/twitter-image.tsx",
+    "src/app/[locale]/education/page.tsx",
+    "src/app/[locale]/oral-histories/[slug]/page.tsx",
   ];
 
-  it("should not reintroduce known English fallback strings on biodiversity and compare detail surfaces", () => {
-    const HARDCODED_ENGLISH_FALLBACKS = /GBIF Costa Rica|Comparison Not Found/g;
+  it("should not reintroduce known English fallback strings on audited high-traffic Spanish surfaces", () => {
+    const HARDCODED_ENGLISH_FALLBACKS =
+      /GBIF Costa Rica|Comparison Not Found|View all printable resources|Browse Trees|Try Identify|Compare Trees|title: "Not Found"|Clear all|Max \$\{maxTrees\} trees|Remove \$\{tree\.title\}|\+\{tree\.uses\.length - 5\} more/g;
 
     const violations: { file: string; matches: string[] }[] = [];
     for (const relPath of paritySensitiveFiles) {
@@ -617,7 +621,7 @@ describe("High-traffic Spanish surface parity", () => {
 
     if (violations.length > 0) {
       console.log(
-        `Known English fallback strings found on high-traffic surfaces:\n` +
+        `Known English fallback strings found on audited high-traffic surfaces:\n` +
           violations
             .map((v) => `  ${v.file}: ${v.matches.join(", ")}`)
             .join("\n")
@@ -635,10 +639,144 @@ describe("High-traffic Spanish surface parity", () => {
 
     expect(esMessages.treeDetail?.otherLanguage).toBe("Inglés");
   });
+
+  it("should provide localized education CTA labels for both locales", () => {
+    const enMessagesPath = path.join(ROOT, "messages/en.json");
+    const esMessagesPath = path.join(ROOT, "messages/es.json");
+    const enMessages = JSON.parse(fs.readFileSync(enMessagesPath, "utf-8")) as {
+      education?: {
+        tips?: {
+          explore?: { action?: string };
+          identify?: { action?: string };
+          compare?: { action?: string };
+        };
+      };
+    };
+    const esMessages = JSON.parse(fs.readFileSync(esMessagesPath, "utf-8")) as {
+      education?: {
+        tips?: {
+          explore?: { action?: string };
+          identify?: { action?: string };
+          compare?: { action?: string };
+        };
+      };
+    };
+
+    expect(enMessages.education?.tips?.explore?.action).toBe("Browse Trees");
+    expect(enMessages.education?.tips?.identify?.action).toBe(
+      "Try Identification"
+    );
+    expect(enMessages.education?.tips?.compare?.action).toBe("Compare Trees");
+
+    expect(esMessages.education?.tips?.explore?.action).toBe(
+      "Explorar Árboles"
+    );
+    expect(esMessages.education?.tips?.identify?.action).toBe(
+      "Probar Identificación"
+    );
+    expect(esMessages.education?.tips?.compare?.action).toBe(
+      "Comparar Árboles"
+    );
+  });
+
+  it("should provide localized oral-history not-found metadata for both locales", () => {
+    const enMessagesPath = path.join(ROOT, "messages/en.json");
+    const esMessagesPath = path.join(ROOT, "messages/es.json");
+    const enMessages = JSON.parse(fs.readFileSync(enMessagesPath, "utf-8")) as {
+      oralHistories?: { notFoundTitle?: string };
+    };
+    const esMessages = JSON.parse(fs.readFileSync(esMessagesPath, "utf-8")) as {
+      oralHistories?: { notFoundTitle?: string };
+    };
+
+    expect(enMessages.oralHistories?.notFoundTitle).toBe(
+      "Oral History Not Found"
+    );
+    expect(esMessages.oralHistories?.notFoundTitle).toBe(
+      "Historia Oral No Encontrada"
+    );
+  });
+
+  it("should provide localized interactive comparison helper copy for both locales", () => {
+    const enMessagesPath = path.join(ROOT, "messages/en.json");
+    const esMessagesPath = path.join(ROOT, "messages/es.json");
+    const enMessages = JSON.parse(fs.readFileSync(enMessagesPath, "utf-8")) as {
+      comparison?: {
+        clearAll?: string;
+        maxTreesReached?: string;
+        removeSelectedTree?: string;
+        moreUses?: string;
+      };
+    };
+    const esMessages = JSON.parse(fs.readFileSync(esMessagesPath, "utf-8")) as {
+      comparison?: {
+        clearAll?: string;
+        maxTreesReached?: string;
+        removeSelectedTree?: string;
+        moreUses?: string;
+      };
+    };
+
+    expect(enMessages.comparison?.clearAll).toBe("Clear all");
+    expect(enMessages.comparison?.maxTreesReached).toBe(
+      "Maximum {count} trees"
+    );
+    expect(enMessages.comparison?.removeSelectedTree).toBe(
+      "Remove {treeTitle}"
+    );
+    expect(enMessages.comparison?.moreUses).toBe("+{count} more");
+
+    expect(esMessages.comparison?.clearAll).toBe("Limpiar todo");
+    expect(esMessages.comparison?.maxTreesReached).toBe(
+      "Máximo {count} árboles"
+    );
+    expect(esMessages.comparison?.removeSelectedTree).toBe(
+      "Eliminar {treeTitle}"
+    );
+    expect(esMessages.comparison?.moreUses).toBe("+{count} más");
+  });
 });
 
 // ---------------------------------------------------------------------------
-// 14. Console-cleanliness: no stray console.log in page/component source
+// 14. Conservation lesson status normalization
+// ---------------------------------------------------------------------------
+
+describe("Conservation lesson status normalization", () => {
+  const conservationLessonPage = path.join(
+    ROOT,
+    "src/app/[locale]/education/lessons/conservation/page.tsx"
+  );
+  const conservationLessonData = path.join(
+    ROOT,
+    "src/app/[locale]/education/lessons/conservation/conservation-data.ts"
+  );
+
+  it("should count conservation statuses using IUCN codes from content data", () => {
+    const content = fs.readFileSync(conservationLessonPage, "utf-8");
+
+    expect(content).toContain('tree.conservationStatus || "NE"');
+    expect(content).toContain('["CR", "EN", "VU"]');
+    expect(content).not.toContain('"Not Evaluated"');
+    expect(content).not.toContain('"Critically Endangered"');
+  });
+
+  it("should map lesson status legend entries to IUCN codes", () => {
+    const content = fs.readFileSync(conservationLessonData, "utf-8");
+
+    for (const statusKey of [
+      'key: "CR"',
+      'key: "EN"',
+      'key: "VU"',
+      'key: "NT"',
+      'key: "LC"',
+    ]) {
+      expect(content).toContain(statusKey);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 15. Console-cleanliness: no stray console.log in page/component source
 // ---------------------------------------------------------------------------
 
 describe("Console cleanliness: no unguarded console.log", () => {


### PR DESCRIPTION
## Summary
- localize remaining high-traffic Spanish fallback copy on education, oral history, and interactive comparison surfaces
- align conservation lesson status counting and legend keys with IUCN code-based content data
- expand route regression coverage and update the implementation plan to reflect the completed parity work

## Validation
- npm test -- --run tests/route-regression.test.ts
- npm run build