### PR TITLE
fix(scripts): stop manage-tree-images.mjs from mislabeling copyrighted photos as CC-licensed

### DIFF
--- a/content/trees/en/arrayan.mdx
+++ b/content/trees/en/arrayan.mdx
@@ -122,44 +122,44 @@ commonProblems:
 
 <ImageGallery>
   <ImageCard
-    src="https://inaturalist-open-data.s3.amazonaws.com/photos/112077794/medium.jpeg"
+    src="https://inaturalist-open-data.s3.amazonaws.com/photos/127934223/medium.jpg"
     alt="Weinmannia pinnata - Whole tree"
     title="Whole tree"
     credit="(c) Leonardo Álvarez-Alcázar, some rights reserved (CC BY-NC)"
     license="CC BY-NC"
-    sourceUrl="https://www.inaturalist.org/taxa/284923-Weinmannia-pinnata/browse_photos"
+    sourceUrl="https://www.inaturalist.org/observations/78192835"
   />
   <ImageCard
-    src="https://inaturalist-open-data.s3.amazonaws.com/photos/112077786/medium.jpeg"
+    src="https://inaturalist-open-data.s3.amazonaws.com/photos/127934235/medium.jpg"
     alt="Weinmannia pinnata - Leaves"
     title="Leaves"
     credit="(c) Leonardo Álvarez-Alcázar, some rights reserved (CC BY-NC)"
     license="CC BY-NC"
-    sourceUrl="https://www.inaturalist.org/taxa/284923-Weinmannia-pinnata/browse_photos"
+    sourceUrl="https://www.inaturalist.org/observations/78192835"
   />
   <ImageCard
-    src="https://inaturalist-open-data.s3.amazonaws.com/photos/112077778/medium.jpeg"
+    src="https://inaturalist-open-data.s3.amazonaws.com/photos/339569499/medium.jpeg"
     alt="Weinmannia pinnata - Whole tree"
     title="Whole tree"
     credit="(c) Octavio Rivera Hernández, some rights reserved (CC BY-NC)"
     license="CC BY-NC"
-    sourceUrl="https://www.inaturalist.org/taxa/284923-Weinmannia-pinnata/browse_photos"
+    sourceUrl="https://www.inaturalist.org/observations/193310319"
   />
   <ImageCard
-    src="https://inaturalist-open-data.s3.amazonaws.com/photos/112077767/medium.jpeg"
+    src="https://inaturalist-open-data.s3.amazonaws.com/photos/127934246/medium.jpg"
     alt="Weinmannia pinnata - Leaves"
     title="Leaves"
     credit="(c) Leonardo Álvarez-Alcázar, some rights reserved (CC BY-NC)"
     license="CC BY-NC"
-    sourceUrl="https://www.inaturalist.org/taxa/284923-Weinmannia-pinnata/browse_photos"
+    sourceUrl="https://www.inaturalist.org/observations/78192835"
   />
   <ImageCard
-    src="https://inaturalist-open-data.s3.amazonaws.com/photos/511368454/medium.jpg"
+    src="https://inaturalist-open-data.s3.amazonaws.com/photos/46022763/medium.jpeg"
     alt="Weinmannia pinnata - Whole tree"
     title="Whole tree"
-    credit="(c) Guillaume Léotard, some rights reserved (CC BY-NC)"
+    credit="(c) Martin Reith, some rights reserved (CC BY-NC)"
     license="CC BY-NC"
-    sourceUrl="https://www.inaturalist.org/taxa/284923-Weinmannia-pinnata/browse_photos"
+    sourceUrl="https://www.inaturalist.org/observations/29490177"
   />
 </ImageGallery>
 

--- a/content/trees/es/arrayan.mdx
+++ b/content/trees/es/arrayan.mdx
@@ -123,44 +123,44 @@ commonProblems:
 
 <ImageGallery>
   <ImageCard
-    src="https://inaturalist-open-data.s3.amazonaws.com/photos/112077794/medium.jpeg"
+    src="https://inaturalist-open-data.s3.amazonaws.com/photos/127934223/medium.jpg"
     alt="Weinmannia pinnata - Whole tree"
     title="Whole tree"
     credit="(c) Leonardo Álvarez-Alcázar, some rights reserved (CC BY-NC)"
     license="CC BY-NC"
