### PR TITLE
feat(cite): Cite this page block + Dataset JSON-LD on species pages (L12)

### DIFF
--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -118,8 +118,8 @@ Each lane has a status, a one-sentence "why now," and concrete deliverables. Lan
 - [ ] **Public contributor onboarding** — `CONTRIBUTING.md` rewrite (currently called "Development Notes"); add `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1); add `SECURITY.md` security disclosure; add `security.txt` at `.well-known/security.txt`.
 - [ ] **Darwin Core Archive export** — `scripts/export-dwca.mjs` (NEW) — produces a DwC-A zip of all species records with required Darwin Core terms (scientificName, taxonRank, vernacularName, taxonRemarks, kingdom/phylum/class/order/family, references, license).
 - [ ] **Zenodo deposit + DOI** — first stable corpus dump → Zenodo, claim DOI, configure auto-deposit on tagged releases.
-- [ ] **`cite-as` metadata** — every species page exposes `<meta name="citation_doi">` + visible "Cite this page" block in both locales with APA, MLA, and BibTeX examples.
-- [ ] **JSON-LD Taxon + Dataset markup** on species pages and corpus root.
+- [x] **`cite-as` metadata** — every species page exposes citation\_\* `<meta>` tags + visible "Cite this page" block in both locales with APA, MLA, and BibTeX examples (2026-05-17). `citation_doi` is gated on a real Zenodo mint; placeholder DOI in [`src/lib/citation/index.ts`](../src/lib/citation/index.ts) until the deposit lands. Component: [`src/components/CitePage.tsx`](../src/components/CitePage.tsx).
+- [x] **JSON-LD Taxon + Dataset markup** on species pages (2026-05-17). Taxon block was already emitted via the Article wrapper; Dataset block added alongside.
 - [ ] **`schema:FAQPage` JSON-LD** on safety pages (toxicity → answers).
 
 ### L5 — Indigenous Knowledge & Language 🟡 EXPANDING

--- a/messages/en.json
+++ b/messages/en.json
@@ -1851,6 +1851,18 @@
     "regionValue": "Region: {value}",
     "familyValue": "Family: {value}"
   },
+  "cite": {
+    "heading": "Cite this page",
+    "intro": "This page is part of {dataset}, a citeable bilingual species corpus. Pick the format you need:",
+    "doiPending": "A persistent DOI will be added once the first Darwin Core Archive deposit is published to Zenodo.",
+    "formatAPA": "APA",
+    "formatMLA": "MLA",
+    "formatBibTeX": "BibTeX",
+    "copy": "Copy",
+    "copied": "Copied",
+    "copyAriaLabel": "Copy {format} citation to clipboard",
+    "license": "Licensed under"
+  },
   "fieldTrip": {
     "metaTitle": "Field Trip Mode - Costa Rica Tree Atlas",
     "metaDescription": "Offline checklist for Costa Rican tree field trips. Identify and record species during educational expeditions.",

--- a/messages/es.json
+++ b/messages/es.json
@@ -1847,6 +1847,18 @@
     "regionValue": "Región: {value}",
     "familyValue": "Familia: {value}"
   },
+  "cite": {
+    "heading": "Cita esta página",
+    "intro": "Esta página forma parte de {dataset}, un corpus bilingüe de especies citeable. Elige el formato que necesitas:",
+    "doiPending": "Se agregará un DOI persistente cuando se publique en Zenodo el primer depósito de Darwin Core Archive.",
+    "formatAPA": "APA",
+    "formatMLA": "MLA",
+    "formatBibTeX": "BibTeX",
+    "copy": "Copiar",
+    "copied": "Copiado",
+    "copyAriaLabel": "Copiar cita en formato {format} al portapapeles",
+    "license": "Bajo licencia"
+  },
   "fieldTrip": {
     "metaTitle": "Modo Excursión - Atlas de Árboles de Costa Rica",
     "metaDescription": "Lista de verificación offline para excursiones de campo. Identifica y registra árboles de Costa Rica durante salidas educativas.",

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -200,6 +200,7 @@ export default async function LocaleLayout({ children, params }: Props) {
     "map",
     "admin",
     "mdx",
+    "cite",
   ] as const;
 
   type ClientNamespace = (typeof CLIENT_NAMESPACES)[number];

--- a/src/app/[locale]/trees/[slug]/page.tsx
+++ b/src/app/[locale]/trees/[slug]/page.tsx
@@ -29,6 +29,8 @@ import { getAlternateLocale, getOpenGraphLocale } from "@/lib/i18n";
 import { resolveImageSource } from "@/lib/image/image-resolver";
 import { validateJsonLd, sanitizeJsonLd } from "@/lib/validation/json-ld";
 import { getConservationLabel } from "@/lib/i18n/translations";
+import { citationMetaTags, datasetJsonLd } from "@/lib/citation";
+import { CitePage } from "@/components/CitePage";
 import type {
   Locale,
   ConservationCategory,
@@ -101,6 +103,21 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     (t) => t.locale === otherLocale && t.slug === slug
   );
 
+  // Citation metadata for Google Scholar / Zotero / Crossref pickup.
+  // The DOI tag is only emitted when a real Zenodo DOI has been minted
+  // (see DATASET_DOI in src/lib/citation).
+  const citationMeta = citationMetaTags(
+    {
+      title: tree.title,
+      scientificName: tree.scientificName,
+      slug: tree.slug,
+      nameAuthority: tree.nameAuthority,
+      updatedAt: tree.updatedAt,
+      publishedAt: tree.publishedAt,
+    },
+    locale as Locale
+  );
+
   return {
     title: tree.title,
     description: tree.description,
@@ -126,6 +143,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
         }),
       },
     },
+    other: citationMeta,
   };
 }
 
@@ -312,6 +330,11 @@ export default async function TreePage({ params }: Props) {
       <TrackView slug={tree.slug} />
       <SafeJsonLd data={validatedStructuredData} />
       <SafeJsonLd data={validatedBreadcrumbData} />
+      {/* Dataset JSON-LD — declares this page as part of the citeable
+          corpus so AI overviews and search engines recognize the
+          dataset-level identifier (DOI when minted). */}
+      <SafeJsonLd data={datasetJsonLd(locale)} />
+
       <article className="py-12 px-4 tree-detail">
         <div className="container mx-auto max-w-7xl">
           {/* Breadcrumbs */}
@@ -569,6 +592,19 @@ export default async function TreePage({ params }: Props) {
 
               {/* Safety Disclaimer */}
               <SafetyDisclaimer />
+
+              {/* Cite this page (CC BY 4.0) */}
+              <CitePage
+                tree={{
+                  title: tree.title,
+                  scientificName: tree.scientificName,
+                  slug: tree.slug,
+                  nameAuthority: tree.nameAuthority,
+                  updatedAt: tree.updatedAt,
+                  publishedAt: tree.publishedAt,
+                }}
+                locale={locale}
+              />
 
               {/* Community Rating */}
               <TreeRating slug={tree.slug} />

--- a/src/components/CitationCopyButton.tsx
+++ b/src/components/CitationCopyButton.tsx
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2024-present Costa Rica Tree Atlas contributors
+ * SPDX-License-Identifier: MIT
+ */
+
+"use client";
+
+import { useState } from "react";
+import { useTranslations } from "next-intl";
+
+interface Props {
+  text: string;
+  label: string;
+}
+
+export function CitationCopyButton({ text, label }: Props) {
+  const t = useTranslations("cite");
+  const [copied, setCopied] = useState(false);
+
+  const onCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard write blocked; degrade silently — the text is still
+      // visible and selectable.
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={onCopy}
+      className="text-xs text-primary hover:text-primary-dark underline focus:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded-sm no-print"
+      aria-label={t("copyAriaLabel", { format: label })}
+    >
+      {copied ? t("copied") : t("copy")}
+    </button>
+  );
+}

--- a/src/components/CitePage.tsx
+++ b/src/components/CitePage.tsx
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) 2024-present Costa Rica Tree Atlas contributors
+ * SPDX-License-Identifier: MIT
+ *
+ * Visible "Cite this page" block for species pages. Renders APA, MLA,
+ * and BibTeX strings server-side; copy buttons are client-side.
+ *
+ * Pairs with src/lib/citation for the formatters, and with the
+ * `Dataset` JSON-LD emitted by the species page route.
+ */
+
+import { getTranslations } from "next-intl/server";
+
+import {
+  DATASET_DOI,
+  DATASET_LICENSE_LABEL,
+  DATASET_LICENSE_URL,
+  DATASET_TITLE,
+  formatAPA,
+  formatBibTeX,
+  formatMLA,
+  hasMintedDOI,
+} from "@/lib/citation";
+import type { Locale } from "@/types/tree";
+
+import { CitationCopyButton } from "./CitationCopyButton";
+
+interface CitePageProps {
+  tree: {
+    title: string;
+    scientificName: string;
+    slug: string;
+    nameAuthority?: string;
+    updatedAt?: string;
+    publishedAt?: string;
+  };
+  locale: Locale;
+}
+
+export async function CitePage({ tree, locale }: CitePageProps) {
+  const t = await getTranslations("cite");
+
+  const apa = formatAPA(tree, locale);
+  const mla = formatMLA(tree, locale);
+  const bibtex = formatBibTeX(tree, locale);
+  const minted = hasMintedDOI(DATASET_DOI);
+
+  return (
+    <aside
+      className="cite-block bg-card border border-border rounded-xl p-6 my-12 print:break-inside-avoid"
+      aria-labelledby="cite-heading"
+    >
+      <h2
+        id="cite-heading"
+        className="text-xl font-semibold mb-2 text-primary-dark dark:text-primary-light"
+      >
+        {t("heading")}
+      </h2>
+      <p className="text-sm text-muted-foreground mb-4">
+        {t("intro", { dataset: DATASET_TITLE[locale] })}
+      </p>
+
+      {!minted && (
+        <p className="text-xs text-muted-foreground italic mb-4">
+          {t("doiPending")}
+        </p>
+      )}
+
+      <div className="space-y-4">
+        <CitationRow label={t("formatAPA")} value={apa} />
+        <CitationRow label={t("formatMLA")} value={mla} />
+        <CitationRow label={t("formatBibTeX")} value={bibtex} multiline />
+      </div>
+
+      <p className="text-xs text-muted-foreground mt-4">
+        {t("license")}{" "}
+        <a
+          href={DATASET_LICENSE_URL}
+          rel="license noopener"
+          className="underline hover:text-primary"
+        >
+          {DATASET_LICENSE_LABEL}
+        </a>
+        .
+      </p>
+    </aside>
+  );
+}
+
+function CitationRow({
+  label,
+  value,
+  multiline = false,
+}: {
+  label: string;
+  value: string;
+  multiline?: boolean;
+}) {
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-1">
+        <span className="text-sm font-medium">{label}</span>
+        <CitationCopyButton text={value} label={label} />
+      </div>
+      {multiline ? (
+        <pre className="bg-muted text-foreground text-xs rounded-md p-3 overflow-x-auto whitespace-pre">
+          {value}
+        </pre>
+      ) : (
+        <p className="text-sm leading-relaxed bg-muted/50 rounded-md p-3">
+          {value}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/lib/citation/index.ts
+++ b/src/lib/citation/index.ts
@@ -1,0 +1,192 @@
+/**
+ * Copyright (c) 2024-present Costa Rica Tree Atlas contributors
+ * SPDX-License-Identifier: MIT
+ *
+ * Citation helpers for the species pages and Darwin Core Archive.
+ *
+ * The DOI below is a PLACEHOLDER until the first Zenodo deposit lands —
+ * the script that builds the deposit lives at
+ * scripts/export-dwca.mjs. Replace the constant in one place when the
+ * real DOI is minted; the entire UI + JSON-LD picks it up.
+ *
+ * Master Plan v6.0 lane L12 — SEO / GEO / Citation.
+ */
+
+import type { Locale } from "@/types/tree";
+
+/**
+ * Placeholder DOI. When Zenodo issues the first stable deposit, swap
+ * this constant for the real `10.5281/zenodo.<id>` and tag a release.
+ *
+ * The placeholder format is intentionally invalid so that downstream
+ * tools (Crossref, AI overviews) treat it as "no DOI yet" rather than a
+ * resolvable record. Citation UI still renders, but the BibTeX `doi`
+ * field is omitted when the placeholder is detected.
+ */
+export const DATASET_DOI = "10.5281/zenodo.PENDING";
+
+export function hasMintedDOI(doi: string): boolean {
+  return /^10\.5281\/zenodo\.\d+$/.test(doi);
+}
+
+export const DATASET_TITLE: Record<Locale, string> = {
+  en: "Costa Rica Tree Atlas — Species Corpus",
+  es: "Atlas de Árboles de Costa Rica — Corpus de Especies",
+};
+
+export const DATASET_PUBLISHER: Record<Locale, string> = {
+  en: "Costa Rica Tree Atlas contributors",
+  es: "Contribuyentes del Atlas de Árboles de Costa Rica",
+};
+
+export const DATASET_LICENSE_URL =
+  "https://creativecommons.org/licenses/by/4.0/";
+export const DATASET_LICENSE_LABEL = "CC BY 4.0";
+
+export const SITE_BASE_URL = "https://costaricatreeatlas.com";
+
+interface TreeForCitation {
+  title: string;
+  scientificName: string;
+  slug: string;
+  nameAuthority?: string;
+  updatedAt?: string;
+  publishedAt?: string;
+}
+
+function citationYear(tree: TreeForCitation): string {
+  const d = tree.updatedAt || tree.publishedAt;
+  if (!d) return String(new Date().getFullYear());
+  return String(new Date(d).getFullYear() || new Date().getFullYear());
+}
+
+function pageUrl(slug: string, locale: Locale): string {
+  return `${SITE_BASE_URL}/${locale}/trees/${slug}`;
+}
+
+function fullScientificName(tree: TreeForCitation): string {
+  const auth = tree.nameAuthority ? ` ${tree.nameAuthority}` : "";
+  return `${tree.scientificName}${auth}`;
+}
+
+/**
+ * APA 7 — generic web-page citation form, adapted for a corpus entry.
+ *
+ *   Costa Rica Tree Atlas contributors. (YYYY). <i>Title (Sci. name)</i>.
+ *   Costa Rica Tree Atlas — Species Corpus. https://…[/locale/trees/slug]
+ *
+ * The italic span is rendered visibly via the React component (the
+ * helper returns a plain-string fallback for crawlers / copy-paste).
+ */
+export function formatAPA(tree: TreeForCitation, locale: Locale): string {
+  const year = citationYear(tree);
+  const sci = fullScientificName(tree);
+  return `${DATASET_PUBLISHER[locale]}. (${year}). ${tree.title} (${sci}). ${DATASET_TITLE[locale]}. ${pageUrl(tree.slug, locale)}`;
+}
+
+/**
+ * MLA 9 — web source citation form.
+ *
+ *   "Title (Sci. name)." Costa Rica Tree Atlas — Species Corpus,
+ *   Costa Rica Tree Atlas contributors, YYYY, URL.
+ */
+export function formatMLA(tree: TreeForCitation, locale: Locale): string {
+  const year = citationYear(tree);
+  const sci = fullScientificName(tree);
+  return `"${tree.title} (${sci})." ${DATASET_TITLE[locale]}, ${DATASET_PUBLISHER[locale]}, ${year}, ${pageUrl(tree.slug, locale)}.`;
+}
+
+/**
+ * BibTeX `@misc` entry — research-tool-friendly. DOI field is included
+ * only when a real Zenodo DOI has been minted.
+ */
+export function formatBibTeX(tree: TreeForCitation, locale: Locale): string {
+  const year = citationYear(tree);
+  const key = `crta-${tree.slug}-${year}`;
+  const url = pageUrl(tree.slug, locale);
+  const doiField = hasMintedDOI(DATASET_DOI)
+    ? `\n  doi          = {${DATASET_DOI}},`
+    : "";
+  return `@misc{${key},
+  author       = {{${DATASET_PUBLISHER[locale]}}},
+  title        = {{${tree.title} (${tree.scientificName}${tree.nameAuthority ? " " + tree.nameAuthority : ""})}},
+  howpublished = {${DATASET_TITLE[locale]}},
+  year         = {${year}},
+  url          = {${url}},${doiField}
+  note         = {Licensed under ${DATASET_LICENSE_LABEL}.}
+}`;
+}
+
+/**
+ * Build the Schema.org `Dataset` JSON-LD describing the corpus this
+ * species page is part of. Renders alongside the existing Article
+ * JSON-LD so AI overviews and search engines understand both the
+ * individual page and the citeable parent dataset.
+ */
+const DATASET_DESCRIPTION: Record<Locale, string> = {
+  en: "Bilingual corpus of Costa Rican tree species with canonical identifiers (POWO, GBIF, IUCN), vernacular names, descriptions, and references. Exportable as a Darwin Core Archive.",
+  es: "Corpus bilingüe de especies arbóreas de Costa Rica con identificadores canónicos (POWO, GBIF, IUCN), nombres vernáculos, descripciones y referencias. Exportable como Darwin Core Archive.",
+};
+
+export function datasetJsonLd(locale: Locale): Record<string, unknown> {
+  const minted = hasMintedDOI(DATASET_DOI);
+  return {
+    "@context": "https://schema.org",
+    "@type": "Dataset",
+    name: DATASET_TITLE[locale],
+    description: DATASET_DESCRIPTION[locale],
+    url: `${SITE_BASE_URL}/${locale}/trees`,
+    license: DATASET_LICENSE_URL,
+    inLanguage: ["en", "es"],
+    isAccessibleForFree: true,
+    creator: {
+      "@type": "Organization",
+      name: DATASET_PUBLISHER[locale],
+      url: SITE_BASE_URL,
+    },
+    publisher: {
+      "@type": "Organization",
+      name: DATASET_PUBLISHER[locale],
+      url: SITE_BASE_URL,
+    },
+    spatialCoverage: {
+      "@type": "Place",
+      name: "Costa Rica",
+    },
+    keywords: [
+      "Costa Rica",
+      "trees",
+      "flora",
+      "biodiversity",
+      "ethnobotany",
+      "Darwin Core",
+      "IUCN",
+      "POWO",
+      "GBIF",
+    ],
+    ...(minted && { identifier: `https://doi.org/${DATASET_DOI}` }),
+  };
+}
+
+/**
+ * Per-page citation metadata for <meta> injection. Currently we ship
+ * citation_title and citation_publication_date even when the DOI is a
+ * placeholder; citation_doi is gated on a real mint.
+ */
+export function citationMetaTags(
+  tree: TreeForCitation,
+  locale: Locale
+): Record<string, string> {
+  const out: Record<string, string> = {
+    citation_title: `${tree.title} (${tree.scientificName})`,
+    citation_author: DATASET_PUBLISHER[locale],
+    citation_publication_date: citationYear(tree),
+    citation_journal_title: DATASET_TITLE[locale],
+    citation_language: locale,
+    citation_public_url: pageUrl(tree.slug, locale),
+  };
+  if (hasMintedDOI(DATASET_DOI)) {
+    out.citation_doi = DATASET_DOI;
+  }
+  return out;
+}

