### PR TITLE
feat(seo): schema:FAQPage JSON-LD on safety pages (L12)

### DIFF
--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -120,7 +120,7 @@ Each lane has a status, a one-sentence "why now," and concrete deliverables. Lan
 - [ ] **Zenodo deposit + DOI** — first stable corpus dump → Zenodo, claim DOI, configure auto-deposit on tagged releases.
 - [x] **`cite-as` metadata** — every species page exposes citation\_\* `<meta>` tags + visible "Cite this page" block in both locales with APA, MLA, and BibTeX examples (2026-05-17). `citation_doi` is gated on a real Zenodo mint; placeholder DOI in [`src/lib/citation/index.ts`](../src/lib/citation/index.ts) until the deposit lands. Component: [`src/components/CitePage.tsx`](../src/components/CitePage.tsx).
 - [x] **JSON-LD Taxon + Dataset markup** on species pages (2026-05-17). Taxon block was already emitted via the Article wrapper; Dataset block added alongside.
-- [ ] **`schema:FAQPage` JSON-LD** on safety pages (toxicity → answers).
+- [x] **`schema:FAQPage` JSON-LD** on safety pages (2026-05-17). Four Q/A pairs (ingestion, skin contact, eye contact, emergency contacts) emitted from existing localized first-aid copy via [`src/lib/seo/safety-faq.ts`](../src/lib/seo/safety-faq.ts); rendered alongside the existing `MedicalWebPage` block on `/[locale]/safety`. Question copy lives under `safety.page.faq*` keys in both locales.
 
 ### L5 — Indigenous Knowledge & Language 🟡 EXPANDING
 

--- a/messages/en.json
+++ b/messages/en.json
@@ -999,7 +999,12 @@
       "structuredDataName": "Tree Safety Guide",
       "structuredDataDescription": "Complete safety information about Costa Rican trees.",
       "structuredDataMainEntityName": "Tree Toxicity and First Aid",
-      "structuredDataMainEntityDescription": "Toxicity levels, skin contact risks, and emergency contacts for Costa Rican trees."
+      "structuredDataMainEntityDescription": "Toxicity levels, skin contact risks, and emergency contacts for Costa Rican trees.",
+      "faqIngestionQuestion": "What should I do if someone swallows part of a Costa Rican tree or plant?",
+      "faqSkinContactQuestion": "What should I do if tree sap or plant material contacts the skin?",
+      "faqEyeContactQuestion": "What should I do if tree sap or plant material enters the eyes?",
+      "faqEmergencyQuestion": "Who do I call in Costa Rica for a plant-poisoning emergency?",
+      "faqEmergencyAnswer": "Call the National Poison Control Center at 2223-1028 (available 24/7) for plant-poisoning guidance. For police, fire, or ambulance, dial 911. National Insurance Institute (INS) medical assistance: 800-8000-911. Have the plant or plant part ready for identification."
     }
   },
   "conservation": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -995,7 +995,12 @@
       "structuredDataName": "Guía de Seguridad de Árboles",
       "structuredDataDescription": "Información completa sobre la seguridad de los árboles de Costa Rica.",
       "structuredDataMainEntityName": "Toxicidad y Primeros Auxilios de Árboles",
