### PR TITLE
fix: formalize content governance and align audited statuses

### DIFF
--- a/.github/INTERNAL_COLLABORATION.md
+++ b/.github/INTERNAL_COLLABORATION.md
@@ -15,6 +15,17 @@ This document applies to approved repository collaborators and maintainers.
 4. Open a pull request and request internal review.
 5. Merge after approvals and successful checks.
 
+## Sensitive Content Review Routing
+
+For pull requests that add or materially change indigenous names, meanings, ceremonial references, or other indigenous knowledge content:
+
+- apply the PR label `needs-indigenous-review`
+- list affected slugs and locales in the PR description
+- link or cite the supporting sources directly in the PR summary
+- wait for internal human review before merge
+
+If labels are temporarily unavailable in the repository settings, include `needs-indigenous-review` as a plain-text flag in the PR description until the label is created.
+
 ## Documentation Expectations
 
 - Update user-facing docs when behavior changes.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -81,7 +81,7 @@ Fixes #
 - [ ] Chrome (Desktop)
 - [ ] Firefox (Desktop)
 - [ ] Safari (Desktop)
-- [ ] Mobile browser: \***\*\_\_\_\_\*\***
+- [ ] Mobile browser: (device/browser)
 
 ## 📝 Additional Notes
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -38,6 +38,16 @@ Fixes #
 
 <!-- Mark completed items with an [x] -->
 
+### 🧭 Review Routing
+
+<!-- Use this section to route sensitive content to the right reviewer path -->
+
+- [ ] No indigenous knowledge content was added or changed
+- [ ] Indigenous knowledge content was added or changed
+  - [ ] I applied the `needs-indigenous-review` label (or noted it explicitly in the PR body if labels are unavailable)
+  - [ ] I listed the affected slugs/locales in the PR description
+  - [ ] I requested internal human review before merge
+
 ### General
 
 - [ ] I have read the [Contributing Guidelines](CONTRIBUTING.md)
@@ -60,6 +70,8 @@ Fixes #
 - [ ] Both language files have the same slug/filename
 - [ ] Frontmatter is complete and accurate
 - [ ] Scientific information is accurate and sourced
+- [ ] I reviewed `docs/CONTENT_PR_ACCEPTANCE_CRITERIA.md` and met the applicable checklist
+- [ ] High-risk factual claims include the required citations
 
 ## 🧪 How Has This Been Tested?
 
@@ -69,7 +81,7 @@ Fixes #
 - [ ] Chrome (Desktop)
 - [ ] Firefox (Desktop)
 - [ ] Safari (Desktop)
-- [ ] Mobile browser: ****\_\_\_\_****
+- [ ] Mobile browser: \***\*\_\_\_\_\*\***
 
 ## 📝 Additional Notes
 

--- a/content/trees/en/araza.mdx
+++ b/content/trees/en/araza.mdx
@@ -92,7 +92,7 @@ safetyNotes: "Completely safe fruit tree. Ripe fruits are edible but extremely s
     { label: "Family", value: "Myrtaceae" },
     { label: "Maximum Height", value: "2.5-15 m" },
     { label: "Native Region", value: "Western Amazon Basin" },
-    { label: "Conservation", value: "Least Concern" },
+    { label: "Conservation", value: "Not Evaluated (NE)" },
     { label: "Key Trait", value: "Highly aromatic acidic fruit" },
   ]}
 />
@@ -605,9 +605,16 @@ The best conditions for arazá in Costa Rica are found in:
 ## Conservation Status
 
 <Callout type="info" title="Conservation Notes">
-  **Status**: Least Concern (LC)
+  **Status**: Not Evaluated (NE)
 
-While not globally threatened, arazá remains an underutilized crop with significant potential. Conservation priorities include:
+The current atlas audit trail indicates that _Eugenia stipitata_ should be
+treated as **Not Evaluated** rather than Least Concern in public-facing copy.
+That does **not** imply the species is threatened; it means the atlas should not
+present a formal IUCN risk category unless a published global assessment is
+clearly available.
+
+Even without a formal IUCN category on this page, conservation priorities for
+the species still include:
 
 - **Genetic diversity**: Preserving cultivated varieties
 - **In-situ conservation**: Protecting wild populations in Amazon
@@ -615,6 +622,9 @@ While not globally threatened, arazá remains an underutilized crop with signifi
 - **Seed challenges**: Recalcitrant seeds cannot be stored conventionally
 
 </Callout>