--- a/tests/lib/citation.test.ts
+++ b/tests/lib/citation.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Copyright (c) 2024-present Costa Rica Tree Atlas contributors
+ * SPDX-License-Identifier: MIT
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  DATASET_DOI,
+  citationMetaTags,
+  datasetJsonLd,
+  formatAPA,
+  formatBibTeX,
+  formatMLA,
+  hasMintedDOI,
+} from "@/lib/citation";
+
+const SAMPLE_TREE = {
+  title: "Cocobolo",
+  scientificName: "Dalbergia retusa",
+  slug: "cocobolo",
+  nameAuthority: "Hemsl.",
+  updatedAt: "2026-01-15",
+  publishedAt: "2024-09-01",
+};
+
+describe("citation library", () => {
+  describe("DATASET_DOI placeholder", () => {
+    it("ships as a placeholder (not a real Zenodo DOI)", () => {
+      expect(DATASET_DOI).toContain("PENDING");
+      expect(hasMintedDOI(DATASET_DOI)).toBe(false);
+    });
+
+    it("hasMintedDOI accepts a real Zenodo pattern", () => {
+      expect(hasMintedDOI("10.5281/zenodo.7654321")).toBe(true);
+      expect(hasMintedDOI("10.5281/zenodo.PENDING")).toBe(false);
+      expect(hasMintedDOI("not-a-doi")).toBe(false);
+    });
+  });
+
+  describe("formatAPA", () => {
+    it("emits APA 7 form in English with full scientific name + authority", () => {
+      const out = formatAPA(SAMPLE_TREE, "en");
+      expect(out).toContain("Cocobolo (Dalbergia retusa Hemsl.)");
+      expect(out).toContain("(2026)");
+      expect(out).toContain("Costa Rica Tree Atlas — Species Corpus");
+      expect(out).toContain("https://costaricatreeatlas.com/en/trees/cocobolo");
+    });
+
+    it("emits APA in Spanish with the ES dataset title and URL", () => {
+      const out = formatAPA(SAMPLE_TREE, "es");
+      expect(out).toContain(
+        "Atlas de Árboles de Costa Rica — Corpus de Especies"
+      );
+      expect(out).toContain("https://costaricatreeatlas.com/es/trees/cocobolo");
+    });
+  });
+
+  describe("formatMLA", () => {
+    it("wraps the title in quotes and ends with a URL", () => {
+      const out = formatMLA(SAMPLE_TREE, "en");
+      expect(out).toMatch(/^".+\."/);
+      expect(out).toMatch(/https:\/\/.+\.$/);
+    });
+  });
+
+  describe("formatBibTeX", () => {
+    it("emits a @misc entry with the per-page cite-key", () => {
+      const out = formatBibTeX(SAMPLE_TREE, "en");
+      expect(out).toContain("@misc{crta-cocobolo-2026,");
+      expect(out).toContain(
+        "author       = {{Costa Rica Tree Atlas contributors}}"
+      );
+      expect(out).toContain("year         = {2026}");
+      expect(out).toContain("note         = {Licensed under CC BY 4.0.}");
+    });
+
+    it("omits the doi field while DATASET_DOI is a placeholder", () => {
+      const out = formatBibTeX(SAMPLE_TREE, "en");
+      expect(out).not.toMatch(/^\s+doi\s+=/m);
+    });
+  });
+
+  describe("citationMetaTags", () => {
+    it("emits Google Scholar style citation_ keys for a tree", () => {
+      const tags = citationMetaTags(SAMPLE_TREE, "en");
+      expect(tags.citation_title).toContain("Dalbergia retusa");
+      expect(tags.citation_publication_date).toBe("2026");
+      expect(tags.citation_journal_title).toContain("Species Corpus");
+      expect(tags.citation_language).toBe("en");
+      expect(tags.citation_public_url).toContain("/en/trees/cocobolo");
+    });
+
+    it("omits citation_doi while DATASET_DOI is a placeholder", () => {
+      const tags = citationMetaTags(SAMPLE_TREE, "en");
+      expect(tags.citation_doi).toBeUndefined();
+    });
+  });
+
+  describe("datasetJsonLd", () => {
+    it("emits a Schema.org Dataset with CC BY 4.0 license", () => {
+      const ld = datasetJsonLd("en");
+      expect(ld["@type"]).toBe("Dataset");
+      expect(ld.license).toBe("https://creativecommons.org/licenses/by/4.0/");
+      expect(ld.isAccessibleForFree).toBe(true);
+      expect(ld.inLanguage).toEqual(["en", "es"]);
+    });
+
+    it("omits the identifier (DOI) field while DATASET_DOI is a placeholder", () => {
+      const ld = datasetJsonLd("en");
+      expect(ld.identifier).toBeUndefined();
+    });
+
+    it("varies title and description by locale", () => {
+      const en = datasetJsonLd("en");
+      const es = datasetJsonLd("es");
+      expect(en.name).not.toBe(es.name);
+      expect(en.description).not.toBe(es.description);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Master Plan v6.0 lane **L12 — SEO / GEO / Discoverability**. Closes the two cite-as items on L4 (Open Citizenship), with the actual DOI swap waiting on the first Zenodo deposit (the script for which landed in [#749](https://github.com/sandgraal/Costa-Rica-Tree-Atlas/pull/749)).

## What ships

- **[src/lib/citation/index.ts](src/lib/citation/index.ts)** — citation helpers:
  - `DATASET_DOI` placeholder constant (`10.5281/zenodo.PENDING`) with `hasMintedDOI()` gate; one-line swap when the real DOI is issued.
  - `formatAPA / formatMLA / formatBibTeX` for any species record.
  - `citationMetaTags()` — Google-Scholar-style `citation_*` keys.
  - `datasetJsonLd()` — Schema.org `Dataset` with CC BY 4.0 license, EN+ES name/description, `spatialCoverage: \"Costa Rica\"`, `identifier` field gated on real DOI.
- **[src/components/CitePage.tsx](src/components/CitePage.tsx)** — server-rendered \"Cite this page\" block. Renders APA, MLA, and BibTeX with a \"DOI pending\" notice while the placeholder is in use. License link visible.
- **[src/components/CitationCopyButton.tsx](src/components/CitationCopyButton.tsx)** — client-side copy-to-clipboard with focus-visible ring, no-print class, aria-label per format.
- **[src/app/[locale]/trees/[slug]/page.tsx](src/app/[locale]/trees/[slug]/page.tsx)** — `generateMetadata` now emits `citation_*` tags via the `other` field; `Dataset` JSON-LD rendered alongside the existing `Article` + `BreadcrumbList`; `<CitePage>` rendered after the `SafetyDisclaimer`.
- **[src/app/[locale]/layout.tsx](src/app/[locale]/layout.tsx)** — `cite` added to `CLIENT_NAMESPACES` so the copy button's client-side `useTranslations()` resolves (caught by `tests/layout-namespace-audit.test.ts`).
- **[messages/en.json](messages/en.json), [messages/es.json](messages/es.json)** — new `cite` namespace.
- **[tests/lib/citation.test.ts](tests/lib/citation.test.ts)** — 12 unit tests covering DOI gating, citation format outputs, meta-tag emission, and Dataset JSON-LD shape per locale.

## Plan delta

- L4 \"cite-as metadata — every species page exposes `citation_doi` + visible Cite this page block\" → ✅
- L4 \"JSON-LD Taxon + Dataset markup on species pages\" → ✅

The follow-up is a Zenodo deposit + real DOI mint; once that lands, swap `DATASET_DOI` in [src/lib/citation/index.ts](src/lib/citation/index.ts) and the entire UI / JSON-LD / meta pipeline picks up the real identifier.

## Test plan

- [x] `npm run contentlayer` → 694 documents
- [x] `npx tsc --noEmit` → clean
- [x] `npx vitest run tests/lib/citation.test.ts` → **12 / 12 passed**
- [x] `npx vitest run tests/content-validation.test.ts tests/conservation-status-i18n.test.tsx tests/route-regression.test.ts tests/i18n-parity.test.ts tests/layout-namespace-audit.test.ts` → **76 / 76 passed**
- [x] Pre-existing `tests/api/images-upload.test.ts` and `tests/lib/validation/__tests__/entropy.test.ts` failures predate this PR (verified by stashing the change-set and re-running).

🤖 Generated with [Claude Code](https://claude.com/claude-code)