-    sourceUrl="https://www.inaturalist.org/taxa/284923-Weinmannia-pinnata/browse_photos"
+    sourceUrl="https://www.inaturalist.org/observations/78192835"
   />
   <ImageCard
-    src="https://inaturalist-open-data.s3.amazonaws.com/photos/112077786/medium.jpeg"
+    src="https://inaturalist-open-data.s3.amazonaws.com/photos/127934235/medium.jpg"
     alt="Weinmannia pinnata - Leaves"
     title="Leaves"
     credit="(c) Leonardo Álvarez-Alcázar, some rights reserved (CC BY-NC)"
     license="CC BY-NC"
-    sourceUrl="https://www.inaturalist.org/taxa/284923-Weinmannia-pinnata/browse_photos"
+    sourceUrl="https://www.inaturalist.org/observations/78192835"
   />
   <ImageCard
-    src="https://inaturalist-open-data.s3.amazonaws.com/photos/112077778/medium.jpeg"
+    src="https://inaturalist-open-data.s3.amazonaws.com/photos/339569499/medium.jpeg"
     alt="Weinmannia pinnata - Whole tree"
     title="Whole tree"
     credit="(c) Octavio Rivera Hernández, some rights reserved (CC BY-NC)"
     license="CC BY-NC"
-    sourceUrl="https://www.inaturalist.org/taxa/284923-Weinmannia-pinnata/browse_photos"
+    sourceUrl="https://www.inaturalist.org/observations/193310319"
   />
   <ImageCard
-    src="https://inaturalist-open-data.s3.amazonaws.com/photos/112077767/medium.jpeg"
+    src="https://inaturalist-open-data.s3.amazonaws.com/photos/127934246/medium.jpg"
     alt="Weinmannia pinnata - Leaves"
     title="Leaves"
     credit="(c) Leonardo Álvarez-Alcázar, some rights reserved (CC BY-NC)"
     license="CC BY-NC"
-    sourceUrl="https://www.inaturalist.org/taxa/284923-Weinmannia-pinnata/browse_photos"
+    sourceUrl="https://www.inaturalist.org/observations/78192835"
   />
   <ImageCard
-    src="https://inaturalist-open-data.s3.amazonaws.com/photos/511368454/medium.jpg"
+    src="https://inaturalist-open-data.s3.amazonaws.com/photos/46022763/medium.jpeg"
     alt="Weinmannia pinnata - Whole tree"
     title="Whole tree"
-    credit="(c) Guillaume Léotard, some rights reserved (CC BY-NC)"
+    credit="(c) Martin Reith, some rights reserved (CC BY-NC)"
     license="CC BY-NC"
-    sourceUrl="https://www.inaturalist.org/taxa/284923-Weinmannia-pinnata/browse_photos"
+    sourceUrl="https://www.inaturalist.org/observations/29490177"
   />
 </ImageGallery>
 

--- a/public/images/trees/attributions.json
+++ b/public/images/trees/attributions.json
@@ -491,35 +491,40 @@
         {
           "id": 127934223,
           "attribution": "(c) Leonardo Álvarez-Alcázar, some rights reserved (CC BY-NC)",
+          "license": "CC BY-NC",
           "observationId": 78192835,
           "category": "whole_tree"
         },
         {
           "id": 127934235,
           "attribution": "(c) Leonardo Álvarez-Alcázar, some rights reserved (CC BY-NC)",
+          "license": "CC BY-NC",
           "observationId": 78192835,
           "category": "leaves"
         },
         {
           "id": 339569499,
           "attribution": "(c) Octavio Rivera Hernández, some rights reserved (CC BY-NC)",
+          "license": "CC BY-NC",
           "observationId": 193310319,
           "category": "whole_tree"
         },
         {
           "id": 127934246,
           "attribution": "(c) Leonardo Álvarez-Alcázar, some rights reserved (CC BY-NC)",
+          "license": "CC BY-NC",
           "observationId": 78192835,
           "category": "leaves"
         },
         {
-          "id": 342617772,
-          "attribution": "(c) Guillaume Léotard, some rights reserved (CC BY-NC)",
-          "observationId": 194850867,
+          "id": 46022763,
+          "attribution": "(c) Martin Reith, some rights reserved (CC BY-NC)",
+          "license": "CC BY-NC",
+          "observationId": 29490177,
           "category": "whole_tree"
         }
       ],
