### PR TITLE
fix: localize remaining parity surfaces

### DIFF
--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -217,6 +217,11 @@ The root layout (`src/app/[locale]/layout.tsx`) already wraps all pages in `<mai
 - [x] Introduce shared route-shell primitives — `PageShell`, `PageHeader` components; use-cases page migrated
 - [x] Document the optional-dependency adapter pattern for future integrations (`docs/OPTIONAL_DEPENDENCY_ADAPTER_PATTERN.md`)
 - [x] Removed known baseline `console.log` debt from route/component source and tightened regression baseline to zero
+- [x] Removed stale slash-combined bilingual copy from the base `ErrorBoundary`; shared page/component wrappers now pass localized error message sets and regression coverage guards the shared boundary too
+- [x] Localized `ShareLink` default copy via the shared `share` namespace and extended the share-surface regression audit to cover translated link-copy labels
+- [x] Localized remaining API docs helper labels (rate-limit header descriptions, section labels, CTA link copy) and added regression coverage for those public developer surfaces
+- [x] Localized the admin image-proposals list/detail UI (metadata, filters, empty/error states, actions, and review labels) and added regression coverage for those locale-prefixed admin surfaces
+- [x] Localized the admin performance dashboard’s panel labels, rating chips, and metric descriptions; regression coverage now guards those locale-prefixed monitoring surfaces too
 
 ---
 

--- a/messages/en.json
+++ b/messages/en.json
@@ -1280,6 +1280,11 @@
     "authDesc": "Send an X-API-Key header issued by the maintainers, or call from an allowlisted IP. Unauthorized requests are rejected with HTTP 401.",
     "rateLimit": "Rate Limiting",
     "rateLimitDesc": "100 requests per minute per IP address. Rate limit headers are included in all responses.",
+    "rateLimitHeaders": {
+      "limit": "Maximum requests per window",
+      "remaining": "Remaining requests",
+      "reset": "Unix timestamp when the limit resets"
+    },
     "endpoints": "Endpoints",
     "tryIt": "Try it",
     "response": "Response",
@@ -1287,6 +1292,7 @@
     "required": "Required",
     "optional": "Optional",
     "example": "Example",
+    "githubIssues": "GitHub Issues",
     "trees": {
       "list": "List Trees",
       "listDesc": "Retrieve a paginated list of trees with optional filtering and sorting.",
@@ -1508,7 +1514,108 @@
       "tooltipClearVote": "Clear vote",
       "badgeNeedsPhoto": "Needs Photo",
       "badgeLocal": "Local",
-      "badgeExternal": "External"
+      "badgeExternal": "External",
+      "proposals": {
+        "pageTitle": "Image Proposals | Admin",
+        "heading": "📋 Image Proposals",
+        "description": "Review and manage proposed image changes from workflows and user flags.",
+        "backToImageReview": "← Back to Image Review",
+        "searchByTreeSlug": "Search by Tree Slug",
+        "searchPlaceholder": "e.g., ceiba, guanacaste",
+        "status": "Status",
+        "source": "Source",
+        "allStatuses": "All Statuses",
+        "allSources": "All Sources",
+        "quickFiltersAll": "All",
+        "loading": "Loading...",
+        "resultsCount": "{count, plural, =0 {No proposals found} =1 {# proposal found} other {# proposals found}}",
+        "errorTitle": "Error",
+        "emptyTitle": "No proposals found",
+        "emptyDescription": "Try adjusting your filters or run the weekly image workflow.",
+        "current": "Current",
+        "proposed": "Proposed",
+        "currentImageAlt": "Current image",
+        "proposedImageAlt": "Proposed image",
+        "noCurrent": "No current",
+        "imageTypeLabel": "{imageType} image",
+        "quality": "Quality",
+        "resolution": "Resolution",
+        "created": "Created",
+        "flags": "{count, plural, =1 {# flag} other {# flags}}",
+        "approve": "✓ Approve",
+        "deny": "✗ Deny",
+        "archive": "Archive",
+        "apply": "🚀 Apply",
+        "reopen": "↩ Reopen",
+        "previous": "← Previous",
+        "next": "Next →",
+        "pageOf": "Page {page} of {totalPages}",
+        "statuses": {
+          "pending": "Pending",
+          "approved": "Approved",
+          "applied": "Applied",
+          "denied": "Denied",
+          "archived": "Archived"
+        },
+        "sources": {
+          "workflow": "Workflow",
+          "userFlag": "User flag",
+          "admin": "Admin",
+          "script": "Script"
+        },
+        "errors": {
+          "databaseNotInitialized": "Database not initialized. Please run migrations first.",
+          "unauthorized": "Unauthorized. Please log in.",
+          "fetchFailed": "Failed to fetch proposals",
+          "updateFailed": "Failed to update proposal",
+          "generic": "An error occurred"
+        }
+      },
+      "proposalDetail": {
+        "pageTitle": "Proposal {idShort} · Admin",
+        "heading": "🔍 Proposal Details",
+        "backToProposals": "← Back to Proposals",
+        "errorTitle": "Error",
+        "notFound": "Proposal not found",
+        "headerMeta": "{imageType} image • {source} • Created {createdAt}",
+        "imageComparison": "Image Comparison",
+        "currentImage": "Current Image",
+        "proposedImage": "Proposed Image",
+        "currentImageAlt": "Current image",
+        "proposedImageAlt": "Proposed image",
+        "noCurrentImage": "No current image",
+        "newBadge": "NEW",
+        "sourceLabel": "Source: {source}",
+        "qualityMetrics": "Quality Metrics",
+        "qualityScore": "Quality Score",
+        "resolution": "Resolution",
+        "fileSize": "File Size",
+        "imageType": "Image Type",
+        "proposalReason": "Proposal Reason",
+        "noReasonProvided": "No reason provided",
+        "workflowRun": "Workflow Run",
+        "takeAction": "Take Action",
+        "reviewNotes": "Review Notes (optional)",
+        "reviewNotesPlaceholder": "Add notes about your decision...",
+        "approve": "✓ Approve",
+        "deny": "✗ Deny",
+        "archive": "Archive",
+        "applyImage": "🚀 Apply Image",
+        "reviewInformation": "Review Information",
+        "reviewedAt": "Reviewed At",
+        "reviewedBy": "Reviewed By",
+        "reviewNotesLabel": "Review Notes",
+        "auditHistory": "Audit History",
+        "errors": {
+          "databaseNotInitialized": "Database not initialized. Please run migrations first.",
+          "unauthorized": "Unauthorized. Please log in.",
+          "notFound": "Proposal not found.",
+          "fetchFailed": "Failed to fetch proposal",
+          "updateFailed": "Failed to update proposal",
+          "applyFailed": "Failed to apply proposal",
+          "generic": "An error occurred"
+        }
+      }
     },
     "contributions": {
       "pageTitle": "Review Contributions | Admin",
@@ -1567,6 +1674,53 @@
       "pageDescription": "Monitor Core Web Vitals and performance budgets for Costa Rica Tree Atlas.",
       "heading": "⚡ Performance Monitoring",
       "description": "Capture live Core Web Vitals for the current session and review performance budgets.",
+      "liveVitalsHeading": "Live Core Web Vitals",
+      "liveVitalsDescription": "Metrics are captured from the current session using the browser Performance APIs.",
+      "refreshSnapshot": "Refresh snapshot",
+      "copied": "Copied",
+      "copyFailed": "Copy failed",
+      "copyJson": "Copy JSON",
+      "resourceMix": "Resource Mix",
+      "resourceMixDescription": "Transfer size totals for this page load.",
+      "resourceJavaScript": "JavaScript",
+      "resourceCss": "CSS",
+      "resourceImages": "Images",
+      "resourceTotal": "Total",
+      "resourceCounted": "Resources counted",
+      "referenceTargets": "Reference Targets",
+      "referenceTargetsDescription": "Targets align with Web Vitals guidance and the project performance budgets.",
+      "goodTarget": "Good",
+      "needsImprovementTarget": "Needs improvement",
+      "lastUpdated": "Last updated",
+      "waitingForMetrics": "Waiting for metrics...",
+      "historicalTrackingHint": "Pair this dashboard with Vercel Speed Insights and Lighthouse CI for historical tracking and regression alerts.",
+      "rating": {
+        "good": "Good",
+        "needsImprovement": "Needs Improvement",
+        "poor": "Poor"
+      },
+      "metrics": {
+        "lcp": {
+          "label": "Largest Contentful Paint",
+          "description": "Render timing for the largest element in view."
+        },
+        "cls": {
+          "label": "Cumulative Layout Shift",
+          "description": "Unexpected layout movement during page load."
+        },
+        "inp": {
+          "label": "Interaction to Next Paint",
+          "description": "Responsiveness to user interactions (estimated from events)."
+        },
+        "fcp": {
+          "label": "First Contentful Paint",
+          "description": "Time until the first text or image is rendered."
+        },
+        "ttfb": {
+          "label": "Time to First Byte",
+          "description": "Server response latency measured on navigation."
+        }
+      },
       "vercelAnalytics": "Open Vercel Analytics",
       "speedInsightsDocs": "Speed Insights Docs"
     },

--- a/messages/es.json
+++ b/messages/es.json
@@ -1276,6 +1276,11 @@
     "authDesc": "Envía un header X-API-Key emitido por el equipo mantenedor, o llama desde una IP en allowlist. Las solicitudes no autorizadas se rechazan con HTTP 401.",
     "rateLimit": "Límite de Solicitudes",
     "rateLimitDesc": "100 solicitudes por minuto por dirección IP. Los headers de límite se incluyen en todas las respuestas.",
+    "rateLimitHeaders": {
+      "limit": "Máximo de solicitudes por ventana",
+      "remaining": "Solicitudes restantes",
+      "reset": "Marca de tiempo Unix cuando se reinicia el límite"
+    },
     "endpoints": "Endpoints",
     "tryIt": "Probar",
     "response": "Respuesta",
@@ -1283,6 +1288,7 @@
     "required": "Requerido",
     "optional": "Opcional",
     "example": "Ejemplo",
+    "githubIssues": "Issues de GitHub",
     "trees": {
       "list": "Listar Árboles",
       "listDesc": "Obtiene una lista paginada de árboles con filtrado y ordenamiento opcional.",
@@ -1504,7 +1510,108 @@
       "tooltipClearVote": "Borrar voto",
       "badgeNeedsPhoto": "Necesita Foto",
       "badgeLocal": "Local",
-      "badgeExternal": "Externa"
+      "badgeExternal": "Externa",
+      "proposals": {
+        "pageTitle": "Propuestas de Imágenes | Admin",
+        "heading": "📋 Propuestas de Imágenes",
+        "description": "Revisa y gestiona los cambios de imágenes propuestos por flujos automáticos y reportes de personas usuarias.",
+        "backToImageReview": "← Volver a Revisión de Imágenes",
+        "searchByTreeSlug": "Buscar por slug del árbol",
+        "searchPlaceholder": "p. ej., ceiba, guanacaste",
+        "status": "Estado",
+        "source": "Fuente",
+        "allStatuses": "Todos los estados",
+        "allSources": "Todas las fuentes",
+        "quickFiltersAll": "Todas",
+        "loading": "Cargando...",
+        "resultsCount": "{count, plural, =0 {No se encontraron propuestas} =1 {# propuesta encontrada} other {# propuestas encontradas}}",
+        "errorTitle": "Error",
+        "emptyTitle": "No se encontraron propuestas",
+        "emptyDescription": "Intenta ajustar tus filtros o ejecuta el flujo semanal de imágenes.",
+        "current": "Actual",
+        "proposed": "Propuesta",
+        "currentImageAlt": "Imagen actual",
+        "proposedImageAlt": "Imagen propuesta",
+        "noCurrent": "Sin actual",
+        "imageTypeLabel": "Imagen {imageType}",
+        "quality": "Calidad",
+        "resolution": "Resolución",
+        "created": "Creada",
+        "flags": "{count, plural, =1 {# reporte} other {# reportes}}",
+        "approve": "✓ Aprobar",
+        "deny": "✗ Denegar",
+        "archive": "Archivar",
+        "apply": "🚀 Aplicar",
+        "reopen": "↩ Reabrir",
+        "previous": "← Anterior",
+        "next": "Siguiente →",
+        "pageOf": "Página {page} de {totalPages}",
+        "statuses": {
+          "pending": "Pendiente",
+          "approved": "Aprobada",
+          "applied": "Aplicada",
+          "denied": "Denegada",
+          "archived": "Archivada"
+        },
+        "sources": {
+          "workflow": "Flujo automático",
+          "userFlag": "Reporte de usuario",
+          "admin": "Admin",
+          "script": "Script"
+        },
+        "errors": {
+          "databaseNotInitialized": "La base de datos no está inicializada. Ejecuta primero las migraciones.",
+          "unauthorized": "No autorizado. Inicia sesión.",
+          "fetchFailed": "No se pudieron obtener las propuestas",
+          "updateFailed": "No se pudo actualizar la propuesta",
+          "generic": "Ocurrió un error"
+        }
+      },
+      "proposalDetail": {
+        "pageTitle": "Propuesta {idShort} · Admin",
+        "heading": "🔍 Detalles de la Propuesta",
+        "backToProposals": "← Volver a Propuestas",
+        "errorTitle": "Error",
+        "notFound": "Propuesta no encontrada",
+        "headerMeta": "Imagen {imageType} • {source} • Creada {createdAt}",
+        "imageComparison": "Comparación de Imágenes",
+        "currentImage": "Imagen Actual",
+        "proposedImage": "Imagen Propuesta",
+        "currentImageAlt": "Imagen actual",
+        "proposedImageAlt": "Imagen propuesta",
+        "noCurrentImage": "No hay imagen actual",
+        "newBadge": "NUEVA",
+        "sourceLabel": "Fuente: {source}",
+        "qualityMetrics": "Métricas de Calidad",
+        "qualityScore": "Puntaje de Calidad",
+        "resolution": "Resolución",
+        "fileSize": "Tamaño del Archivo",
+        "imageType": "Tipo de Imagen",
+        "proposalReason": "Motivo de la Propuesta",
+        "noReasonProvided": "No se proporcionó motivo",
+        "workflowRun": "Ejecución del flujo",
+        "takeAction": "Tomar Acción",
+        "reviewNotes": "Notas de revisión (opcional)",
+        "reviewNotesPlaceholder": "Agrega notas sobre tu decisión...",
+        "approve": "✓ Aprobar",
+        "deny": "✗ Denegar",
+        "archive": "Archivar",
+        "applyImage": "🚀 Aplicar Imagen",
+        "reviewInformation": "Información de la Revisión",
+        "reviewedAt": "Revisada el",
+        "reviewedBy": "Revisada por",
+        "reviewNotesLabel": "Notas de revisión",
+        "auditHistory": "Historial de Auditoría",
+        "errors": {
+          "databaseNotInitialized": "La base de datos no está inicializada. Ejecuta primero las migraciones.",
+          "unauthorized": "No autorizado. Inicia sesión.",
+          "notFound": "Propuesta no encontrada.",
+          "fetchFailed": "No se pudo obtener la propuesta",
+          "updateFailed": "No se pudo actualizar la propuesta",
+          "applyFailed": "No se pudo aplicar la propuesta",
+          "generic": "Ocurrió un error"
+        }
+      }
     },
     "contributions": {
       "pageTitle": "Revisar Contribuciones | Admin",
@@ -1563,6 +1670,53 @@
       "pageDescription": "Monitorea Core Web Vitals y presupuestos de rendimiento para Atlas de Árboles de Costa Rica.",
       "heading": "⚡ Monitoreo de Rendimiento",
       "description": "Captura Core Web Vitals en vivo para la sesión actual y revisa los presupuestos de rendimiento.",
+      "liveVitalsHeading": "Core Web Vitals en Vivo",
+      "liveVitalsDescription": "Las métricas se capturan de la sesión actual usando las APIs de Performance del navegador.",
+      "refreshSnapshot": "Actualizar instantánea",
+      "copied": "Copiado",
+      "copyFailed": "Error al copiar",
+      "copyJson": "Copiar JSON",
+      "resourceMix": "Distribución de Recursos",
+      "resourceMixDescription": "Totales de tamaño de transferencia para esta carga de página.",
+      "resourceJavaScript": "JavaScript",
+      "resourceCss": "CSS",
+      "resourceImages": "Imágenes",
+      "resourceTotal": "Total",
+      "resourceCounted": "Recursos contados",
+      "referenceTargets": "Objetivos de Referencia",
+      "referenceTargetsDescription": "Los objetivos se alinean con las guías de Web Vitals y los presupuestos de rendimiento del proyecto.",
+      "goodTarget": "Bueno",
+      "needsImprovementTarget": "Necesita mejora",
+      "lastUpdated": "Última actualización",
+      "waitingForMetrics": "Esperando métricas...",
+      "historicalTrackingHint": "Combina este panel con Vercel Speed Insights y Lighthouse CI para seguimiento histórico y alertas de regresión.",
+      "rating": {
+        "good": "Bueno",
+        "needsImprovement": "Necesita mejora",
+        "poor": "Deficiente"
+      },
+      "metrics": {
+        "lcp": {
+          "label": "Largest Contentful Paint",
+          "description": "Tiempo de renderizado del elemento más grande visible."
+        },
+        "cls": {
+          "label": "Cumulative Layout Shift",
+          "description": "Movimiento inesperado del diseño durante la carga de la página."
+        },
+        "inp": {
+          "label": "Interaction to Next Paint",
+          "description": "Capacidad de respuesta a las interacciones de la persona usuaria (estimada a partir de eventos)."
+        },
+        "fcp": {
+          "label": "First Contentful Paint",
+          "description": "Tiempo hasta que se renderiza el primer texto o imagen."
+        },
+        "ttfb": {
+          "label": "Time to First Byte",
+          "description": "Latencia de respuesta del servidor medida en la navegación."
+        }
+      },
       "vercelAnalytics": "Abrir Vercel Analytics",
       "speedInsightsDocs": "Documentación de Speed Insights"
     },

--- a/src/app/[locale]/admin/images/proposals/ProposalsListClient.tsx
+++ b/src/app/[locale]/admin/images/proposals/ProposalsListClient.tsx
@@ -144,6 +144,8 @@ export default function ProposalsListClient() {
         return t("proposals.sources.workflow");
       case "USER_FLAG":
         return t("proposals.sources.userFlag");
+      case "USER_UPLOAD":
+        return t("proposals.sources.userUpload");
       case "ADMIN":
         return t("proposals.sources.admin");
       case "SCRIPT":

--- a/src/app/[locale]/admin/images/proposals/ProposalsListClient.tsx
+++ b/src/app/[locale]/admin/images/proposals/ProposalsListClient.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import Image from "next/image";
+import { useTranslations } from "next-intl";
 import { Link } from "@i18n/navigation";
 import {
   type ImageProposal,
@@ -24,6 +25,7 @@ interface ProposalsResponse {
 type FilterStatus = ImageProposalStatus | "ALL";
 
 export default function ProposalsListClient() {
+  const t = useTranslations("admin.images");
   const [proposals, setProposals] = useState<ImageProposal[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -52,19 +54,19 @@ export default function ProposalsListClient() {
       const response = await fetch(`/api/admin/images/proposals?${params}`);
 
       if (response.status === 503) {
-        setError("Database not initialized. Please run migrations first.");
+        setError(t("proposals.errors.databaseNotInitialized"));
         setProposals([]);
         return;
       }
 
       if (response.status === 401) {
-        setError("Unauthorized. Please log in.");
+        setError(t("proposals.errors.unauthorized"));
         setProposals([]);
         return;
       }
 
       if (!response.ok) {
-        throw new Error("Failed to fetch proposals");
+        throw new Error(t("proposals.errors.fetchFailed"));
       }
 
       const data: ProposalsResponse = await response.json();
@@ -72,12 +74,14 @@ export default function ProposalsListClient() {
       setTotalPages(data.pagination.totalPages);
       setTotal(data.pagination.total);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "An error occurred");
+      setError(
+        err instanceof Error ? err.message : t("proposals.errors.generic")
+      );
       setProposals([]);
     } finally {
       setLoading(false);
     }
-  }, [page, filterStatus, filterSource, searchQuery]);
+  }, [filterSource, filterStatus, page, searchQuery, t]);
 
   useEffect(() => {
     void fetchProposals();
@@ -101,15 +105,53 @@ export default function ProposalsListClient() {
       );
 
       if (!response.ok) {
-        throw new Error("Failed to update proposal");
+        throw new Error(t("proposals.errors.updateFailed"));
       }
 
       // Refresh the list
       await fetchProposals();
     } catch (err) {
-      alert(err instanceof Error ? err.message : "Failed to update proposal");
+      alert(
+        err instanceof Error ? err.message : t("proposals.errors.updateFailed")
+      );
     } finally {
       setActionLoading(null);
+    }
+  };
+
+  const getStatusLabel = (status: ImageProposalStatus | FilterStatus) => {
+    switch (status) {
+      case "PENDING":
+        return t("proposals.statuses.pending");
+      case "APPROVED":
+        return t("proposals.statuses.approved");
+      case "APPLIED":
+        return t("proposals.statuses.applied");
+      case "DENIED":
+        return t("proposals.statuses.denied");
+      case "ARCHIVED":
+        return t("proposals.statuses.archived");
+      case "ALL":
+        return t("proposals.allStatuses");
+      default:
+        return status;
+    }
+  };
+
+  const getSourceLabel = (source: ImageProposalSource | "ALL") => {
+    switch (source) {
+      case "WORKFLOW":
+        return t("proposals.sources.workflow");
+      case "USER_FLAG":
+        return t("proposals.sources.userFlag");
+      case "ADMIN":
+        return t("proposals.sources.admin");
+      case "SCRIPT":
+        return t("proposals.sources.script");
+      case "ALL":
+        return t("proposals.allSources");
+      default:
+        return source;
     }
   };
 
@@ -166,7 +208,7 @@ export default function ProposalsListClient() {
               htmlFor="search"
               className="block text-sm font-medium text-muted-foreground mb-1"
             >
-              Search by Tree Slug
+              {t("proposals.searchByTreeSlug")}
             </label>
             <input
               id="search"
@@ -176,7 +218,7 @@ export default function ProposalsListClient() {
                 setSearchQuery(e.target.value);
                 setPage(1);
               }}
-              placeholder="e.g., ceiba, guanacaste"
+              placeholder={t("proposals.searchPlaceholder")}
               className="w-full px-3 py-2 border border-border rounded-lg bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary"
             />
           </div>
@@ -187,7 +229,7 @@ export default function ProposalsListClient() {
               htmlFor="status"
               className="block text-sm font-medium text-muted-foreground mb-1"
             >
-              Status
+              {t("proposals.status")}
             </label>
             <select
               id="status"
@@ -198,10 +240,10 @@ export default function ProposalsListClient() {
               }}
               className="px-3 py-2 border border-border rounded-lg bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
             >
-              <option value="ALL">All Statuses</option>
+              <option value="ALL">{t("proposals.allStatuses")}</option>
               {IMAGE_PROPOSAL_STATUSES.map((status) => (
                 <option key={status} value={status}>
-                  {status.charAt(0) + status.slice(1).toLowerCase()}
+                  {getStatusLabel(status)}
                 </option>
               ))}
             </select>
@@ -213,7 +255,7 @@ export default function ProposalsListClient() {
               htmlFor="source"
               className="block text-sm font-medium text-muted-foreground mb-1"
             >
-              Source
+              {t("proposals.source")}
             </label>
             <select
               id="source"
@@ -224,11 +266,10 @@ export default function ProposalsListClient() {
               }}
               className="px-3 py-2 border border-border rounded-lg bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
             >
-              <option value="ALL">All Sources</option>
+              <option value="ALL">{t("proposals.allSources")}</option>
               {IMAGE_PROPOSAL_SOURCES.map((source) => (
                 <option key={source} value={source}>
-                  {source.charAt(0) +
-                    source.slice(1).toLowerCase().replace("_", " ")}
+                  {getSourceLabel(source)}
                 </option>
               ))}
             </select>
@@ -248,7 +289,7 @@ export default function ProposalsListClient() {
                 : "bg-amber-100 text-amber-800 hover:bg-amber-200 dark:bg-amber-900/30 dark:text-amber-300"
             }`}
           >