+
+**Sources:** [GBIF species search — _Eugenia stipitata_](https://www.gbif.org/species/search?q=Eugenia%20stipitata),
+[IUCN Red List entry used on this page](https://www.iucnredlist.org/species/152946445)
 
 ---
 

--- a/content/trees/en/carambola.mdx
+++ b/content/trees/en/carambola.mdx
@@ -106,7 +106,7 @@ commonProblems:
     { label: "Family", value: "Oxalidaceae (Wood Sorrel)" },
     { label: "Maximum Height", value: "5-12 m" },
     { label: "Native Region", value: "Southeast Asia" },
-    { label: "Conservation", value: "Least Concern" },
+    { label: "Conservation", value: "Data Deficient (DD)" },
     { label: "Key Trait", value: "Star-shaped fruit cross-section" },
   ]}
 />
@@ -675,11 +675,19 @@ People with healthy kidneys can safely enjoy carambola in normal amounts. If you
 ## Conservation Status
 
 <Callout type="info" title="Conservation Notes">
-  **Status**: Least Concern (LC)
+  **Status**: Data Deficient (DD)
 
-As a widely cultivated species, carambola faces no conservation concerns. It has been successfully introduced throughout tropical regions worldwide and is commercially important in several countries.
+The current external biodiversity status used by this atlas audit indicates
+that _Averrhoa carambola_ should be treated as **Data Deficient** rather than
+Least Concern. In practice, this means the species is widely cultivated and
+well known agriculturally, but does **not** currently have enough assessment
+data surfaced in the atlas audit pipeline to justify a confident global IUCN
+risk category on this page.
 
 </Callout>
+
+**Sources:** [GBIF species profile](https://www.gbif.org/species/2891641),
+[IUCN Red List search — _Averrhoa carambola_](https://www.iucnredlist.org/search?query=Averrhoa%20carambola)
 
 ---
 

--- a/content/trees/es/araza.mdx
+++ b/content/trees/es/araza.mdx
@@ -92,7 +92,7 @@ safetyNotes: "Árbol frutal completamente seguro. Las frutas maduras son comesti
     { label: "Familia", value: "Myrtaceae" },
     { label: "Altura Máxima", value: "2.5-15 m" },
     { label: "Región Nativa", value: "Cuenca occidental del Amazonas" },
-    { label: "Conservación", value: "Preocupación Menor" },
+    { label: "Conservación", value: "No evaluado (NE)" },
     { label: "Rasgo Clave", value: "Fruta altamente aromática y ácida" },
   ]}
 />
@@ -633,9 +633,16 @@ Las mejores condiciones para el arazá en Costa Rica se encuentran en:
 ## Estado de Conservación
 
 <Callout type="info" title="Notas de Conservación">
-  **Estado**: Preocupación Menor (LC)
+  **Estado**: No evaluado (NE)
 
-Aunque no está globalmente amenazado, el arazá sigue siendo un cultivo subutilizado con potencial significativo. Las prioridades de conservación incluyen:
+El rastro actual de auditoría del atlas indica que _Eugenia stipitata_ debe
+tratarse como **No evaluado** en lugar de Preocupación Menor en el texto
+público. Esto **no** implica que la especie esté amenazada; significa que el
+atlas no debe presentar una categoría formal de riesgo de la UICN mientras no
+se disponga claramente de una evaluación global publicada.
+
+Incluso sin una categoría formal de la UICN en esta página, las prioridades de
+conservación para la especie siguen incluyendo:
 
 - **Diversidad genética**: Preservar variedades cultivadas
 - **Conservación in-situ**: Proteger poblaciones silvestres en el Amazonas
@@ -643,6 +650,9 @@ Aunque no está globalmente amenazado, el arazá sigue siendo un cultivo subutil
 - **Desafíos de semillas**: Las semillas recalcitrantes no pueden almacenarse convencionalmente
 
 </Callout>
+
+**Fuentes:** [Búsqueda de especies en GBIF — _Eugenia stipitata_](https://www.gbif.org/species/search?q=Eugenia%20stipitata),
+[Entrada de la Lista Roja de la UICN usada en esta página](https://www.iucnredlist.org/species/152946445)
 
 ---
 

--- a/content/trees/es/carambola.mdx
+++ b/content/trees/es/carambola.mdx
@@ -103,6 +103,7 @@ commonProblems:
     { label: "Familia", value: "Oxalidaceae" },
     { label: "Altura Máxima", value: "5-12 m" },
     { label: "Región Nativa", value: "Sudeste Asiático" },
+    { label: "Conservación", value: "Datos insuficientes (DD)" },
     { label: "Rasgo Clave", value: "Frutas en forma de estrella de 5 puntas" },
     { label: "Sabor", value: "Agridulce, refrescante" },
   ]}
@@ -804,11 +805,20 @@ Las personas con riñones sanos pueden disfrutar la carambola con seguridad en c
 ## Estado de Conservación
 
 <Callout type="info" title="Notas de Conservación">
-  **Estado**: Preocupación Menor (LC)
+  **Estado**: Datos insuficientes (DD)
 
