### PR TITLE
fix: resolve production audit via effect override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7867,9 +7867,9 @@
       }
     },
     "node_modules/effect": {
-      "version": "3.18.4",
-      "resolved": "https://registry.npmjs.org/effect/-/effect-3.18.4.tgz",
-      "integrity": "sha512-b1LXQJLe9D11wfnOKAk3PKxuqYshQ0Heez+y5pnkd3jLj1yx9QhM72zZ9uUrOQyNvrs2GZZd/3maL0ZV18YuDA==",
+      "version": "3.20.0",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-3.20.0.tgz",
+      "integrity": "sha512-qMLfDJscrNG8p/aw+IkT9W7fgj50Z4wG5bLBy0Txsxz8iUHjDIkOgO3SV0WZfnQbNG2VJYb0b+rDLMrhM4+Krw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
   "overrides": {
     "hono": "4.12.7",
     "@hono/node-server": "1.19.11",
-    "lodash": "4.17.23"
+    "lodash": "4.17.23",
+    "@prisma/config": {
+      "effect": "3.20.0"
+    }
   },
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary
- override Prisma's transitive `effect` dependency to the patched `3.20.0` release
- refresh `package-lock.json` so production installs resolve the non-vulnerable version
- keep the fix narrowly scoped instead of forcing a broader Prisma version change

## Verification
- npm audit --omit=dev --audit-level=high
- npm run lint
- npm run build