-      "updatedAt": "2026-02-26T23:09:19.029Z"
+      "updatedAt": "2026-07-04T11:59:38.965Z"
     }
   },
   "balsa": {

--- a/scripts/manage-tree-images.mjs
+++ b/scripts/manage-tree-images.mjs
@@ -123,9 +123,12 @@ const OPEN_LICENSE_CODES = new Set([
   "cc-by-nc-nd",
 ]);
 
-// Human-readable labels for the license badge shown in the gallery. Falls
-// back to the raw code (upper-cased) for any license iNaturalist adds later
-// that isn't in this map, so display never silently drops the real value.
+// Human-readable labels for the license badge shown in the gallery. Only
+// consulted for codes that already passed hasOpenLicense(), so a code
+// outside OPEN_LICENSE_CODES is dropped entirely by formatLicenseLabel
+// (returns null) rather than ever reaching the fallback below. The
+// upper-cased fallback exists solely so this map staying in sync with
+// OPEN_LICENSE_CODES is a display nicety, not a correctness requirement.
 const LICENSE_LABELS = {
   cc0: "CC0",
   pd: "Public Domain",

--- a/scripts/manage-tree-images.mjs
+++ b/scripts/manage-tree-images.mjs
@@ -109,6 +109,49 @@ const FEATURED_DETAIL_PATTERNS = [
   /semilla/,
 ];
 
+// iNaturalist license_code values that permit reuse on the site (with
+// attribution). A missing/null license_code means "all rights reserved" —
+// iNaturalist's default for photos the uploader hasn't explicitly licensed —
+// and must NEVER be treated as usable.
+const OPEN_LICENSE_CODES = new Set([
+  "cc0",
+  "pd",
+  "cc-by",
+  "cc-by-sa",
+  "cc-by-nc",
+  "cc-by-nc-sa",
+  "cc-by-nc-nd",
+]);
+
+// Human-readable labels for the license badge shown in the gallery. Falls
+// back to the raw code (upper-cased) for any license iNaturalist adds later
+// that isn't in this map, so display never silently drops the real value.
+const LICENSE_LABELS = {
+  cc0: "CC0",
+  pd: "Public Domain",
+  "cc-by": "CC BY",
+  "cc-by-sa": "CC BY-SA",
+  "cc-by-nc": "CC BY-NC",
+  "cc-by-nc-sa": "CC BY-NC-SA",
+  "cc-by-nc-nd": "CC BY-NC-ND",
+};
+
+// True only for a recognized, explicitly open license_code. Anything else
+// (null, undefined, empty string, or an unrecognized code) is treated as
+// not safely reusable — fail closed, not open.
+function hasOpenLicense(licenseCode) {
+  return (
+    typeof licenseCode === "string" &&
+    OPEN_LICENSE_CODES.has(licenseCode.toLowerCase())
+  );
+}
+
+function formatLicenseLabel(licenseCode) {
+  if (!hasOpenLicense(licenseCode)) return null;
+  const key = licenseCode.toLowerCase();
+  return LICENSE_LABELS[key] || licenseCode.toUpperCase();
+}
+
 // Parse arguments
 const args = process.argv.slice(2);
 const command = args.find((a) => !a.startsWith("--")) || "audit";
@@ -457,6 +500,16 @@ function extractPhotos(observations, photos, seen) {
 
       seen.add(photo.id);
 
+      // Never make an all-rights-reserved (or unrecognized-license) photo a
+      // candidate at all — filtering here, not just at display time, means
+      // a copyrighted photo can never end up selected as the featured image.
+      if (!hasOpenLicense(photo.license_code)) {
+        log.verbose(
+          `Skipping photo ${photo.id}: license_code "${photo.license_code}" is not an open license`
+        );
+        continue;
+      }
+
       const largeUrl = buildInatPhotoUrl(photo.url, "large");
       const originalUrl = buildInatPhotoUrl(photo.url, "original");
 
@@ -466,6 +519,7 @@ function extractPhotos(observations, photos, seen) {
         largeUrl,
         downloadUrl: originalUrl,
         attribution: photo.attribution || "iNaturalist user",
+        licenseCode: photo.license_code,
         observationId: obs.id,
         votes: obs.faves_count || 0,
         place: obs.place_guess || "",
@@ -828,6 +882,16 @@ function categorizePhotos(observations, categories, seen) {
 
       seen.add(photo.id);
 
+      // Never make an all-rights-reserved (or unrecognized-license) photo a
+      // candidate at all — filtering here, not just at display time, means
+      // a copyrighted photo can never end up selected for the gallery.
+      if (!hasOpenLicense(photo.license_code)) {
+        log.verbose(
+          `Skipping gallery photo ${photo.id}: license_code "${photo.license_code}" is not an open license`
+        );
+        continue;
+      }
+
       const mediumUrl = buildInatPhotoUrl(photo.url, "medium");
       const largeUrl = buildInatPhotoUrl(photo.url, "large");
       const originalUrl = buildInatPhotoUrl(photo.url, "original");
@@ -838,6 +902,7 @@ function categorizePhotos(observations, categories, seen) {
         downloadUrl: originalUrl,
         largeUrl,
         attribution: photo.attribution || "iNaturalist user",
+        licenseCode: photo.license_code,
         observationId: obs.id,
         votes: obs.faves_count || 0,
         place: obs.place_guess || "",
@@ -947,8 +1012,27 @@ async function updateMdxGallery(filePath, treeName, newImages, scientificName) {
       return { updated: false, reason: "no_gallery_section" };
     }
 
+    // Hard validation: never write a license badge for a photo that isn't
+    // openly licensed, even if it slipped past upstream filtering. Fail
+    // closed by dropping the image rather than mislabeling it.
+    const licensedImages = [];
+    for (const img of newImages) {
+      const licenseLabel = formatLicenseLabel(img.licenseCode);
+      if (!licenseLabel) {
+        log.warn(
+          `${treeName}: dropping photo ${img.id} from gallery — license_code "${img.licenseCode}" is not an open license and cannot be attributed as reusable`
+        );
+        continue;
+      }
+      licensedImages.push({ ...img, licenseLabel });
+    }
+
+    if (licensedImages.length === 0) {
+      return { updated: false, reason: "no_openly_licensed_photos" };
+    }
+
     // Generate new ImageCard components
-    const imageCards = newImages
+    const imageCards = licensedImages
       .map((img, idx) => {
         const title = img.category
           ? `${img.category.replace(/_/g, " ").replace(/^\w/, (c) => c.toUpperCase())}`
@@ -959,7 +1043,7 @@ async function updateMdxGallery(filePath, treeName, newImages, scientificName) {
     alt="${scientificName} - ${title}"
     title="${title}"
     credit="${img.attribution}"
-    license="CC BY-NC"
+    license="${img.licenseLabel}"
     sourceUrl="https://www.inaturalist.org/observations/${img.observationId}"
   />`;
       })
@@ -974,7 +1058,7 @@ async function updateMdxGallery(filePath, treeName, newImages, scientificName) {
     );
 
     await fs.writeFile(filePath, updatedContent, "utf8");
-    return { updated: true, imagesCount: newImages.length };
+    return { updated: true, imagesCount: licensedImages.length };
   } catch (err) {
     return { updated: false, reason: err.message };
   }
@@ -1445,6 +1529,7 @@ async function downloadImages() {
       // Update attributions
       attributions[treeName] = {
         attribution: result.photo.attribution,
+        license: formatLicenseLabel(result.photo.licenseCode),
         source: `https://www.inaturalist.org/observations/${result.photo.observationId}`,
         downloadedAt: new Date().toISOString(),
         votes: result.photo.votes ?? 0,
@@ -1592,6 +1677,7 @@ async function refreshImages() {
 
       attributions[treeName] = {
         attribution: downloadResult.photo.attribution,
+        license: formatLicenseLabel(downloadResult.photo.licenseCode),
         source: `https://www.inaturalist.org/observations/${downloadResult.photo.observationId}`,
         downloadedAt: new Date().toISOString(),
         votes: downloadResult.photo.votes ?? 0,
@@ -1888,6 +1974,7 @@ async function refreshGalleryImages() {
         photos: newPhotos.map((p) => ({
           id: p.id,
           attribution: p.attribution,
+          license: formatLicenseLabel(p.licenseCode),
           observationId: p.observationId,
           category: p.category,
         })),


### PR DESCRIPTION
## 📋 Description

Fixes two image-tooling defects surfaced while drafting the roble-de-altura (*Quercus costaricensis*) species page: `scripts/manage-tree-images.mjs` never read iNaturalist's `license_code` field on candidate photos, so:

1. An all-rights-reserved photo could be selected as a featured or gallery image at all (no license filtering anywhere in the candidate pipeline), and
2. `updateMdxGallery()` hardcoded `license="CC BY-NC"` on every gallery `<ImageCard>` regardless of the source photo's real license — so even when the correct `attribution` string said "all rights reserved," the separate `license` prop shown next to it falsely claimed CC BY-NC.

This is the exact same class of tooling risk that was caught and hand-corrected for the roble-de-altura page's own gallery, but not fixed at the source (see [content #385e16d9](https://github.com/sandgraal/Costa-Rica-Tree-Atlas/commit/385e16d93a4c3d0226743cc6e10d184d882c67c5) commit message), including the `weekly-image-quality.yml` scheduled workflow, which calls these same script commands unattended.

### Fix

- `extractPhotos()` (featured-image pipeline) and `categorizePhotos()` (gallery pipeline) now capture `photo.license_code` and reject any photo without a recognized open license (`cc0`, `pd`, `cc-by`, `cc-by-sa`, `cc-by-nc`, `cc-by-nc-sa`, `cc-by-nc-nd`) *before* it enters scoring/selection — so a copyrighted photo can no longer become the chosen image at all, not just get mislabeled.
- `updateMdxGallery()` has an independent second guard that drops any image lacking an open license rather than writing a badge for it, and now writes the photo's real, resolved license label instead of the hardcoded string.
- `attributions.json` entries (both featured-image and gallery) now record the resolved `license` per photo for future auditability.

### A second reported issue that did not reproduce

The same investigation flagged a whole-file UTF-8 → `\uXXXX` re-encoding side effect in `attributions.json` (610+ unrelated line changes). I could not reproduce this: `saveAttributions()` uses plain `JSON.stringify(attributions, null, 2)` with no replacer, which preserves literal UTF-8 by default. Verified both by code inspection and by re-running the exact write path (fixture round-trip + a live `refresh-gallery` run, see below) — no escaping was introduced either time, and the resulting diff stayed minimal. Likely caused by external tooling in the other session, not this script. No code change was needed for this part.

## 🎯 Related Issue

Fixes #

## 🔄 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## ✅ Checklist

### 🧭 Review Routing

- [x] No indigenous knowledge content was added or changed

### General

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

### For Content Changes

As a live verification of the fix, I ran `refresh-gallery --tree=arrayan --force` against real iNaturalist data. It correctly skipped 6 all-rights-reserved candidate photos it would previously have been eligible to select/mislabel, and replaced `arrayan`'s gallery with 5 openly-licensed photos, each now labeled with its real license. Both `content/trees/en/arrayan.mdx` and `content/trees/es/arrayan.mdx` are included in this PR as a result.

- [x] I have added/updated both English AND Spanish versions (if content changed) — arrayan gallery refresh via the fixed script, both locales
- [x] Both language files have the same slug/filename
- [x] Frontmatter is complete and accurate

## 🧪 How Has This Been Tested?

- `node scripts/manage-tree-images.mjs refresh-gallery --tree=arrayan --force` (real iNaturalist data): correctly skipped 6 all-rights-reserved candidate photos, updated the gallery with 5 openly-licensed replacements, each labeled with its real license.
- `npm run contentlayer`: 694 documents generated, clean build.
- `npx vitest run tests/content-validation.test.ts tests/conservation-status-i18n.test.tsx tests/route-regression.test.ts`: 71/71 pass.
- `npx vitest run` (full suite): 797/810 pass; the 13 failures (`tests/api/images-upload.test.ts`, `tests/lib/citation.test.ts`) are pre-existing and reproduce identically with this change stashed out — confirmed unrelated.

## 📝 Additional Notes

This was investigated and fixed per an out-of-scope follow-up flagged during the roble-de-altura content PR (not yet merged, on a separate branch) — that PR's own gallery was hand-corrected but the underlying script logic was left as a known bug until this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)