-      "structuredDataMainEntityDescription": "Niveles de toxicidad, riesgos de contacto con la piel y contactos de emergencia para árboles de Costa Rica."
+      "structuredDataMainEntityDescription": "Niveles de toxicidad, riesgos de contacto con la piel y contactos de emergencia para árboles de Costa Rica.",
+      "faqIngestionQuestion": "¿Qué hacer si alguien ingiere parte de un árbol o planta de Costa Rica?",
+      "faqSkinContactQuestion": "¿Qué hacer si la savia o el material vegetal entra en contacto con la piel?",
+      "faqEyeContactQuestion": "¿Qué hacer si la savia o el material vegetal entra en los ojos?",
+      "faqEmergencyQuestion": "¿A quién llamar en Costa Rica ante una emergencia por envenenamiento con plantas?",
+      "faqEmergencyAnswer": "Llame al Centro Nacional de Control de Intoxicaciones al 2223-1028 (disponible 24/7) para orientación ante envenenamiento por plantas. Para policía, bomberos o ambulancia, marque 911. Asistencia médica del Instituto Nacional de Seguros (INS): 800-8000-911. Tenga la planta o la parte de la planta lista para su identificación."
     }
   },
   "conservation": {

--- a/src/app/[locale]/safety/page.tsx
+++ b/src/app/[locale]/safety/page.tsx
@@ -3,6 +3,7 @@ import { setRequestLocale, getTranslations } from "next-intl/server";
 import { allTrees } from "contentlayer/generated";
 import { SafetyPageClient } from "./SafetyPageClient";
 import { SafeJsonLd } from "@/components/SafeJsonLd";
+import { buildSafetyFaqJsonLd } from "@/lib/seo/safety-faq";
 import type { Locale } from "@/types";
 
 interface SafetyPageProps {
@@ -49,9 +50,48 @@ export default async function SafetyPage({ params }: SafetyPageProps) {
     },
   };
 
+  const faqJsonLd = buildSafetyFaqJsonLd({
+    locale,
+    ingestion: {
+      question: t("faqIngestionQuestion"),
+      steps: [
+        t("ingestionStep1"),
+        t("ingestionStep2"),
+        t("ingestionStep3"),
+        t("ingestionStep4"),
+        t("ingestionStep5"),
+      ],
+    },
+    skinContact: {
+      question: t("faqSkinContactQuestion"),
+      steps: [
+        t("skinContactStep1"),
+        t("skinContactStep2"),
+        t("skinContactStep3"),
+        t("skinContactStep4"),
+        t("skinContactStep5"),
+      ],
+    },
+    eyeContact: {
+      question: t("faqEyeContactQuestion"),
+      steps: [
+        t("eyeContactStep1"),
+        t("eyeContactStep2"),
+        t("eyeContactStep3"),
+        t("eyeContactStep4"),
+        t("eyeContactStep5"),
+      ],
+    },
+    emergency: {
+      question: t("faqEmergencyQuestion"),
+      answer: t("faqEmergencyAnswer"),
+    },
+  });
+
   return (
     <>
       <SafeJsonLd data={structuredData} />
+      <SafeJsonLd data={faqJsonLd} />
       <SafetyPageClient trees={trees} />
     </>
   );

--- a/src/app/[locale]/safety/page.tsx
+++ b/src/app/[locale]/safety/page.tsx
@@ -3,6 +3,7 @@ import { setRequestLocale, getTranslations } from "next-intl/server";
 import { allTrees } from "contentlayer/generated";
 import { SafetyPageClient } from "./SafetyPageClient";
 import { SafeJsonLd } from "@/components/SafeJsonLd";
+import { SITE_BASE_URL } from "@/lib/citation";
 import { buildSafetyFaqJsonLd } from "@/lib/seo/safety-faq";
 import type { Locale } from "@/types";
 
@@ -42,7 +43,7 @@ export default async function SafetyPage({ params }: SafetyPageProps) {
     "@type": "WebPage",
     name: t("structuredDataName"),
     description: t("structuredDataDescription"),
-    url: `https://costaricatreeatlas.com/${locale}/safety`,
+    url: `${SITE_BASE_URL}/${locale}/safety`,
     mainEntity: {
       "@type": "MedicalWebPage",
       name: t("structuredDataMainEntityName"),

--- a/src/lib/seo/safety-faq.ts
+++ b/src/lib/seo/safety-faq.ts
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2024-present Costa Rica Tree Atlas contributors
+ * SPDX-License-Identifier: MIT
+ *
+ * Schema.org FAQPage JSON-LD for the bilingual Safety guide.
+ *
+ * Master Plan v6.0 lane L12 — SEO / GEO / Discoverability.
+ *
+ * Why FAQPage on Safety: poison-emergency questions are exactly the
+ * kind of query that an AI overview or search engine should answer
+ * with an authoritative, sourced answer. The page already has the
+ * underlying first-aid copy in `safety.page.*`; this helper restates
+ * it in machine-readable form.
+ *
+ * The helper is intentionally pure (no `next-intl` import). The route
+ * resolves translations server-side and hands the strings in. That
+ * keeps the helper unit-testable for both locales without spinning up
+ * the i18n runtime.
+ */
+
+import type { Locale } from "@/types/tree";
+import { SITE_BASE_URL } from "@/lib/citation";
+
+export interface SafetyFaqStepSet {
+  question: string;
+  steps: string[];
+}
+
+export interface SafetyFaqPair {
+  question: string;
+  answer: string;
+}
+
+export interface SafetyFaqInput {
+  locale: Locale;
+  ingestion: SafetyFaqStepSet;
+  skinContact: SafetyFaqStepSet;
+  eyeContact: SafetyFaqStepSet;
+  emergency: SafetyFaqPair;
+}
+
+/**
+ * Render a list of imperative steps into a single answer string with a
+ * locale-appropriate numbering. The numbered form helps AI overviews
+ * preserve order when summarizing.
+ */
+function joinSteps(steps: string[]): string {
+  return steps.map((step, idx) => `${idx + 1}. ${step}`).join(" ");
+}
+
+/**
+ * Build the Schema.org FAQPage JSON-LD for the Safety guide. The
+ * `mainEntity` array is the ordered list of Question/Answer pairs
+ * (ingestion → skin contact → eye contact → emergency contacts).
+ *
+ * Schema reference: https://schema.org/FAQPage
+ */
+export function buildSafetyFaqJsonLd(
+  input: SafetyFaqInput
+): Record<string, unknown> {
+  const { locale, ingestion, skinContact, eyeContact, emergency } = input;
+
+  const pairs: Array<{ question: string; answer: string }> = [
+    { question: ingestion.question, answer: joinSteps(ingestion.steps) },
+    { question: skinContact.question, answer: joinSteps(skinContact.steps) },
+    { question: eyeContact.question, answer: joinSteps(eyeContact.steps) },
+    { question: emergency.question, answer: emergency.answer },
+  ];
+
+  return {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    url: `${SITE_BASE_URL}/${locale}/safety`,
+    inLanguage: locale,
+    mainEntity: pairs.map(({ question, answer }) => ({
+      "@type": "Question",
+      name: question,
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: answer,
+      },
+    })),
+  };
+}

--- a/src/lib/seo/safety-faq.ts
+++ b/src/lib/seo/safety-faq.ts
@@ -40,9 +40,11 @@ export interface SafetyFaqInput {
 }
 
 /**
- * Render a list of imperative steps into a single answer string with a
- * locale-appropriate numbering. The numbered form helps AI overviews
- * preserve order when summarizing.
+ * Render a list of imperative steps into a single numbered answer
+ * string. The numbering uses Western Arabic digits (1., 2., 3., …),
+ * which read correctly in both EN and ES — neither locale needs
+ * special enumeration markers here. The numbered form helps AI
+ * overviews preserve order when summarizing.
  */
 function joinSteps(steps: string[]): string {
   return steps.map((step, idx) => `${idx + 1}. ${step}`).join(" ");
@@ -60,7 +62,7 @@ export function buildSafetyFaqJsonLd(
 ): Record<string, unknown> {
   const { locale, ingestion, skinContact, eyeContact, emergency } = input;
 
-  const pairs: Array<{ question: string; answer: string }> = [
+  const pairs: SafetyFaqPair[] = [
     { question: ingestion.question, answer: joinSteps(ingestion.steps) },
     { question: skinContact.question, answer: joinSteps(skinContact.steps) },
     { question: eyeContact.question, answer: joinSteps(eyeContact.steps) },

--- a/tests/lib/safety-faq.test.ts
+++ b/tests/lib/safety-faq.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2024-present Costa Rica Tree Atlas contributors
+ * SPDX-License-Identifier: MIT
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { buildSafetyFaqJsonLd } from "@/lib/seo/safety-faq";
+import type { SafetyFaqInput } from "@/lib/seo/safety-faq";
+
+function sampleInput(locale: "en" | "es"): SafetyFaqInput {
+  return {
+    locale,
+    ingestion: {
+      question: "Q-ingest",
+      steps: ["i1", "i2", "i3"],
+    },
+    skinContact: {
+      question: "Q-skin",
+      steps: ["s1", "s2"],
+    },
+    eyeContact: {
+      question: "Q-eye",
+      steps: ["e1", "e2"],
+    },
+    emergency: {
+      question: "Q-emergency",
+      answer: "Call 2223-1028.",
+    },
+  };
+}
+
+describe("buildSafetyFaqJsonLd", () => {
+  it("emits a Schema.org FAQPage with one Question per topic", () => {
+    const ld = buildSafetyFaqJsonLd(sampleInput("en"));
+    expect(ld["@context"]).toBe("https://schema.org");
+    expect(ld["@type"]).toBe("FAQPage");
+
+    const mainEntity = ld.mainEntity as Array<Record<string, unknown>>;
+    expect(Array.isArray(mainEntity)).toBe(true);
+    expect(mainEntity).toHaveLength(4);
+    mainEntity.forEach((q) => {
+      expect(q["@type"]).toBe("Question");
+      expect(typeof q.name).toBe("string");
+      const ans = q.acceptedAnswer as Record<string, unknown>;
+      expect(ans["@type"]).toBe("Answer");
+      expect(typeof ans.text).toBe("string");
+      expect((ans.text as string).length).toBeGreaterThan(0);
+    });
+  });
+
+  it("numbers multi-step answers in order so AI overviews preserve sequence", () => {
+    const ld = buildSafetyFaqJsonLd(sampleInput("en"));
+    const mainEntity = ld.mainEntity as Array<Record<string, unknown>>;
+    const ingestion = mainEntity[0].acceptedAnswer as Record<string, unknown>;
+    expect(ingestion.text).toBe("1. i1 2. i2 3. i3");
+  });
+
+  it("uses the emergency answer verbatim (single-paragraph form, no numbering)", () => {
+    const ld = buildSafetyFaqJsonLd(sampleInput("en"));
+    const mainEntity = ld.mainEntity as Array<Record<string, unknown>>;
+    const emergency = mainEntity[3].acceptedAnswer as Record<string, unknown>;
+    expect(emergency.text).toBe("Call 2223-1028.");
+  });
+
+  it("emits the correct locale-scoped URL and inLanguage for ES", () => {
+    const ld = buildSafetyFaqJsonLd(sampleInput("es"));
+    expect(ld.url).toBe("https://costaricatreeatlas.com/es/safety");
+    expect(ld.inLanguage).toBe("es");
+  });
+
+  it("emits the correct locale-scoped URL and inLanguage for EN", () => {
+    const ld = buildSafetyFaqJsonLd(sampleInput("en"));
+    expect(ld.url).toBe("https://costaricatreeatlas.com/en/safety");
+    expect(ld.inLanguage).toBe("en");
+  });
+
+  it("preserves question text exactly as provided (no translation in helper)", () => {
+    const ld = buildSafetyFaqJsonLd(sampleInput("en"));
+    const mainEntity = ld.mainEntity as Array<Record<string, unknown>>;
+    expect(mainEntity.map((q) => q.name)).toEqual([
+      "Q-ingest",
+      "Q-skin",
+      "Q-eye",
+      "Q-emergency",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `buildSafetyFaqJsonLd()` helper at `src/lib/seo/safety-faq.ts` — a pure function that emits a Schema.org `FAQPage` with four ordered Q/A pairs for the bilingual Safety guide (ingestion, skin contact, eye contact, emergency contacts).
- Renders a second `SafeJsonLd` block on `/[locale]/safety` alongside the existing `MedicalWebPage` JSON-LD. URL and `inLanguage` are locale-scoped.
- Adds `safety.page.faq*` keys to EN+ES messages. Step-based answers reuse the existing `ingestionStep1..5` / `skinContactStep1..5` / `eyeContactStep1..5` keys — no copy duplication. Numbered answer form preserves step order for AI overviews.

Master Plan v6.0 lane L12 (SEO / GEO / Discoverability). Closes the `schema:FAQPage` item on L4's discoverability slice; follows the cite-as + Dataset JSON-LD shipped in #753.

## Why FAQPage on Safety

Poison-emergency questions are the most load-bearing AI-overview surface this site has. The page already held all of the underlying first-aid copy; this exposes it in a machine-readable form a search engine or LLM can quote with order preserved.

## Test plan

- [x] `npx vitest run tests/lib/safety-faq.test.ts tests/lib/citation.test.ts tests/i18n-parity.test.ts tests/route-regression.test.ts tests/layout-namespace-audit.test.ts` → 66 passed
- [x] `npm run contentlayer` → 694 documents
- [x] `npm run type-check` → no new errors in changed files
- [ ] Manual: view-source on `/en/safety` and `/es/safety`, confirm both JSON-LD blocks present
- [ ] Manual: paste rendered FAQPage into Google's Rich Results Test, confirm 4 questions detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)