-            ⏳ Pending
+            ⏳ {t("proposals.statuses.pending")}
           </button>
           <button
             onClick={() => {
@@ -261,7 +302,7 @@ export default function ProposalsListClient() {
                 : "bg-blue-100 text-blue-800 hover:bg-blue-200 dark:bg-blue-900/30 dark:text-blue-300"
             }`}
           >
-            ✓ Approved
+            ✓ {t("proposals.statuses.approved")}
           </button>
           <button
             onClick={() => {
@@ -274,7 +315,7 @@ export default function ProposalsListClient() {
                 : "bg-green-100 text-green-800 hover:bg-green-200 dark:bg-green-900/30 dark:text-green-300"
             }`}
           >
-            ✅ Applied
+            ✅ {t("proposals.statuses.applied")}
           </button>
           <button
             onClick={() => {
@@ -287,7 +328,7 @@ export default function ProposalsListClient() {
                 : "bg-red-100 text-red-800 hover:bg-red-200 dark:bg-red-900/30 dark:text-red-300"
             }`}
           >
-            ✗ Denied
+            ✗ {t("proposals.statuses.denied")}
           </button>
           <button
             onClick={() => {
@@ -300,7 +341,7 @@ export default function ProposalsListClient() {
                 : "bg-gray-100 text-gray-800 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-300"
             }`}
           >
-            All
+            {t("proposals.quickFiltersAll")}
           </button>
         </div>
       </div>
@@ -308,14 +349,14 @@ export default function ProposalsListClient() {
       {/* Results count */}
       <div className="text-sm text-muted-foreground">
         {loading
-          ? "Loading..."
-          : `${total} proposal${total !== 1 ? "s" : ""} found`}
+          ? t("proposals.loading")
+          : t("proposals.resultsCount", { count: total })}
       </div>
 
       {/* Error state */}
       {error && (
         <div className="bg-red-50 dark:bg-red-950/30 border border-red-200 dark:border-red-900 rounded-xl p-4 text-red-600">
-          <p className="font-medium">Error</p>
+          <p className="font-medium">{t("proposals.errorTitle")}</p>
           <p className="text-sm">{error}</p>
         </div>
       )}
@@ -344,9 +385,9 @@ export default function ProposalsListClient() {
       {/* Proposals list */}
       {!loading && !error && proposals.length === 0 && (
         <div className="bg-card border border-border rounded-xl p-8 text-center">
-          <p className="text-muted-foreground">No proposals found</p>
+          <p className="text-muted-foreground">{t("proposals.emptyTitle")}</p>
           <p className="text-sm text-muted-foreground mt-1">
-            Try adjusting your filters or run the weekly image workflow.
+            {t("proposals.emptyDescription")}
           </p>
         </div>
       )}
@@ -366,18 +407,18 @@ export default function ProposalsListClient() {
                     {proposal.currentUrl ? (
                       <Image
                         src={proposal.currentUrl}
-                        alt="Current"
+                        alt={t("proposals.currentImageAlt")}
                         fill
                         className="object-cover"
                         sizes="96px"
                       />
                     ) : (
                       <div className="w-full h-full flex items-center justify-center text-muted-foreground text-xs">
-                        No current
+                        {t("proposals.noCurrent")}
                       </div>
                     )}
                     <div className="absolute bottom-0 left-0 right-0 bg-black/60 text-white text-xs py-0.5 text-center">
-                      Current
+                      {t("proposals.current")}
                     </div>
                   </div>
 
@@ -390,13 +431,13 @@ export default function ProposalsListClient() {
                   <div className="relative w-24 h-24 rounded-lg overflow-hidden bg-muted flex-shrink-0 ring-2 ring-primary">
                     <Image
                       src={proposal.proposedUrl}
-                      alt="Proposed"
+                      alt={t("proposals.proposedImageAlt")}
                       fill
                       className="object-cover"
                       sizes="96px"
                     />
                     <div className="absolute bottom-0 left-0 right-0 bg-primary text-primary-foreground text-xs py-0.5 text-center">
-                      Proposed
+                      {t("proposals.proposed")}
                     </div>
                   </div>
                 </div>
@@ -414,19 +455,21 @@ export default function ProposalsListClient() {
                         </Link>
                       </h3>
                       <p className="text-sm text-muted-foreground">
-                        {proposal.imageType} image
+                        {t("proposals.imageTypeLabel", {
+                          imageType: proposal.imageType,
+                        })}
                       </p>
                     </div>
                     <div className="flex gap-2 flex-shrink-0">
                       <span
                         className={`px-2 py-0.5 rounded-full text-xs font-medium ${getStatusBadgeClass(proposal.status)}`}
                       >
-                        {proposal.status}
+                        {getStatusLabel(proposal.status)}
                       </span>
                       <span
                         className={`px-2 py-0.5 rounded-full text-xs font-medium ${getSourceBadgeClass(proposal.source)}`}
                       >
-                        {proposal.source.replace("_", " ")}
+                        {getSourceLabel(proposal.source)}
                       </span>
                     </div>
                   </div>
@@ -441,12 +484,19 @@ export default function ProposalsListClient() {
                   {/* Metrics */}
                   <div className="flex gap-4 mt-2 text-xs text-muted-foreground">
                     {proposal.qualityScore !== null && (
-                      <span>Quality: {proposal.qualityScore.toFixed(0)}%</span>
+                      <span>
+                        {t("proposals.quality")}:{" "}
+                        {proposal.qualityScore.toFixed(0)}%
+                      </span>
                     )}
                     {proposal.resolution && (
-                      <span>Resolution: {proposal.resolution}</span>
+                      <span>
+                        {t("proposals.resolution")}: {proposal.resolution}
+                      </span>
                     )}
-                    <span>Created: {formatDate(proposal.createdAt)}</span>
+                    <span>
+                      {t("proposals.created")}: {formatDate(proposal.createdAt)}
+                    </span>
                   </div>
 
                   {/* Vote counts */}
@@ -459,7 +509,7 @@ export default function ProposalsListClient() {
                     </span>
                     {proposal.flagCount > 0 && (
                       <span className="text-orange-600">
-                        🚩 {proposal.flagCount} flags
+                        🚩 {t("proposals.flags", { count: proposal.flagCount })}
                       </span>
                     )}
                   </div>
@@ -475,14 +525,18 @@ export default function ProposalsListClient() {
                       disabled={actionLoading === proposal.id}
                       className="px-3 py-1.5 bg-green-600 hover:bg-green-700 text-white text-sm rounded-lg transition-colors disabled:opacity-50"
                     >
-                      {actionLoading === proposal.id ? "..." : "✓ Approve"}
+                      {actionLoading === proposal.id
+                        ? "..."
+                        : t("proposals.approve")}
                     </button>
                     <button
                       onClick={() => handleStatusChange(proposal.id, "DENIED")}
                       disabled={actionLoading === proposal.id}
                       className="px-3 py-1.5 bg-red-600 hover:bg-red-700 text-white text-sm rounded-lg transition-colors disabled:opacity-50"
                     >
-                      {actionLoading === proposal.id ? "..." : "✗ Deny"}
+                      {actionLoading === proposal.id
+                        ? "..."
+                        : t("proposals.deny")}
                     </button>
                     <button
                       onClick={() =>
@@ -491,7 +545,9 @@ export default function ProposalsListClient() {
                       disabled={actionLoading === proposal.id}
                       className="px-3 py-1.5 bg-gray-600 hover:bg-gray-700 text-white text-sm rounded-lg transition-colors disabled:opacity-50"
                     >
-                      {actionLoading === proposal.id ? "..." : "Archive"}
+                      {actionLoading === proposal.id
+                        ? "..."
+                        : t("proposals.archive")}
                     </button>
                   </div>
                 )}
@@ -503,7 +559,9 @@ export default function ProposalsListClient() {
                       disabled={actionLoading === proposal.id}
                       className="px-3 py-1.5 bg-primary hover:bg-primary/90 text-primary-foreground text-sm rounded-lg transition-colors disabled:opacity-50"
                     >
-                      {actionLoading === proposal.id ? "..." : "🚀 Apply"}
+                      {actionLoading === proposal.id
+                        ? "..."
+                        : t("proposals.apply")}
                     </button>
                   </div>
                 )}
@@ -516,7 +574,9 @@ export default function ProposalsListClient() {
                       disabled={actionLoading === proposal.id}
                       className="px-3 py-1.5 bg-amber-600 hover:bg-amber-700 text-white text-sm rounded-lg transition-colors disabled:opacity-50"
                     >
-                      {actionLoading === proposal.id ? "..." : "↩ Reopen"}
+                      {actionLoading === proposal.id
+                        ? "..."
+                        : t("proposals.reopen")}
                     </button>
                   </div>
                 )}
@@ -536,10 +596,10 @@ export default function ProposalsListClient() {
             disabled={page === 1}
             className="px-4 py-2 bg-card border border-border rounded-lg hover:bg-muted disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
           >
-            ← Previous
+            {t("proposals.previous")}
           </button>
           <span className="px-4 py-2 text-muted-foreground">
-            Page {page} of {totalPages}
+            {t("proposals.pageOf", { page, totalPages })}
           </span>
           <button
             onClick={() => {
@@ -548,7 +608,7 @@ export default function ProposalsListClient() {
             disabled={page === totalPages}
             className="px-4 py-2 bg-card border border-border rounded-lg hover:bg-muted disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
           >
-            Next →
+            {t("proposals.next")}
           </button>
         </div>
       )}

--- a/src/app/[locale]/admin/images/proposals/[id]/ProposalDetailClient.tsx
+++ b/src/app/[locale]/admin/images/proposals/[id]/ProposalDetailClient.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import Image from "next/image";
+import { useTranslations } from "next-intl";
 import { Link } from "@i18n/navigation";
 import {
   type ImageProposal,
@@ -27,6 +28,7 @@ interface ProposalDetailClientProps {
 export default function ProposalDetailClient({
   proposalId,
 }: ProposalDetailClientProps) {
+  const t = useTranslations("admin.images");
   const [proposal, setProposal] = useState<
     ProposalDetailResponse["data"] | null
   >(null);
@@ -46,35 +48,39 @@ export default function ProposalDetailClient({
         );
 
         if (response.status === 503) {
-          setError("Database not initialized. Please run migrations first.");
+          setError(t("proposalDetail.errors.databaseNotInitialized"));
           return;
         }
 
         if (response.status === 401) {
-          setError("Unauthorized. Please log in.");
+          setError(t("proposalDetail.errors.unauthorized"));
           return;
         }
 
         if (response.status === 404) {
-          setError("Proposal not found.");
+          setError(t("proposalDetail.errors.notFound"));
           return;
         }
 
         if (!response.ok) {
-          throw new Error("Failed to fetch proposal");
+          throw new Error(t("proposalDetail.errors.fetchFailed"));
         }
 
         const data: ProposalDetailResponse = await response.json();
         setProposal(data.data);
       } catch (err) {
-        setError(err instanceof Error ? err.message : "An error occurred");
+        setError(
+          err instanceof Error
+            ? err.message
+            : t("proposalDetail.errors.generic")
+        );
       } finally {
         setLoading(false);
       }
     };
 
     void fetchProposal();
-  }, [proposalId]);
+  }, [proposalId, t]);
 
   const handleStatusChange = async (newStatus: ImageProposalStatus) => {
     if (!proposal) return;
@@ -99,7 +105,9 @@ export default function ProposalDetailClient({
           message?: string;
         } | null;
         throw new Error(
-          payload?.error || payload?.message || "Failed to update proposal"
+          payload?.error ||
+            payload?.message ||
+            t("proposalDetail.errors.updateFailed")
         );
       }
 
@@ -111,7 +119,11 @@ export default function ProposalDetailClient({
       setProposal(data.data);
       setReviewNotes("");
     } catch (err) {
-      alert(err instanceof Error ? err.message : "Failed to update proposal");
+      alert(
+        err instanceof Error
+          ? err.message
+          : t("proposalDetail.errors.updateFailed")
+      );
     } finally {
       setActionLoading(false);
     }
@@ -136,7 +148,9 @@ export default function ProposalDetailClient({
           message?: string;
         } | null;
         throw new Error(
-          payload?.error || payload?.message || "Failed to apply proposal"
+          payload?.error ||
+            payload?.message ||
+            t("proposalDetail.errors.applyFailed")
         );
       }
 
@@ -147,9 +161,45 @@ export default function ProposalDetailClient({
       setProposal(data.data);
       setReviewNotes("");
     } catch (err) {
-      alert(err instanceof Error ? err.message : "Failed to apply proposal");
+      alert(
+        err instanceof Error
+          ? err.message
+          : t("proposalDetail.errors.applyFailed")
+      );
     } finally {
       setActionLoading(false);
+    }
+  };
+
+  const getStatusLabel = (status: ImageProposalStatus) => {
+    switch (status) {
+      case "PENDING":
+        return t("proposals.statuses.pending");
+      case "APPROVED":
+        return t("proposals.statuses.approved");
+      case "APPLIED":
+        return t("proposals.statuses.applied");
+      case "DENIED":
+        return t("proposals.statuses.denied");
+      case "ARCHIVED":
+        return t("proposals.statuses.archived");
+      default:
+        return status;
+    }
+  };
+
+  const getSourceLabel = (source: ImageProposal["source"]) => {
+    switch (source) {
+      case "WORKFLOW":
+        return t("proposals.sources.workflow");
+      case "USER_FLAG":
+        return t("proposals.sources.userFlag");
+      case "ADMIN":
+        return t("proposals.sources.admin");
+      case "SCRIPT":
+        return t("proposals.sources.script");
+      default:
+        return source;
     }
   };
 
@@ -197,13 +247,13 @@ export default function ProposalDetailClient({
   if (error) {
     return (
       <div className="bg-red-50 dark:bg-red-950/30 border border-red-200 dark:border-red-900 rounded-xl p-6 text-red-600">
-        <p className="font-medium">Error</p>
+        <p className="font-medium">{t("proposalDetail.errorTitle")}</p>
         <p className="text-sm">{error}</p>
         <Link
           href="/admin/images/proposals"
           className="inline-block mt-4 text-sm underline hover:no-underline"
         >
-          ← Back to Proposals
+          {t("proposalDetail.backToProposals")}
         </Link>
       </div>
     );
@@ -212,7 +262,7 @@ export default function ProposalDetailClient({
   if (!proposal) {
     return (
       <div className="bg-card border border-border rounded-xl p-6 text-center">
-        <p className="text-muted-foreground">Proposal not found</p>
+        <p className="text-muted-foreground">{t("proposalDetail.notFound")}</p>
       </div>
     );
   }
@@ -235,12 +285,15 @@ export default function ProposalDetailClient({
               <span
                 className={`px-3 py-1 rounded-full text-sm font-medium ${getStatusBadgeClass(proposal.status)}`}
               >
-                {proposal.status}
+                {getStatusLabel(proposal.status)}
               </span>
             </div>
             <p className="text-muted-foreground mt-1">
-              {proposal.imageType} image • {proposal.source.replace("_", " ")} •
-              Created {formatDate(proposal.createdAt)}
+              {t("proposalDetail.headerMeta", {
+                imageType: proposal.imageType,
+                source: getSourceLabel(proposal.source),
+                createdAt: formatDate(proposal.createdAt),
+              })}
             </p>
           </div>
 
@@ -264,19 +317,19 @@ export default function ProposalDetailClient({
       {/* Side-by-side comparison */}
       <div className="bg-card border border-border rounded-xl p-6">
         <h3 className="text-lg font-semibold text-foreground mb-4">
-          Image Comparison
+          {t("proposalDetail.imageComparison")}
         </h3>
         <div className="grid md:grid-cols-2 gap-8">
           {/* Current image */}
           <div>
             <h4 className="text-sm font-medium text-muted-foreground mb-2">
-              Current Image
+              {t("proposalDetail.currentImage")}
             </h4>
             <div className="relative aspect-square rounded-xl overflow-hidden bg-muted border border-border">
               {proposal.currentUrl ? (
                 <Image
                   src={proposal.currentUrl}
-                  alt="Current image"
+                  alt={t("proposalDetail.currentImageAlt")}
                   fill
                   className="object-cover"
                   sizes="(max-width: 768px) 100vw, 50vw"
@@ -285,14 +338,18 @@ export default function ProposalDetailClient({
                 <div className="w-full h-full flex items-center justify-center text-muted-foreground">
                   <div className="text-center">
                     <span className="text-4xl block mb-2">📷</span>
-                    <span className="text-sm">No current image</span>
+                    <span className="text-sm">
+                      {t("proposalDetail.noCurrentImage")}
+                    </span>
                   </div>
                 </div>
               )}
             </div>
             {proposal.currentSource && (
               <p className="text-xs text-muted-foreground mt-2 truncate">
-                Source: {proposal.currentSource}
+                {t("proposalDetail.sourceLabel", {
+                  source: proposal.currentSource,
+                })}
               </p>
             )}
           </div>
@@ -300,23 +357,25 @@ export default function ProposalDetailClient({
           {/* Proposed image */}
           <div>
             <h4 className="text-sm font-medium text-muted-foreground mb-2">
-              Proposed Image
+              {t("proposalDetail.proposedImage")}
             </h4>
             <div className="relative aspect-square rounded-xl overflow-hidden bg-muted border-2 border-primary">
               <Image
                 src={proposal.proposedUrl}
-                alt="Proposed image"
+                alt={t("proposalDetail.proposedImageAlt")}
                 fill
                 className="object-cover"
                 sizes="(max-width: 768px) 100vw, 50vw"
               />
               <div className="absolute top-2 right-2 bg-primary text-primary-foreground px-2 py-1 rounded text-xs font-medium">
-                NEW
+                {t("proposalDetail.newBadge")}
               </div>
             </div>
             {proposal.proposedSource && (
               <p className="text-xs text-muted-foreground mt-2 truncate">
-                Source: {proposal.proposedSource}
+                {t("proposalDetail.sourceLabel", {
+                  source: proposal.proposedSource,
+                })}
               </p>
             )}
           </div>
@@ -328,12 +387,14 @@ export default function ProposalDetailClient({
         {/* Quality metrics */}
         <div className="bg-card border border-border rounded-xl p-6">
           <h3 className="text-lg font-semibold text-foreground mb-4">
-            Quality Metrics
+            {t("proposalDetail.qualityMetrics")}
           </h3>
           <dl className="space-y-3">
             {proposal.qualityScore !== null && (
               <div className="flex justify-between">
-                <dt className="text-muted-foreground">Quality Score</dt>
+                <dt className="text-muted-foreground">
+                  {t("proposalDetail.qualityScore")}
+                </dt>
                 <dd className="font-medium">
                   <span
                     className={
@@ -351,20 +412,26 @@ export default function ProposalDetailClient({
             )}
             {proposal.resolution && (
               <div className="flex justify-between">
-                <dt className="text-muted-foreground">Resolution</dt>
+                <dt className="text-muted-foreground">
+                  {t("proposalDetail.resolution")}
+                </dt>
                 <dd className="font-medium">{proposal.resolution}</dd>
               </div>
             )}
             {proposal.fileSize && (
               <div className="flex justify-between">
-                <dt className="text-muted-foreground">File Size</dt>
+                <dt className="text-muted-foreground">
+                  {t("proposalDetail.fileSize")}
+                </dt>
                 <dd className="font-medium">
                   {(proposal.fileSize / 1024).toFixed(0)} KB
                 </dd>
               </div>
             )}
             <div className="flex justify-between">
-              <dt className="text-muted-foreground">Image Type</dt>
+              <dt className="text-muted-foreground">
+                {t("proposalDetail.imageType")}
+              </dt>
               <dd className="font-medium">{proposal.imageType}</dd>
             </div>
           </dl>
@@ -373,16 +440,18 @@ export default function ProposalDetailClient({
         {/* Reason */}
         <div className="bg-card border border-border rounded-xl p-6">
           <h3 className="text-lg font-semibold text-foreground mb-4">
-            Proposal Reason
+            {t("proposalDetail.proposalReason")}
           </h3>
           {proposal.reason ? (
             <p className="text-muted-foreground">{proposal.reason}</p>
           ) : (
-            <p className="text-muted-foreground italic">No reason provided</p>
+            <p className="text-muted-foreground italic">
+              {t("proposalDetail.noReasonProvided")}
+            </p>
           )}
           {proposal.workflowRunId && (
             <p className="text-xs text-muted-foreground mt-4">
-              Workflow Run:{" "}
+              {t("proposalDetail.workflowRun")}:{" "}
               <code className="bg-muted px-1 rounded">
                 {proposal.workflowRunId}
               </code>
@@ -395,7 +464,7 @@ export default function ProposalDetailClient({
       {(proposal.status === "PENDING" || proposal.status === "APPROVED") && (
         <div className="bg-card border border-border rounded-xl p-6">
           <h3 className="text-lg font-semibold text-foreground mb-4">
-            Take Action
+            {t("proposalDetail.takeAction")}
           </h3>
 
           {/* Review notes */}
@@ -404,7 +473,7 @@ export default function ProposalDetailClient({
               htmlFor="reviewNotes"
               className="block text-sm font-medium text-muted-foreground mb-1"
             >
-              Review Notes (optional)
+              {t("proposalDetail.reviewNotes")}
             </label>
             <textarea
               id="reviewNotes"
@@ -412,7 +481,7 @@ export default function ProposalDetailClient({
               onChange={(e) => {
                 setReviewNotes(e.target.value);
               }}
-              placeholder="Add notes about your decision..."
+              placeholder={t("proposalDetail.reviewNotesPlaceholder")}
               rows={3}
               className="w-full px-3 py-2 border border-border rounded-lg bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary resize-none"
             />
@@ -427,21 +496,21 @@ export default function ProposalDetailClient({
                   disabled={actionLoading}
                   className="px-4 py-2 bg-green-600 hover:bg-green-700 text-white rounded-lg transition-colors disabled:opacity-50 flex items-center gap-2"
                 >
-                  {actionLoading ? "..." : "✓ Approve"}
+                  {actionLoading ? "..." : t("proposalDetail.approve")}
                 </button>
                 <button
                   onClick={() => handleStatusChange("DENIED")}
                   disabled={actionLoading}
                   className="px-4 py-2 bg-red-600 hover:bg-red-700 text-white rounded-lg transition-colors disabled:opacity-50 flex items-center gap-2"
                 >
-                  {actionLoading ? "..." : "✗ Deny"}
+                  {actionLoading ? "..." : t("proposalDetail.deny")}
                 </button>
                 <button
                   onClick={() => handleStatusChange("ARCHIVED")}
                   disabled={actionLoading}
                   className="px-4 py-2 bg-gray-600 hover:bg-gray-700 text-white rounded-lg transition-colors disabled:opacity-50 flex items-center gap-2"
                 >
-                  {actionLoading ? "..." : "Archive"}
+                  {actionLoading ? "..." : t("proposalDetail.archive")}
                 </button>
               </>
             )}
@@ -452,7 +521,7 @@ export default function ProposalDetailClient({
                 disabled={actionLoading}
                 className="px-4 py-2 bg-primary hover:bg-primary/90 text-primary-foreground rounded-lg transition-colors disabled:opacity-50 flex items-center gap-2"
               >
-                {actionLoading ? "..." : "🚀 Apply Image"}
+                {actionLoading ? "..." : t("proposalDetail.applyImage")}
               </button>
             )}
           </div>
@@ -463,22 +532,28 @@ export default function ProposalDetailClient({
       {proposal.reviewedAt && (
         <div className="bg-card border border-border rounded-xl p-6">
           <h3 className="text-lg font-semibold text-foreground mb-4">
-            Review Information
+            {t("proposalDetail.reviewInformation")}
           </h3>
           <dl className="space-y-2">
             <div className="flex justify-between">
-              <dt className="text-muted-foreground">Reviewed At</dt>
+              <dt className="text-muted-foreground">
+                {t("proposalDetail.reviewedAt")}
+              </dt>
               <dd className="font-medium">{formatDate(proposal.reviewedAt)}</dd>
             </div>
             {proposal.reviewedBy && (
               <div className="flex justify-between">
-                <dt className="text-muted-foreground">Reviewed By</dt>
+                <dt className="text-muted-foreground">
+                  {t("proposalDetail.reviewedBy")}
+                </dt>
                 <dd className="font-medium">{proposal.reviewedBy}</dd>
               </div>
             )}
             {proposal.reviewNotes && (
               <div className="mt-3">
-                <dt className="text-muted-foreground mb-1">Review Notes</dt>
+                <dt className="text-muted-foreground mb-1">
+                  {t("proposalDetail.reviewNotesLabel")}
+                </dt>
                 <dd className="bg-muted rounded-lg p-3 text-sm">
                   {proposal.reviewNotes}
                 </dd>
@@ -492,7 +567,7 @@ export default function ProposalDetailClient({
       {proposal.auditHistory && proposal.auditHistory.length > 0 && (
         <div className="bg-card border border-border rounded-xl p-6">
           <h3 className="text-lg font-semibold text-foreground mb-4">
-            Audit History
+            {t("proposalDetail.auditHistory")}
           </h3>
           <div className="space-y-3">
             {proposal.auditHistory.map((audit) => (

--- a/src/app/[locale]/admin/images/proposals/[id]/page.tsx
+++ b/src/app/[locale]/admin/images/proposals/[id]/page.tsx
@@ -1,4 +1,4 @@
-import { setRequestLocale } from "next-intl/server";
+import { getTranslations, setRequestLocale } from "next-intl/server";
 import type { Metadata } from "next";
 import { Link } from "@i18n/navigation";
 import ProposalDetailClient from "./ProposalDetailClient";
@@ -10,9 +10,11 @@ type Props = {
 };
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
-  const { id } = await params;
+  const { locale, id } = await params;
+  const t = await getTranslations({ locale, namespace: "admin.images" });
+
   return {
-    title: `Proposal ${id.slice(0, 8)}... - Admin`,
+    title: t("proposalDetail.pageTitle", { idShort: id.slice(0, 8) }),
     robots: { index: false, follow: false },
     alternates: {
       languages: {
@@ -32,6 +34,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 export default async function ProposalDetailPage({ params }: Props) {
   const { locale, id } = await params;
   setRequestLocale(locale);
+  const t = await getTranslations({ locale, namespace: "admin.images" });
 
   return (
     <div className="py-8 px-4">
@@ -42,10 +45,10 @@ export default async function ProposalDetailPage({ params }: Props) {
             href="/admin/images/proposals"
             className="text-sm text-muted-foreground hover:text-primary mb-4 inline-block"
           >
-            ← Back to Proposals
+            {t("proposalDetail.backToProposals")}
           </Link>
           <h1 className="text-3xl font-bold text-foreground">
-            🔍 Proposal Details
+            {t("proposalDetail.heading")}
           </h1>
         </div>
 

--- a/src/app/[locale]/admin/images/proposals/page.tsx
+++ b/src/app/[locale]/admin/images/proposals/page.tsx
@@ -1,4 +1,4 @@
-import { setRequestLocale } from "next-intl/server";
+import { getTranslations, setRequestLocale } from "next-intl/server";
 import type { Metadata } from "next";
 import { Link } from "@i18n/navigation";
 import ProposalsListClient from "./ProposalsListClient";
@@ -9,9 +9,12 @@ type Props = {
   params: Promise<{ locale: string }>;
 };
 
-export async function generateMetadata(): Promise<Metadata> {
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "admin.images" });
+
   return {
-    title: "Image Proposals - Admin",
+    title: t("proposals.pageTitle"),
     robots: { index: false, follow: false },
     alternates: {
       languages: {
@@ -32,6 +35,7 @@ export async function generateMetadata(): Promise<Metadata> {
 export default async function ProposalsPage({ params }: Props) {
   const { locale } = await params;
   setRequestLocale(locale);
+  const t = await getTranslations({ locale, namespace: "admin.images" });
 
   return (
     <div className="py-8 px-4">
@@ -42,14 +46,13 @@ export default async function ProposalsPage({ params }: Props) {
             href="/admin/images"
             className="text-sm text-muted-foreground hover:text-primary mb-4 inline-block"
           >
-            ← Back to Image Review
+            {t("proposals.backToImageReview")}
           </Link>
           <h1 className="text-3xl font-bold text-foreground">
-            📋 Image Proposals
+            {t("proposals.heading")}
           </h1>
           <p className="text-muted-foreground mt-2">
-            Review and manage proposed image changes from workflows and user
-            flags.
+            {t("proposals.description")}
           </p>
         </div>
 

--- a/src/app/[locale]/admin/performance/PerformanceDashboardClient.tsx
+++ b/src/app/[locale]/admin/performance/PerformanceDashboardClient.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { useTranslations } from "next-intl";
 
 type Rating = "good" | "needs-improvement" | "poor";
 
@@ -35,53 +36,35 @@ type InteractionEventEntry = PerformanceEntry & {
 
 const METRICS: Array<{
   key: MetricKey;
-  label: string;
   unit: string;
-  description: string;
   thresholds: { good: number; needsImprovement: number };
 }> = [
   {
     key: "lcp",
-    label: "Largest Contentful Paint",
     unit: "ms",
-    description: "Render timing for the largest element in view.",
     thresholds: { good: 2500, needsImprovement: 4000 },
   },
   {
     key: "cls",
-    label: "Cumulative Layout Shift",
     unit: "",
-    description: "Unexpected layout movement during page load.",
     thresholds: { good: 0.1, needsImprovement: 0.25 },
   },
   {
     key: "inp",
-    label: "Interaction to Next Paint",
     unit: "ms",
-    description: "Responsiveness to user interactions (estimated from events).",
     thresholds: { good: 200, needsImprovement: 500 },
   },
   {
     key: "fcp",
-    label: "First Contentful Paint",
     unit: "ms",
-    description: "Time until the first text or image is rendered.",
     thresholds: { good: 1800, needsImprovement: 3000 },
   },
   {
     key: "ttfb",
-    label: "Time to First Byte",
     unit: "ms",
-    description: "Server response latency measured on navigation.",
     thresholds: { good: 800, needsImprovement: 1800 },
   },
 ];
-
-const ratingLabels: Record<Rating, string> = {
-  good: "Good",
-  "needs-improvement": "Needs Improvement",
-  poor: "Poor",
-};
 
 const ratingClasses: Record<Rating, string> = {
   good: "border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-900 dark:bg-emerald-950/40 dark:text-emerald-300",
@@ -145,6 +128,7 @@ const getMetricValue = (
 };
 
 export default function PerformanceDashboardClient() {
+  const t = useTranslations("admin.performance");
   const [metrics, setMetrics] = useState<Record<MetricKey, number | null>>({
     lcp: null,
     cls: null,
@@ -303,6 +287,15 @@ export default function PerformanceDashboardClient() {
     };
   }, [refreshSnapshot, updateMetric]);
 
+  const ratingLabels: Record<Rating, string> = useMemo(
+    () => ({
+      good: t("rating.good"),
+      "needs-improvement": t("rating.needsImprovement"),
+      poor: t("rating.poor"),
+    }),
+    [t]
+  );
+
   const snapshots = useMemo<MetricSnapshot[]>(
     () =>
       METRICS.map((metric) => {
@@ -310,14 +303,14 @@ export default function PerformanceDashboardClient() {
 
         return {
           key: metric.key,
-          label: metric.label,
+          label: t(`metrics.${metric.key}.label`),
           value,
           unit: metric.unit,
-          description: metric.description,
+          description: t(`metrics.${metric.key}.description`),
           rating: getRating(metric.key, value),
         };
       }),
-    [metrics]
+    [metrics, t]
   );
 
   const jsonSnapshot = useMemo(
@@ -348,11 +341,10 @@ export default function PerformanceDashboardClient() {
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div>
           <h2 className="text-xl font-semibold text-foreground">
-            Live Core Web Vitals
+            {t("liveVitalsHeading")}
           </h2>
           <p className="text-sm text-muted-foreground">
-            Metrics are captured from the current session using the browser
-            Performance APIs.
+            {t("liveVitalsDescription")}
           </p>
         </div>
         <div className="flex flex-wrap gap-2">
@@ -361,7 +353,7 @@ export default function PerformanceDashboardClient() {
             onClick={refreshSnapshot}
             className="rounded-lg border border-border bg-background px-3 py-2 text-sm font-medium text-foreground shadow-sm hover:bg-muted"
           >
-            Refresh snapshot
+            {t("refreshSnapshot")}
           </button>
           <button
             type="button"
@@ -369,10 +361,10 @@ export default function PerformanceDashboardClient() {
             className="rounded-lg border border-border bg-foreground px-3 py-2 text-sm font-medium text-background shadow-sm hover:bg-foreground/90"
           >
             {copyStatus === "copied"
-              ? "Copied"
+              ? t("copied")
               : copyStatus === "failed"
-                ? "Copy failed"
-                : "Copy JSON"}
+                ? t("copyFailed")
+                : t("copyJson")}
           </button>
         </div>
       </div>
@@ -407,36 +399,36 @@ export default function PerformanceDashboardClient() {
       <div className="grid gap-4 lg:grid-cols-3">
         <div className="rounded-xl border border-border bg-card p-4">
           <h3 className="text-sm font-semibold text-foreground">
-            Resource Mix
+            {t("resourceMix")}
           </h3>
           <p className="text-xs text-muted-foreground">
-            Transfer size totals for this page load.
+            {t("resourceMixDescription")}
           </p>
           <div className="mt-4 space-y-2 text-sm text-foreground">
             <div className="flex justify-between">
-              <span>JavaScript</span>
+              <span>{t("resourceJavaScript")}</span>
               <span className="font-semibold">{resources.jsTransferKb} KB</span>
             </div>
             <div className="flex justify-between">
-              <span>CSS</span>
+              <span>{t("resourceCss")}</span>
               <span className="font-semibold">
                 {resources.cssTransferKb} KB
               </span>
             </div>
             <div className="flex justify-between">
-              <span>Images</span>
+              <span>{t("resourceImages")}</span>
               <span className="font-semibold">
                 {resources.imageTransferKb} KB
               </span>
             </div>
             <div className="flex justify-between border-t border-border pt-2">
-              <span>Total</span>
+              <span>{t("resourceTotal")}</span>
               <span className="font-semibold">
                 {resources.totalTransferKb} KB
               </span>
             </div>
             <div className="flex justify-between text-xs text-muted-foreground">
-              <span>Resources counted</span>
+              <span>{t("resourceCounted")}</span>
               <span>{resources.resourceCount}</span>
             </div>
           </div>
@@ -444,11 +436,10 @@ export default function PerformanceDashboardClient() {
 
         <div className="rounded-xl border border-border bg-card p-4 lg:col-span-2">
           <h3 className="text-sm font-semibold text-foreground">
-            Reference Targets
+            {t("referenceTargets")}
           </h3>
           <p className="text-xs text-muted-foreground">
-            Targets align with Web Vitals guidance and the project performance
-            budgets.
+            {t("referenceTargetsDescription")}
           </p>
           <div className="mt-4 grid gap-3 md:grid-cols-2">
             {METRICS.map((metric) => (
@@ -460,11 +451,12 @@ export default function PerformanceDashboardClient() {
                   {metric.key}
                 </div>
                 <div className="mt-1 text-sm text-foreground">
-                  Good: {metric.thresholds.good}
+                  {t("goodTarget")}: {metric.thresholds.good}
                   {metric.unit}
                 </div>
                 <div className="text-xs text-muted-foreground">
-                  Needs improvement: ≤ {metric.thresholds.needsImprovement}
+                  {t("needsImprovementTarget")}: ≤{" "}
+                  {metric.thresholds.needsImprovement}
                   {metric.unit}
                 </div>
               </div>
@@ -475,17 +467,16 @@ export default function PerformanceDashboardClient() {
 
       <div className="rounded-xl border border-border bg-muted/40 p-4 text-sm text-muted-foreground">
         <div className="flex flex-wrap items-center gap-2">
-          <span className="font-semibold text-foreground">Last updated:</span>
+          <span className="font-semibold text-foreground">
+            {t("lastUpdated")}:
+          </span>
           <span>
             {lastUpdated
               ? lastUpdated.toLocaleTimeString()
-              : "Waiting for metrics..."}
+              : t("waitingForMetrics")}
           </span>
         </div>
-        <p className="mt-2">
-          Pair this dashboard with Vercel Speed Insights and Lighthouse CI for
-          historical tracking and regression alerts.
-        </p>
+        <p className="mt-2">{t("historicalTrackingHint")}</p>
       </div>
     </div>
   );

--- a/src/components/APIDocumentation.tsx
+++ b/src/components/APIDocumentation.tsx
@@ -56,14 +56,14 @@ export function APIDocumentation({ locale }: APIDocumentationProps) {
             <div className="rounded bg-gray-100 p-3 text-sm dark:bg-gray-700">
               <div className="grid gap-2 text-gray-700 dark:text-gray-300">
                 <div>
-                  <code>X-RateLimit-Limit</code>: Maximum requests per window
+                  <code>X-RateLimit-Limit</code>: {t("rateLimitHeaders.limit")}
                 </div>
                 <div>
-                  <code>X-RateLimit-Remaining</code>: Remaining requests
+                  <code>X-RateLimit-Remaining</code>:{" "}
+                  {t("rateLimitHeaders.remaining")}
                 </div>
                 <div>
-                  <code>X-RateLimit-Reset</code>: Unix timestamp when limit
-                  resets
+                  <code>X-RateLimit-Reset</code>: {t("rateLimitHeaders.reset")}
                 </div>
               </div>
             </div>
@@ -347,7 +347,7 @@ filtered = requests.get('${baseUrl}/api/v1/trees', params=params)`}
                 clipRule="evenodd"
               />
             </svg>
-            GitHub Issues
+            {t("githubIssues")}
           </a>
         </div>
 
@@ -388,6 +388,7 @@ function EndpointCard({
   example,
   response,
 }: EndpointCardProps) {
+  const t = useTranslations("api");
   const [showResponse, setShowResponse] = useState(false);
 
   return (
@@ -409,7 +410,7 @@ function EndpointCard({
 
       <div className="p-4">
         <h4 className="mb-2 font-medium text-gray-900 dark:text-white">
-          Parameters
+          {t("parameters")}
         </h4>
         <div className="space-y-2">
           {parameters.map((param) => (
@@ -429,7 +430,7 @@ function EndpointCard({
 
       <div className="border-t border-gray-200 p-4 dark:border-gray-700">
         <h4 className="mb-2 font-medium text-gray-900 dark:text-white">
-          Example
+          {t("example")}
         </h4>
         <div className="flex items-center gap-2">
           <code className="flex-1 overflow-x-auto rounded bg-gray-100 p-2 text-sm dark:bg-gray-700">
@@ -441,7 +442,7 @@ function EndpointCard({
             rel="noopener noreferrer"
             className="rounded bg-green-600 px-3 py-2 text-sm font-medium text-white hover:bg-green-700"
           >
-            Try it
+            {t("tryIt")}
           </a>
         </div>
       </div>
@@ -466,7 +467,7 @@ function EndpointCard({
               d="M9 5l7 7-7 7"
             />
           </svg>
-          Response
+          {t("response")}
         </button>
         {showResponse && (
           <pre className="mt-2 overflow-x-auto rounded bg-gray-900 p-4 text-sm text-gray-100">

--- a/src/components/ComponentErrorBoundary.tsx
+++ b/src/components/ComponentErrorBoundary.tsx
@@ -19,9 +19,16 @@ export function ComponentErrorBoundary({
   componentName = "Component",
 }: ComponentErrorBoundaryProps) {
   const t = useTranslations("error");
+  const messages = {
+    title: t("title"),
+    description: t("description"),
+    tryAgain: t("tryAgain"),
+    developmentDetails: t("developmentDetails"),
+  };
 
   return (
     <ErrorBoundary
+      messages={messages}
       fallback={(error, reset) => (
         <div className="border border-destructive bg-destructive/10 rounded-lg p-6">
           <div className="flex items-start gap-3">
@@ -54,7 +61,10 @@ export function ComponentErrorBoundary({
         </div>
       )}
       onError={(error) => {
-        console.error(`${componentName} error:`, error);
+        if (process.env.NODE_ENV === "development") {
+          console.error(`${componentName} error:`, error);
+        }
+
         // Log error with component context
         captureException(error, {
           tags: {

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -22,13 +22,12 @@ interface ErrorBoundaryState {
   error: Error | null;
 }
 
-const DEFAULT_ERROR_BOUNDARY_MESSAGES: ErrorBoundaryMessages = {
-  title: "Something went wrong / Algo salió mal",
+const FALLBACK_ERROR_BOUNDARY_MESSAGES: ErrorBoundaryMessages = {
+  title: "Something went wrong",
   description:
-    "An unexpected error occurred. Please try again. / Ocurrió un error inesperado. Por favor intenta de nuevo.",
-  tryAgain: "Try again / Intentar de nuevo",
-  developmentDetails:
-    "Technical details (development only) / Detalles técnicos (solo en desarrollo)",
+    "An unexpected error occurred. Please try again or return to the homepage.",
+  tryAgain: "Try Again",
+  developmentDetails: "Technical details (development only)",
 };
 
 /**
@@ -72,7 +71,7 @@ export class ErrorBoundary extends Component<
 
   render() {
     if (this.state.hasError && this.state.error) {
-      const messages = this.props.messages ?? DEFAULT_ERROR_BOUNDARY_MESSAGES;
+      const messages = this.props.messages ?? FALLBACK_ERROR_BOUNDARY_MESSAGES;
 
       // Use custom fallback if provided
       if (this.props.fallback) {

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -25,7 +25,7 @@ interface ErrorBoundaryState {
 const FALLBACK_ERROR_BOUNDARY_MESSAGES: ErrorBoundaryMessages = {
   title: "Something went wrong",
   description:
-    "An unexpected error occurred. Please try again or return to the homepage.",
+    "An unexpected error occurred. Please try again.",
   tryAgain: "Try Again",
   developmentDetails: "Technical details (development only)",
 };

--- a/src/components/PageErrorBoundary.tsx
+++ b/src/components/PageErrorBoundary.tsx
@@ -16,9 +16,16 @@ interface PageErrorBoundaryProps {
 export function PageErrorBoundary({ children }: PageErrorBoundaryProps) {
   const router = useRouter();
   const t = useTranslations("error");
+  const messages = {
+    title: t("title"),
+    description: t("description"),
+    tryAgain: t("tryAgain"),
+    developmentDetails: t("developmentDetails"),
+  };
 
   return (
     <ErrorBoundary
+      messages={messages}
       fallback={(error, reset) => (
         <div className="flex items-center justify-center min-h-screen p-8">
           <div className="text-center max-w-lg">
@@ -61,8 +68,9 @@ export function PageErrorBoundary({ children }: PageErrorBoundaryProps) {
         </div>
       )}
       onError={(error, errorInfo) => {
-        // Log to console in development
-        console.error("Page error:", error, errorInfo);
+        if (process.env.NODE_ENV === "development") {
+          console.error("Page error:", error, errorInfo);
+        }
 
         // TODO: Send to error tracking
         // trackError('page_error', { error, errorInfo });

--- a/src/components/ShareLink.tsx
+++ b/src/components/ShareLink.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useTranslations } from "next-intl";
 
 interface ShareLinkProps {
   title?: string;
@@ -9,11 +10,14 @@ interface ShareLinkProps {
 }
 
 export function ShareLink({
-  title = "Share Link",
-  copiedText = "Copied!",
+  title,
+  copiedText,
   className = "",
 }: ShareLinkProps) {
+  const t = useTranslations("share");
   const [copied, setCopied] = useState(false);
+  const resolvedTitle = title ?? t("copyLink");
+  const resolvedCopiedText = copiedText ?? t("copied");
 
   const handleCopy = async () => {
     try {
@@ -23,7 +27,7 @@ export function ShareLink({
         setCopied(false);
       }, 2000);
     } catch (err) {
-      console.error("Failed to copy link:", err);
+      console.error(t("failedToCopy"), err);
     }
   };
 
@@ -31,7 +35,7 @@ export function ShareLink({
     <button
       onClick={handleCopy}
       className={`inline-flex items-center gap-2 px-4 py-2 bg-muted hover:bg-muted/80 border border-border rounded-lg text-sm font-medium transition-colors ${className}`}
-      aria-label={title}
+      aria-label={resolvedTitle}
     >
       {copied ? (
         <>
@@ -48,7 +52,7 @@ export function ShareLink({
               d="M5 13l4 4L19 7"
             />
           </svg>
-          <span className="text-success">{copiedText}</span>
+          <span className="text-success">{resolvedCopiedText}</span>
         </>
       ) : (
         <>
@@ -65,7 +69,7 @@ export function ShareLink({
               d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
             />
           </svg>
-          <span>{title}</span>
+          <span>{resolvedTitle}</span>
         </>
       )}
     </button>

--- a/tests/route-regression.test.ts
+++ b/tests/route-regression.test.ts
@@ -1020,6 +1020,16 @@ describe("High-traffic Spanish surface parity", () => {
           /t\("shareOnPinterest"\)/,
         ],
       },
+      {
+        file: "src/components/ShareLink.tsx",
+        forbiddenPatterns: [/title = "Share Link"/, /copiedText = "Copied!"/],
+        requiredPatterns: [
+          /useTranslations\("share"\)/,
+          /title \?\? t\("copyLink"\)/,
+          /copiedText \?\? t\("copied"\)/,
+          /t\("failedToCopy"\)/,
+        ],
+      },
     ];
 
     const violations: string[] = [];
@@ -1054,6 +1064,8 @@ describe("High-traffic Spanish surface parity", () => {
         shareOnWhatsApp?: string;
         shareOnLinkedIn?: string;
         shareOnPinterest?: string;
+        copyLink?: string;
+        copied?: string;
       };
     };
     const esMessages = JSON.parse(
@@ -1066,9 +1078,15 @@ describe("High-traffic Spanish surface parity", () => {
         shareOnWhatsApp?: string;
         shareOnLinkedIn?: string;
         shareOnPinterest?: string;
+        copyLink?: string;
+        copied?: string;
       };
     };
 
+    expect(enMessages.share?.copyLink).toBe("Copy link");
+    expect(esMessages.share?.copyLink).toBe("Copiar enlace");
+    expect(enMessages.share?.copied).toBe("Copied!");
+    expect(esMessages.share?.copied).toBe("¡Copiado!");
     expect(enMessages.share?.shareNative).toBe("Share...");
     expect(esMessages.share?.shareNative).toBe("Compartir...");
     expect(enMessages.share?.shareOnX).toBe("Share on X / Twitter");
@@ -1085,6 +1103,364 @@ describe("High-traffic Spanish surface parity", () => {
     if (violations.length > 0) {
       console.log(
         `Share surfaces should keep localized menu labels:\n` +
+          violations.map((entry) => `  - ${entry}`).join("\n")
+      );
+    }
+
+    expect(violations).toEqual([]);
+  });
+
+  it("should keep API documentation helper labels localized", () => {
+    const apiDocsContent = fs.readFileSync(
+      path.join(ROOT, "src/components/APIDocumentation.tsx"),
+      "utf-8"
+    );
+
+    const violations: string[] = [];
+
+    for (const pattern of [
+      /Maximum requests per window/,
+      /Remaining requests/,
+      /Unix timestamp when limit resets/,
+      />\s*Parameters\s*</,
+      />\s*Example\s*</,
+      />\s*Try it\s*</,
+      />\s*Response\s*</,
+      />\s*GitHub Issues\s*</,
+    ]) {
+      if (pattern.test(apiDocsContent)) {
+        violations.push(
+          `src/components/APIDocumentation.tsx: matched forbidden pattern ${pattern}`
+        );
+      }
+    }
+
+    for (const pattern of [
+      /useTranslations\("api"\)/,
+      /t\("rateLimitHeaders\.limit"\)/,
+      /t\("rateLimitHeaders\.remaining"\)/,
+      /t\("rateLimitHeaders\.reset"\)/,
+      /\{t\("parameters"\)\}/,
+      /\{t\("example"\)\}/,
+      /\{t\("tryIt"\)\}/,
+      /\{t\("response"\)\}/,
+      /\{t\("githubIssues"\)\}/,
+    ]) {
+      if (!pattern.test(apiDocsContent)) {
+        violations.push(
+          `src/components/APIDocumentation.tsx: missing required pattern ${pattern}`
+        );
+      }
+    }
+
+    const enMessages = JSON.parse(
+      fs.readFileSync(path.join(ROOT, "messages/en.json"), "utf-8")
+    ) as {
+      api?: {
+        rateLimitHeaders?: {
+          limit?: string;
+          remaining?: string;
+          reset?: string;
+        };
+        parameters?: string;
+        example?: string;
+        tryIt?: string;
+        response?: string;
+        githubIssues?: string;
+      };
+    };
+    const esMessages = JSON.parse(
+      fs.readFileSync(path.join(ROOT, "messages/es.json"), "utf-8")
+    ) as {
+      api?: {
+        rateLimitHeaders?: {
+          limit?: string;
+          remaining?: string;
+          reset?: string;
+        };
+        parameters?: string;
+        example?: string;
+        tryIt?: string;
+        response?: string;
+        githubIssues?: string;
+      };
+    };
+
+    expect(enMessages.api?.rateLimitHeaders?.limit).toBe(
+      "Maximum requests per window"
+    );
+    expect(esMessages.api?.rateLimitHeaders?.limit).toBe(
+      "Máximo de solicitudes por ventana"
+    );
+    expect(enMessages.api?.rateLimitHeaders?.remaining).toBe(
+      "Remaining requests"
+    );
+    expect(esMessages.api?.rateLimitHeaders?.remaining).toBe(
+      "Solicitudes restantes"
+    );
+    expect(enMessages.api?.rateLimitHeaders?.reset).toBe(
+      "Unix timestamp when the limit resets"
+    );
+    expect(esMessages.api?.rateLimitHeaders?.reset).toBe(
+      "Marca de tiempo Unix cuando se reinicia el límite"
+    );
+    expect(enMessages.api?.parameters).toBe("Parameters");
+    expect(esMessages.api?.parameters).toBe("Parámetros");
+    expect(enMessages.api?.example).toBe("Example");
+    expect(esMessages.api?.example).toBe("Ejemplo");
+    expect(enMessages.api?.tryIt).toBe("Try it");
+    expect(esMessages.api?.tryIt).toBe("Probar");
+    expect(enMessages.api?.response).toBe("Response");
+    expect(esMessages.api?.response).toBe("Respuesta");
+    expect(enMessages.api?.githubIssues).toBe("GitHub Issues");
+    expect(esMessages.api?.githubIssues).toBe("Issues de GitHub");
+
+    if (violations.length > 0) {
+      console.log(
+        `API documentation labels should stay localized:\n` +
+          violations.map((entry) => `  - ${entry}`).join("\n")
+      );
+    }
+
+    expect(violations).toEqual([]);
+  });
+
+  it("should keep admin image proposal surfaces localized", () => {
+    const componentChecks = [
+      {
+        file: "src/app/[locale]/admin/images/proposals/page.tsx",
+        requiredPatterns: [
+          /getTranslations\(\{ locale, namespace: "admin.images" \}\)/,
+          /t\("proposals\.pageTitle"\)/,
+          /t\("proposals\.backToImageReview"\)/,
+          /t\("proposals\.heading"\)/,
+        ],
+      },
+      {
+        file: "src/app/[locale]/admin/images/proposals/ProposalsListClient.tsx",
+        requiredPatterns: [
+          /useTranslations\("admin.images"\)/,
+          /t\("proposals\.searchByTreeSlug"\)/,
+          /t\("proposals\.allStatuses"\)/,
+          /t\("proposals\.allSources"\)/,
+          /t\("proposals\.resultsCount"/,
+          /t\("proposals\.emptyTitle"\)/,
+          /t\("proposals\.errors\.databaseNotInitialized"\)/,
+        ],
+      },
+      {
+        file: "src/app/[locale]/admin/images/proposals/[id]/page.tsx",
+        requiredPatterns: [
+          /getTranslations\(\{ locale, namespace: "admin.images" \}\)/,
+          /t\("proposalDetail\.pageTitle"/,
+          /t\("proposalDetail\.backToProposals"\)/,
+          /t\("proposalDetail\.heading"\)/,
+        ],
+      },
+      {
+        file: "src/app/[locale]/admin/images/proposals/[id]/ProposalDetailClient.tsx",
+        requiredPatterns: [
+          /useTranslations\("admin.images"\)/,
+          /t\("proposalDetail\.imageComparison"\)/,
+          /t\("proposalDetail\.proposalReason"\)/,
+          /t\("proposalDetail\.takeAction"\)/,
+          /t\("proposalDetail\.reviewInformation"\)/,
+          /t\("proposalDetail\.auditHistory"\)/,
+        ],
+      },
+    ];
+
+    const forbiddenPatterns = [
+      /Back to Image Review/,
+      /Image Proposals/,
+      /Review and manage proposed image changes from workflows and user flags\./,
+      /Search by Tree Slug/,
+      /All Statuses/,
+      /All Sources/,
+      /No proposals found/,
+      /Try adjusting your filters or run the weekly image workflow\./,
+      /Current Image/,
+      /Proposed Image/,
+      /No current image/,
+      /Proposal Details/,
+      /Proposal Reason/,
+      /Take Action/,
+      /Review Information/,
+      /Audit History/,
+      /Apply Image/,
+      /Reviewed At/,
+      /Reviewed By/,
+    ];
+
+    const violations: string[] = [];
+
+    for (const { file, requiredPatterns } of componentChecks) {
+      const content = fs.readFileSync(path.join(ROOT, file), "utf-8");
+
+      for (const pattern of forbiddenPatterns) {
+        if (pattern.test(content)) {
+          violations.push(`${file}: matched forbidden pattern ${pattern}`);
+        }
+      }
+
+      for (const pattern of requiredPatterns) {
+        if (!pattern.test(content)) {
+          violations.push(`${file}: missing required pattern ${pattern}`);
+        }
+      }
+    }
+
+    const enMessages = JSON.parse(
+      fs.readFileSync(path.join(ROOT, "messages/en.json"), "utf-8")
+    ) as {
+      admin?: {
+        images?: {
+          proposals?: { heading?: string; allStatuses?: string };
+          proposalDetail?: { heading?: string; takeAction?: string };
+        };
+      };
+    };
+    const esMessages = JSON.parse(
+      fs.readFileSync(path.join(ROOT, "messages/es.json"), "utf-8")
+    ) as {
+      admin?: {
+        images?: {
+          proposals?: { heading?: string; allStatuses?: string };
+          proposalDetail?: { heading?: string; takeAction?: string };
+        };
+      };
+    };
+
+    expect(enMessages.admin?.images?.proposals?.heading).toBe(
+      "📋 Image Proposals"
+    );
+    expect(esMessages.admin?.images?.proposals?.heading).toBe(
+      "📋 Propuestas de Imágenes"
+    );
+    expect(enMessages.admin?.images?.proposals?.allStatuses).toBe(
+      "All Statuses"
+    );
+    expect(esMessages.admin?.images?.proposals?.allStatuses).toBe(
+      "Todos los estados"
+    );
+    expect(enMessages.admin?.images?.proposalDetail?.heading).toBe(
+      "🔍 Proposal Details"
+    );
+    expect(esMessages.admin?.images?.proposalDetail?.heading).toBe(
+      "🔍 Detalles de la Propuesta"
+    );
+    expect(enMessages.admin?.images?.proposalDetail?.takeAction).toBe(
+      "Take Action"
+    );
+    expect(esMessages.admin?.images?.proposalDetail?.takeAction).toBe(
+      "Tomar Acción"
+    );
+
+    if (violations.length > 0) {
+      console.log(
+        `Admin image proposal surfaces should stay localized:\n` +
+          violations.map((entry) => `  - ${entry}`).join("\n")
+      );
+    }
+
+    expect(violations).toEqual([]);
+  });
+
+  it("should keep admin performance dashboard labels localized", () => {
+    const performanceClient = fs.readFileSync(
+      path.join(
+        ROOT,
+        "src/app/[locale]/admin/performance/PerformanceDashboardClient.tsx"
+      ),
+      "utf-8"
+    );
+
+    const violations: string[] = [];
+
+    for (const pattern of [
+      /Live Core Web Vitals/,
+      /Metrics are captured from the current session using the browser Performance APIs\./,
+      /Refresh snapshot/,
+      /Copy JSON/,
+      /Copy failed/,
+      /Resource Mix/,
+      /Resources counted/,
+      /Reference Targets/,
+      /Last updated/,
+      /Waiting for metrics\.\.\./,
+    ]) {
+      if (pattern.test(performanceClient)) {
+        violations.push(
+          `src/app/[locale]/admin/performance/PerformanceDashboardClient.tsx: matched forbidden pattern ${pattern}`
+        );
+      }
+    }
+
+    for (const pattern of [
+      /useTranslations\("admin.performance"\)/,
+      /t\("liveVitalsHeading"\)/,
+      /t\("refreshSnapshot"\)/,
+      /t\("copyJson"\)/,
+      /t\("resourceMix"\)/,
+      /t\("resourceCounted"\)/,
+      /t\("referenceTargets"\)/,
+      /t\("lastUpdated"\)/,
+      /t\("waitingForMetrics"\)/,
+      /t\(`metrics\.\$\{metric\.key\}\.label`\)/,
+      /t\(`metrics\.\$\{metric\.key\}\.description`\)/,
+    ]) {
+      if (!pattern.test(performanceClient)) {
+        violations.push(
+          `src/app/[locale]/admin/performance/PerformanceDashboardClient.tsx: missing required pattern ${pattern}`
+        );
+      }
+    }
+
+    const enMessages = JSON.parse(
+      fs.readFileSync(path.join(ROOT, "messages/en.json"), "utf-8")
+    ) as {
+      admin?: {
+        performance?: {
+          liveVitalsHeading?: string;
+          resourceMix?: string;
+          lastUpdated?: string;
+          rating?: { good?: string };
+        };
+      };
+    };
+    const esMessages = JSON.parse(
+      fs.readFileSync(path.join(ROOT, "messages/es.json"), "utf-8")
+    ) as {
+      admin?: {
+        performance?: {
+          liveVitalsHeading?: string;
+          resourceMix?: string;
+          lastUpdated?: string;
+          rating?: { good?: string };
+        };
+      };
+    };
+
+    expect(enMessages.admin?.performance?.liveVitalsHeading).toBe(
+      "Live Core Web Vitals"
+    );
+    expect(esMessages.admin?.performance?.liveVitalsHeading).toBe(
+      "Core Web Vitals en Vivo"
+    );
+    expect(enMessages.admin?.performance?.resourceMix).toBe("Resource Mix");
+    expect(esMessages.admin?.performance?.resourceMix).toBe(
+      "Distribución de Recursos"
+    );
+    expect(enMessages.admin?.performance?.lastUpdated).toBe("Last updated");
+    expect(esMessages.admin?.performance?.lastUpdated).toBe(
+      "Última actualización"
+    );
+    expect(enMessages.admin?.performance?.rating?.good).toBe("Good");
+    expect(esMessages.admin?.performance?.rating?.good).toBe("Bueno");
+
+    if (violations.length > 0) {
+      console.log(
+        `Admin performance dashboard labels should stay localized:\n` +
           violations.map((entry) => `  - ${entry}`).join("\n")
       );
     }
@@ -1154,6 +1530,18 @@ describe("High-traffic Spanish surface parity", () => {
   it("should keep shared error and loading fallbacks localized", () => {
     const componentChecks = [
       {
+        file: "src/components/ErrorBoundary.tsx",
+        forbiddenPatterns: [
+          /Something went wrong \/ Algo salió mal/,
+          /Try again \/ Intentar de nuevo/,
+          /Technical details \(development only\) \/ Detalles técnicos \(solo en desarrollo\)/,
+        ],
+        requiredPatterns: [
+          /FALLBACK_ERROR_BOUNDARY_MESSAGES/,
+          /this\.props\.messages \?\? FALLBACK_ERROR_BOUNDARY_MESSAGES/,
+        ],
+      },
+      {
         file: "src/components/LoadingFallback.tsx",
         forbiddenPatterns: [/message = "Loading\.\.\."/],
         requiredPatterns: [
@@ -1178,6 +1566,8 @@ describe("High-traffic Spanish surface parity", () => {
         ],
         requiredPatterns: [
           /useTranslations\("error"\)/,
+          /const messages = \{/,
+          /messages=\{messages\}/,
           /t\("componentErrorTitle"\)/,
           /t\("componentErrorDescription"\)/,
           /t\("tryAgain"\)/,
@@ -1191,6 +1581,8 @@ describe("High-traffic Spanish surface parity", () => {
           />\s*Error Details \(Development Only\)\s*</,
         ],
         requiredPatterns: [
+          /const messages = \{/,
+          /messages=\{messages\}/,
           /t\("pageErrorDescription"\)/,
           /t\("developmentDetails"\)/,
           /error\.stack \?\? error\.message/,


### PR DESCRIPTION
## Summary
- localize shared fallback and helper UI still showing hardcoded English or slash-combined bilingual copy
- translate admin image proposal list/detail and performance dashboard surfaces through next-intl message namespaces
- expand route regression coverage and update the implementation plan to document the completed parity sweep

## Validation
- npx vitest run tests/route-regression.test.ts
- npm run lint
- npm run build