### PR TITLE
fix(content): add missing /en locale prefix to granadillo.mdx links

### DIFF
--- a/content/trees/en/granadillo.mdx
+++ b/content/trees/en/granadillo.mdx
@@ -109,7 +109,7 @@ wildlifeRisks: "No significant risks to wildlife or livestock."
   **Help Document This Species**: Granadillo is a newly added species requiring
   community photo contributions. If you have quality images of this tree (bark,
   leaves, flowers, wood), please contribute through our [photo submission
-  page](/contribute/photo).
+  page](/en/contribute/photo).
 </Callout>
 
 ---
@@ -906,4 +906,4 @@ Look for these **field identification features**:
 
 ---
 
-**_Contributions welcome_** - If you have photos or traditional knowledge about Granadillo, please [contribute](/contribute).
+**_Contributions welcome_** - If you have photos or traditional knowledge about Granadillo, please [contribute](/en/contribute).


### PR DESCRIPTION
## Summary
- A Copilot review comment on [PR #789](https://github.com/sandgraal/Costa-Rica-Tree-Atlas/pull/789) caught that new species content used a non-locale-prefixed internal link (`/contribute/photo` instead of `/en/contribute/photo`). Routes are locale-prefixed under `src/app/[locale]/...`, and the middleware matcher only covers `/(en|es)/...`, so the un-prefixed link 404s.
- The already-shipped `content/trees/en/granadillo.mdx` had the same bug pattern in two links (`/contribute/photo` and `/contribute`).
- Searched all of `content/trees/en/` and `content/trees/es/` for the same pattern (markdown links and `href` attributes to root-relative paths not already prefixed with `/en/` or `/es/`) — these were the only remaining instances.

## Why
Un-prefixed internal links silently 404 for readers who click them, undermining the "Help Document This Species" contribution call-to-action on a live species page.

## Test plan
- [x] `npx contentlayer2 build` — 694 documents generated, no errors
- [x] `npx vitest run tests/route-regression.test.ts` — 42/42 passed

## Note
The same bug pattern was also found to be widespread in `content/comparisons/` (~30 links across ~12 files, both locales). That's out of scope for this PR (different content directory) and has been flagged separately for a follow-up fix.