### PR TITLE
fix(content): add missing Fuentes citation to ceiba.mdx ES cultural section

### DIFF
--- a/content/trees/es/ceiba.mdx
+++ b/content/trees/es/ceiba.mdx
@@ -573,6 +573,8 @@ La **fibra de kapok** es una de las fibras naturales más ligeras conocidas — 
 
 ## Significado Cultural y Espiritual
 
+**Fuentes:** [IUCN Red List — búsqueda de _Ceiba pentandra_](https://www.iucnredlist.org/search?query=Ceiba%20pentandra), [Plants of the World Online (Kew) — _Ceiba pentandra_](https://powo.science.kew.org/taxon/urn:lsid:ipni.org:names:558746-1), [USDA Forest Service — _Ceiba pentandra_](https://www.fs.usda.gov/research/treesearch/5253)
+
 <Callout type="info" title="El Árbol del Mundo Maya — Ya'axché">
 
 Para los antiguos mayas, la Ceiba era el **más sagrado de todos los árboles** —


### PR DESCRIPTION
## Summary
- The EN [Cultural & Spiritual Significance] section of `ceiba.mdx` carries an inline `**Sources:**` line citing IUCN Red List, POWO, and USDA Forest Service; the ES mirror (`## Significado Cultural y Espiritual`) was missing the equivalent `**Fuentes:**` line — an EN/ES presentation asymmetry.
- Added the same sources/links to the ES file, translated naturally ("búsqueda de _Ceiba pentandra_" for "search").
- The bottom-of-page `<ReferencesSection>` was already present and identical in both locales, so this was not a hard citation gap — just parity polish.

## Test plan
- [x] `npm run contentlayer` — rebuilds clean, no schema errors
- [x] `npx vitest run tests/content-validation.test.ts tests/conservation-status-i18n.test.tsx tests/route-regression.test.ts` — 71 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)