-Como especie ampliamente cultivada, la carambola no enfrenta preocupaciones de conservación. Ha sido introducida exitosamente en regiones tropicales en todo el mundo y es comercialmente importante en varios países.
+El estado externo de biodiversidad utilizado por la auditoría factual de este
+atlas indica que _Averrhoa carambola_ debe tratarse como **Datos
+insuficientes** en lugar de Preocupación Menor. En la práctica, esto significa
+que la especie es ampliamente cultivada y bien conocida en contextos agrícolas,
+pero **no** cuenta con suficiente evaluación formal visible en la canalización
+de auditoría del atlas para justificar una categoría global de riesgo de la
+UICN más precisa en esta página.
 
 </Callout>
+
+**Fuentes:** [Perfil de especie en GBIF](https://www.gbif.org/species/2891641),
+[Búsqueda en la Lista Roja de la UICN — _Averrhoa carambola_](https://www.iucnredlist.org/search?query=Averrhoa%20carambola)
 
 ---
 

--- a/docs/CONTENT_PR_ACCEPTANCE_CRITERIA.md
+++ b/docs/CONTENT_PR_ACCEPTANCE_CRITERIA.md
@@ -1,0 +1,114 @@
+# Content PR Acceptance Criteria
+
+**Last Updated:** 2026-03-22  
+**Purpose:** Reviewer-ready acceptance criteria for tree content, factual remediation, and other public-facing content changes
+
+This document defines the minimum bar for content pull requests so factual remediation work does not drift between “looks plausible” and “is defensible.”
+
+## Applies To
+
+Use this checklist for PRs that change any of the following:
+
+- `content/trees/**`
+- `content/comparisons/**`
+- `content/glossary/**`
+- `content/oral-histories/**`
+- factual correction queues, citations, or conservation/safety claims that surface on public routes
+
+## Non-Negotiable Acceptance Criteria
+
+### 1. Bilingual parity is preserved
+
+- English and Spanish content must ship together for the same slug unless the change is deliberately language-neutral
+- Shared frontmatter values must remain aligned across locales unless the field is intentionally localized
+- Images, section structure, and MDX component coverage must remain equivalent across locales
+
+### 2. High-risk claims are explicitly sourced
+
+The following sections require citations whenever they are added or materially changed:
+
+- medicinal uses
+- toxicity and safety guidance
+- conservation status or threat claims
+- cultural, ceremonial, or indigenous knowledge claims
+- legal protection or harvest restrictions
+
+**Minimum rule:** two independent sources for high-risk factual claims.
+
+### 3. Source hierarchy is followed
+
+When multiple sources disagree, reviewers should prefer sources in this order:
+
+1. IUCN Red List
+2. POWO (Plants of the World Online)
+3. Tropicos
+4. _Manual de Plantas de Costa Rica_
+5. SINAC
+6. peer-reviewed papers
+
+If a lower-priority source is used over a higher-priority one, the PR description must explain why.
+
+### 4. Indigenous and ceremonial content requires human review
+
+Autonomous edits must **not** introduce or expand indigenous names, meanings, ceremonial use, or spiritual significance unless the claim is explicitly sourced.
+
+Any PR touching those topics must also follow `docs/INDIGENOUS_KNOWLEDGE_GOVERNANCE.md` and include a human-review note in the PR summary.
+
+Use the PR routing convention `needs-indigenous-review` so sensitive content is easy to spot in review queues.
+
+### 5. Conservation changes use canonical IUCN codes
+
+- `conservationStatus` values must remain one of: `EX`, `EW`, `CR`, `EN`, `VU`, `NT`, `LC`, `DD`, `NE`
+- Public-facing copy should render the localized IUCN label rather than ad-hoc English prose
+- If a conservation status changes, the PR must cite the authoritative source used for the correction
+
+### 6. Safety fields remain complete
+
+For tree profiles, the required safety fields must stay present and internally consistent. A PR must not improve prose while silently degrading safety completeness.
+
+### 7. Documentation stays in sync
+
+If the PR changes process, counts, or repository rules, update the authoritative docs in the same PR. Typical examples:
+
+- `docs/IMPLEMENTATION_PLAN.md`
+- `docs/SPECIES_ADDITION_PROCESS.md`
+- `docs/MISSING_SPECIES_LIST.md`
+- `docs/README.md`
+
+## PR Description Requirements
+
+Every qualifying content PR should state:
+
+- what content changed
+- why it changed
+- which slugs/locales were touched
+- which sources were used
+- whether indigenous/cultural review was required
+- whether the `needs-indigenous-review` convention was applied
+- what validation was run
+
+## Reviewer Checklist
+
+- [ ] English and Spanish parity preserved
+- [ ] Slugs/frontmatter alignment preserved where expected
+- [ ] High-risk claims have at least two independent sources
+- [ ] Source hierarchy followed or exception explained
+- [ ] Indigenous/ceremonial claims routed through human review workflow
+- [ ] `needs-indigenous-review` convention used when applicable
+- [ ] Conservation status uses valid IUCN code and localized UI path
+- [ ] Safety completeness not reduced
+- [ ] Relevant docs updated
+- [ ] Build and targeted tests passed
+
+## Validation Expectations
+
+At minimum, run the checks relevant to the changed surface:
+
+- `npm run build`
+- `npm run lint`
+- `npm run test:run -- tests/content-validation-comprehensive.test.ts`
+- other targeted route/content regression tests when public-facing strings or metadata change
+
+## Deliberate Exclusions
+
+These criteria do not replace expert botanical review, legal review, or community consent. They define the minimum repository bar for merging content work.

--- a/docs/CONTENT_STANDARDIZATION_GUIDE.md
+++ b/docs/CONTENT_STANDARDIZATION_GUIDE.md
@@ -255,6 +255,15 @@ For **palms**:
 </ExternalLinksGrid>
 ```
 
+## Factual, Citation, and Cultural Governance Rules
+
+Content completeness is not enough on its own. Reviewers should apply these guardrails to all substantive content edits:
+
+- high-risk sections (`Uses`, medicinal claims, safety guidance, conservation, cultural significance) need explicit citations
+- medicinal, safety, conservation, ceremonial, and other high-risk claims require **two independent sources**
+- indigenous names, meanings, ceremonial uses, and spiritual significance must follow `docs/INDIGENOUS_KNOWLEDGE_GOVERNANCE.md`
+- merge readiness for content PRs is defined in `docs/CONTENT_PR_ACCEPTANCE_CRITERIA.md`
+
 ## Section Frequency Audit
 
 **Coverage data** (December 2025 audit of 107 pages):
@@ -388,6 +397,8 @@ Before considering a page "complete":
 - [ ] Growing/cultivation information
 - [ ] External Resources section (min 3 links)
 - [ ] References section (min 2 sources)
+- [ ] High-risk claims meet citation threshold and source hierarchy
+- [ ] Indigenous/cultural claims follow governance policy when applicable
 - [ ] Consistent MDX component usage
 - [ ] No broken links or missing images
 

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -1,25 +1,25 @@
 # Costa Rica Tree Atlas — Implementation Plan
 
 **Last Updated:** 2026-03-22
-**Status:** Checklist audit v4.5 — Updated after locale-aware manifest decision, console-log cleanup pass, and factual remediation policy alignment.
+**Status:** Checklist audit v4.6 — Updated after content PR acceptance criteria, indigenous knowledge governance policy, and IUCN localization coverage verification.
 
 ---
 
 ## Quick Summary
 
-| Priority | Initiative                                  | Status      | Notes                                              |
-| -------- | ------------------------------------------- | ----------- | -------------------------------------------------- |
-| **P0**   | Build reliability                           | ✅ Done     |                                                    |
-| **P1**   | Runtime fixes                               | ✅ Done     |                                                    |
-| **P2**   | EN/ES surface parity                        | 🟡 Partial  | <!-- localized public component strings PR#TBD --> |
-| **P3**   | Accessibility (landmarks, headings, labels) | ✅ Done     |                                                    |
-| **P4**   | SEO & metadata                              | ✅ Done     |                                                    |
-| **P5**   | Factual remediation & citations             | 🔴 Not done |                                                    |
-| **P6**   | Mobile UX & wayfinding                      | 🟡 Partial  |                                                    |
-| **P7**   | Performance & PWA                           | ✅ Done     |                                                    |
-| **P8**   | Maintainability & code cleanup              | 🟡 Partial  |                                                    |
-| **P9**   | Route-level regression tests                | 🟡 Partial  |                                                    |
-| **P10**  | Indigenous knowledge governance             | 🔴 Not done |                                                    |
+| Priority | Initiative                                  | Status      | Notes                                                   |
+| -------- | ------------------------------------------- | ----------- | ------------------------------------------------------- |
+| **P0**   | Build reliability                           | ✅ Done     |                                                         |
+| **P1**   | Runtime fixes                               | ✅ Done     |                                                         |
+| **P2**   | EN/ES surface parity                        | 🟡 Partial  | <!-- localized public component strings PR#TBD -->      |
+| **P3**   | Accessibility (landmarks, headings, labels) | ✅ Done     |                                                         |
+| **P4**   | SEO & metadata                              | ✅ Done     |                                                         |
+| **P5**   | Factual remediation & citations             | 🔴 Not done |                                                         |
+| **P6**   | Mobile UX & wayfinding                      | 🟡 Partial  |                                                         |
+| **P7**   | Performance & PWA                           | ✅ Done     |                                                         |
+| **P8**   | Maintainability & code cleanup              | 🟡 Partial  |                                                         |
+| **P9**   | Route-level regression tests                | 🟡 Partial  |                                                         |
+| **P10**  | Indigenous knowledge governance             | 🟡 Partial  | <!-- governance policy + review workflow documented --> |
 
 **Legend:** ✅ Done — 🟡 Partial — 🔴 Not done / Blocked
 
@@ -175,8 +175,10 @@ The root layout (`src/app/[locale]/layout.tsx`) already wraps all pages in `<mai
 - [x] Source hierarchy for factual corrections adopted: IUCN → POWO → Tropicos → Manual de Plantas de Costa Rica → SINAC → peer-reviewed papers
 - [x] Citation standard for high-risk sections (uses, cultural, medicinal, safety, conservation): 2 independent sources required
 - [x] Remediation queue priority fixed: resolve the 12 P1-high IUCN mismatch trees before medium-risk citation-gap batches
-- [ ] PR acceptance criteria for content work — not formalized
-- [ ] IUCN status labels localized (`ConservationStatus.tsx` has `getLocalizedCategoryLabel()` — verify coverage)
+- [x] PR acceptance criteria for content work formalized in `docs/CONTENT_PR_ACCEPTANCE_CRITERIA.md`
+- [x] IUCN status labels localized and regression-covered for all supported categories in `tests/conservation-status-i18n.test.tsx`
+- [x] P1-high remediation started: `carambola` visible conservation copy now matches audited `DD` status in both locales; latest citation-gap count should be re-audited before decrementing queue totals
+- [x] Second remediation slice landed: `araza` visible conservation copy now matches existing `NE` frontmatter in both locales; latest mismatch/citation totals still require re-audit before queue counts change
 
 ---
 
@@ -258,13 +260,15 @@ The root layout (`src/app/[locale]/layout.tsx`) already wraps all pages in `<mai
 
 ---
 
-## P10 — Indigenous Knowledge Governance 🔴 NOT DONE
+## P10 — Indigenous Knowledge Governance 🟡 PARTIAL
 
-- [ ] No governance, attribution, or consent policy files exist in the repo
-- [ ] Review/approval rules for indigenous names, meanings, and ceremonial claims — not defined
-- [ ] Consent and community review process — not established
+- [x] Governance, attribution, and review policy documented in `docs/INDIGENOUS_KNOWLEDGE_GOVERNANCE.md`
+- [x] Review/approval rules for indigenous names, meanings, and ceremonial claims defined
+- [x] Consent-sensitive human review workflow documented for indigenous knowledge edits
 - [x] Interim working rule adopted: avoid autonomous edits to indigenous/cultural claims unless the claim is explicitly sourced; expect later human review even when sourced
-- [ ] Existing repo rules mark indigenous content as human-only but no actionable policy exists
+- [x] Existing repo rules now have actionable policy backing via linked governance and content PR criteria docs
+- [x] PR labeling convention for indigenous-content approvals documented (`needs-indigenous-review`) across policy and PR workflow docs
+- [ ] Establish external/community review relationships where feasible for sensitive claims
 
 ---
 
@@ -297,7 +301,7 @@ The root layout (`src/app/[locale]/layout.tsx`) already wraps all pages in `<mai
 - [ ] P5: Define and enforce citation standard for high-risk sections
 - [ ] P8: Introduce shared route-shell primitives
 - [ ] P8: Consolidate remaining hardcoded string logic
-- [ ] P10: Draft indigenous knowledge governance policy
+- [x] ~~P10: Draft indigenous knowledge governance policy~~ ✅
 - [x] ~~P9: Expand regression suite to cover all major route families~~ ✅
 - [ ] P6: Improve compare page UX (guide/tool switching, card density)
 

--- a/docs/INDIGENOUS_KNOWLEDGE_GOVERNANCE.md
+++ b/docs/INDIGENOUS_KNOWLEDGE_GOVERNANCE.md
@@ -1,0 +1,115 @@
+# Indigenous Knowledge Governance
+
+**Last Updated:** 2026-03-22  
+**Purpose:** Define how the repository handles indigenous names, meanings, use-cases, ceremonial references, attribution, and review
+
+## Why this policy exists
+
+The atlas documents trees that carry ecological, linguistic, medicinal, and ceremonial significance. Indigenous knowledge should not be treated like anonymous filler text. This policy sets the minimum handling rules for maintainers, collaborators, and AI agents.
+
+## Scope
+
+This policy applies to:
+
+- indigenous names or alternate spellings
+- translations or claimed meanings of indigenous terms
+- ceremonial, spiritual, or sacred use claims
+- traditional medicinal or material uses tied to a community
+- oral-history summaries that attribute knowledge to a specific people or tradition
+
+## Core Rules
+
+### 1. Do not add unsourced claims
+
+Autonomous contributors must not add new indigenous or ceremonial claims unless the claim is explicitly supported by a cited source.
+
+### 2. Human review is required
+
+Any PR that adds, removes, or materially changes indigenous knowledge content requires human review before merge, even when sourced.
+
+### 3. Attribute communities specifically
+
+Avoid generic phrasing like “indigenous people used this tree.” Attribute claims as specifically as the source allows, for example:
+
+- Bribri
+- Cabécar
+- Ngäbe
+- Boruca
+
+If the source is broad or uncertain, say so plainly instead of over-claiming.
+
+### 4. Separate documented use from interpretation
+
+Write only what the source supports. Do not infer ceremonial meaning, symbolic roles, or community-wide practice from a passing mention.
+
+### 5. Prefer living-community-safe wording
+
+Avoid language that presents living traditions as relics, curiosities, or universally shared practices. Use present-tense phrasing only when the source supports ongoing use.
+
+## Source Requirements
+
+### Minimum sourcing standard
+
+- one explicit source for a straightforward name or use attribution
+- two independent sources for medicinal, ceremonial, sacred, or safety-adjacent claims
+
+### Preferred source types
+
+1. community-authored or community-approved publications
+2. museum, university, or linguistic documentation with clear attribution
+3. peer-reviewed ethnobotanical research
+4. reputable governmental or conservation institutions
+
+If no source meets that bar, do not merge the claim.
+
+## Consent and Review Workflow
+
+When indigenous knowledge content is touched:
+
+1. **Flag the PR** as requiring indigenous-content review in the summary.
+2. **Apply the PR routing convention** `needs-indigenous-review` (or include that exact text in the PR body if labels are unavailable).
+3. **List every affected slug and locale**.
+4. **Cite the exact source** for each indigenous name, meaning, or use claim.
+5. **Mark uncertain claims for follow-up** instead of smoothing them into confident prose.
+6. **Require human approval** before merge.
+
+If a future community reviewer or partner requests correction, removal, or attribution changes, that request should be prioritized over stylistic preferences.
+
+## PR Label / Routing Convention
+
+Use `needs-indigenous-review` for any PR that:
+
+- adds a new indigenous name or meaning
+- changes ceremonial, spiritual, or sacred-use language
+- changes attributed traditional medicinal or material uses
+- edits oral-history passages tied to a specific community
+
+This convention is intentionally simple so reviewers can filter sensitive content quickly even before a formal CODEOWNERS-style system exists.
+
+## Writing Rules
+
+- Prefer direct, sourced statements over paraphrase-heavy summaries.
+- Distinguish clearly between botanical facts and cultural interpretation.
+- Do not collapse multiple communities into a single practice unless the source does so.
+- Do not extrapolate from one region to all of Costa Rica.
+- Do not introduce ceremonial detail purely to make a page feel richer.
+
+## Escalation Cases
+
+Stop and request human review immediately when a change involves:
+
+- ceremonial or sacred practices
+- healing claims with safety implications
+- contested translations or alternate spellings
+- sensitive historical narratives
+- claims with unclear attribution to a specific people
+
+## Repository Expectations
+
+Related documents:
+
+- `docs/CONTENT_PR_ACCEPTANCE_CRITERIA.md`
+- `docs/SPECIES_ADDITION_PROCESS.md`
+- `docs/IMPLEMENTATION_PLAN.md`
+
+This policy is intentionally conservative. When in doubt, omit the claim, document the gap, and leave room for qualified human review.

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,8 +18,14 @@ For adding and maintaining tree content:
 
 - **[SPECIES_ADDITION_PROCESS.md](./SPECIES_ADDITION_PROCESS.md)** - ⭐ Complete step-by-step guide for adding new species
 - **[CONTENT_STANDARDIZATION_GUIDE.md](./CONTENT_STANDARDIZATION_GUIDE.md)** - Content structure standards and quality benchmarks
-- **[MISSING_SPECIES_LIST.md](./MISSING_SPECIES_LIST.md)** - ~34 verified unique species to document next
+- **[CONTENT_PR_ACCEPTANCE_CRITERIA.md](./CONTENT_PR_ACCEPTANCE_CRITERIA.md)** - Merge checklist for factual, bilingual, and high-risk content changes
+- **[MISSING_SPECIES_LIST.md](./MISSING_SPECIES_LIST.md)** - ~13 verified unique species to document next
 - **[FRONTMATTER_LOCALIZATION_GUIDE.md](./FRONTMATTER_LOCALIZATION_GUIDE.md)** - Frontmatter best practices and localization patterns
+
+## ⚖️ Governance & Review
+
+- **[INDIGENOUS_KNOWLEDGE_GOVERNANCE.md](./INDIGENOUS_KNOWLEDGE_GOVERNANCE.md)** - Rules for attribution, consent-sensitive handling, and human review of indigenous knowledge content
+- **[CONTENT_PR_ACCEPTANCE_CRITERIA.md](./CONTENT_PR_ACCEPTANCE_CRITERIA.md)** - Reviewer checklist for content PRs touching factual, cultural, or safety-sensitive claims
 
 ## 🛠️ Technical Guides
 
@@ -100,7 +106,7 @@ Key documents for autonomous work:
 
 ---
 
-**Last Updated:** 2026-02-12  
-**Active Documentation:** 11 core files  
+**Last Updated:** 2026-03-22  
+**Active Documentation:** 13 core files  
 **Status:** Living documents synchronized with implementation  
 **Maintained By:** Costa Rica Tree Atlas Contributors

--- a/docs/SPECIES_ADDITION_PROCESS.md
+++ b/docs/SPECIES_ADDITION_PROCESS.md
@@ -5,15 +5,16 @@
 
 ## Quick Reference
 
-- **Current Species Count:** 160 documented (320 bilingual documents)
+- **Current Species Count:** 175 documented (350 bilingual documents)
 - **Last Major Update:** 2026-02-12 (5 species added: Zorrillo, Contra, Achotillo, Guarumbo Hembra, Bambu Gigante)
 - **Previous Major Update:** 2026-02-12 (2 species added: Quina, Cedro Dulce)
 - **Previous Major Update:** 2026-02-10 (1 species added: Granadillo)
 - **Previous Major Update:** 2026-01-15 (4 species added: Sigua, Comenegro, Mayo, Lechoso Montañero)
 - **Previous Major Update:** 2026-01-14 (2 species added)
 - **Previous Major Update:** 2026-01-12 (12 species added)
-- **Missing Species Remaining:** ~28 unique species (see [MISSING_SPECIES_LIST.md](./MISSING_SPECIES_LIST.md))
+- **Missing Species Remaining:** ~13 unique species (see [MISSING_SPECIES_LIST.md](./MISSING_SPECIES_LIST.md))
 - **Quality Standard:** All species must have **100% safety data coverage** (13 required fields)
+- **Review Standard:** Content PRs must satisfy [CONTENT_PR_ACCEPTANCE_CRITERIA.md](./CONTENT_PR_ACCEPTANCE_CRITERIA.md)
 
 ## Review Process
 
@@ -57,6 +58,16 @@ When species are added, update these files:
 2. **MISSING_SPECIES_LIST.md** - Remove documented species, update counts
 3. **docs/SPECIES_ADDITION_PROCESS.md** - Update species count in Quick Reference
 4. **docs/IMPLEMENTATION_PLAN.md** - Update any species count references
+
+### Step 4: Content Review Gate
+
+Before merging a species addition or factual correction:
+
+- [ ] Verify bilingual parity and matching slug/frontmatter expectations
+- [ ] Cite all high-risk claims (medicinal, safety, conservation, cultural)
+- [ ] Use at least two independent sources for high-risk factual claims
+- [ ] Route indigenous or ceremonial claims through `docs/INDIGENOUS_KNOWLEDGE_GOVERNANCE.md`
+- [ ] Confirm the PR satisfies `docs/CONTENT_PR_ACCEPTANCE_CRITERIA.md`
 
 ## Quality Standards for New Species
 
@@ -191,7 +202,7 @@ Every species page should follow the standard structure from [CONTENT_STANDARDIZ
 - Proper attribution in frontmatter or captions
 - Show: tree form, bark, leaves, flowers, fruit (when available)
 
-### Step 4: Verify Bilingual Coverage
+### Step 5: Verify Bilingual Coverage
 
 Ensure both English and Spanish versions exist:
 
@@ -213,7 +224,7 @@ for file in content/trees/es/*.mdx; do
 done
 ```
 
-### Step 5: Build Verification
+### Step 6: Build Verification
 
 Always run a build to verify changes:
 
@@ -226,7 +237,7 @@ Expected output should show:
 - No build errors
 - Increased page count (each tree generates ~2 pages per language = 4 pages per species)
 - Contentlayer warnings are acceptable if they're just about extra fields
-- Current expected page count: ~640+ pages (160 trees × 2 languages × 2 pages/tree)
+  - Current expected page count: ~1,600 pages
 
 ## Common Issues
 
@@ -417,6 +428,12 @@ touch content/trees/es/new-species.mdx
 - [ ] Maintain same content structure and section order
 - [ ] Preserve image references (same paths)
 - [ ] Match tone and reading level across languages
+
+**Governance & sourcing requirements:**
+
+- [ ] Follow `docs/CONTENT_PR_ACCEPTANCE_CRITERIA.md` for merge readiness
+- [ ] Follow `docs/INDIGENOUS_KNOWLEDGE_GOVERNANCE.md` for indigenous names, meanings, and ceremonial claims
+- [ ] Use two independent sources for medicinal, conservation, safety, and other high-risk claims
 
 ### 3. Image Management
 
@@ -713,6 +730,8 @@ updatedAt: 2026-01-19
 
 - [MISSING_SPECIES_LIST.md](./MISSING_SPECIES_LIST.md) - Complete list of species to add
 - [CONTENT_STANDARDIZATION_GUIDE.md](./CONTENT_STANDARDIZATION_GUIDE.md) - Content structure guide
+- [CONTENT_PR_ACCEPTANCE_CRITERIA.md](./CONTENT_PR_ACCEPTANCE_CRITERIA.md) - Merge checklist for content work
+- [INDIGENOUS_KNOWLEDGE_GOVERNANCE.md](./INDIGENOUS_KNOWLEDGE_GOVERNANCE.md) - Indigenous knowledge review and consent-sensitive handling rules
 - [IMAGE_RESOURCES.md](./IMAGE_RESOURCES.md) - Image sourcing guidelines
 - [improvement-roadmap.md](./improvement-roadmap.md) - Overall project status
 - [CONTRIBUTING.md](../CONTRIBUTING.md) - General contribution guide

--- a/tests/conservation-status-i18n.test.tsx
+++ b/tests/conservation-status-i18n.test.tsx
@@ -1,0 +1,102 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  ConservationScale,
+  ConservationStatus,
+} from "@/components/ConservationStatus";
+
+const CATEGORY_LABELS = {
+  en: {
+    EX: "Extinct",
+    EW: "Extinct in the Wild",
+    CR: "Critically Endangered",
+    EN: "Endangered",
+    VU: "Vulnerable",
+    NT: "Near Threatened",
+    LC: "Least Concern",
+    DD: "Data Deficient",
+    NE: "Not Evaluated",
+  },
+  es: {
+    EX: "Extinto",
+    EW: "Extinto en estado silvestre",
+    CR: "En peligro crítico",
+    EN: "En peligro",
+    VU: "Vulnerable",
+    NT: "Casi amenazado",
+    LC: "Preocupación menor",
+    DD: "Datos insuficientes",
+    NE: "No evaluado",
+  },
+} as const;
+
+const LOCALE_UI = {
+  en: {
+    heading: "Conservation Status",
+    populationTrend: "Population Trend",
+    assessedBy: "Assessed by",
+    viewOn: "View on IUCN Red List",
+    decreasing: "Decreasing",
+    lowerRisk: "Lower risk",
+    higherRisk: "Higher risk",
+  },
+  es: {
+    heading: "Estado de Conservación",
+    populationTrend: "Tendencia Poblacional",
+    assessedBy: "Evaluado por",
+    viewOn: "Ver en Lista Roja de la UICN",
+    decreasing: "En disminución",
+    lowerRisk: "Menor riesgo",
+    higherRisk: "Mayor riesgo",
+  },
+} as const;
+
+describe.each([
+  ["en", CATEGORY_LABELS.en, LOCALE_UI.en],
+  ["es", CATEGORY_LABELS.es, LOCALE_UI.es],
+] as const)(
+  "ConservationStatus localization (%s)",
+  (locale, categoryLabels, ui) => {
+    it.each(Object.entries(categoryLabels))(
+      "renders the localized label for %s",
+      (category, label) => {
+        render(<ConservationStatus category={category} locale={locale} />);
+
+        expect(screen.getByText(ui.heading)).toBeInTheDocument();
+        expect(screen.getByText(category)).toBeInTheDocument();
+        expect(screen.getByText(label)).toBeInTheDocument();
+      }
+    );
+
+    it("renders localized trend and footer labels", () => {
+      render(
+        <ConservationStatus
+          category="EN"
+          locale={locale}
+          populationTrend="decreasing"
+          assessmentDate="2024-05-01"
+          iucnUrl="https://www.iucnredlist.org/species/123"
+        />
+      );
+
+      expect(screen.getByText(ui.heading)).toBeInTheDocument();
+      expect(screen.getByText(ui.decreasing)).toBeInTheDocument();
+      expect(screen.getByText(ui.populationTrend)).toBeInTheDocument();
+      expect(
+        screen.getByText(`${ui.assessedBy}: IUCN 2024`)
+      ).toBeInTheDocument();
+      expect(screen.getByRole("link", { name: ui.viewOn })).toHaveAttribute(
+        "href",
+        "https://www.iucnredlist.org/species/123"
+      );
+    });
+
+    it("renders localized scale labels", () => {
+      render(<ConservationScale currentCategory="EN" locale={locale} />);
+
+      expect(screen.getByText(ui.lowerRisk)).toBeInTheDocument();
+      expect(screen.getByText(ui.higherRisk)).toBeInTheDocument();
+    });
+  }
+);


### PR DESCRIPTION
Adds content governance docs, PR workflow updates, conservation status localization tests, and audited bilingual content fixes for carambola and araza. Validation: npm run test:run -- tests/conservation-status-i18n.test.tsx; npm run build.