### PR TITLE
fix(content): prepend locale prefix to internal links in content/comparisons

### DIFF
--- a/content/comparisons/en/aguacate-vs-aguacatillo.mdx
+++ b/content/comparisons/en/aguacate-vs-aguacatillo.mdx
@@ -700,8 +700,8 @@ Remember: Aguacate feeds people, Aguacatillo feeds the Resplendent Quetzal. Both
 
 ## Learn More
 
-- [Full Aguacate Profile](/trees/aguacate) - Complete care guide, varieties, propagation
-- [Full Aguacatillo Profile](/trees/aguacatillo) - Cloud forest ecology, quetzal relationship
-- [Tree Safety Guide](/safety) - Persin toxicity, pet safety
-- [Conservation Dashboard](/conservation) - Cloud forest protection, quetzal habitat
+- [Full Aguacate Profile](/en/trees/aguacate) - Complete care guide, varieties, propagation
+- [Full Aguacatillo Profile](/en/trees/aguacatillo) - Cloud forest ecology, quetzal relationship
+- [Tree Safety Guide](/en/safety) - Persin toxicity, pet safety
+- [Conservation Dashboard](/en/conservation) - Cloud forest protection, quetzal habitat
 - [Resplendent Quetzal Research](https://cloudforestalliance.org) - Quetzal conservation

--- a/content/comparisons/en/cedro-amargo-vs-cedro-maria.mdx
+++ b/content/comparisons/en/cedro-amargo-vs-cedro-maria.mdx
@@ -414,8 +414,8 @@ The easiest way to distinguish them: **check the leaves** (compound vs. simple) 
 
 ## Learn More
 
-- [Cedro Amargo Full Profile](/trees/cedro-amargo)
-- [Cedro María Full Profile](/trees/cedro-maria)
-- [All Tree Comparisons](/compare)
-- [Botanical Glossary: Compound Leaf](/glossary/compound-leaf)
-- [Botanical Glossary: Latex](/glossary/latex)
+- [Cedro Amargo Full Profile](/en/trees/cedro-amargo)
+- [Cedro María Full Profile](/en/trees/cedro-maria)
+- [All Tree Comparisons](/en/compare)
+- [Botanical Glossary: Compound Leaf](/en/glossary/compound-leaf)
+- [Botanical Glossary: Latex](/en/glossary/latex)

--- a/content/comparisons/en/corteza-amarilla-vs-cortez-negro.mdx
+++ b/content/comparisons/en/corteza-amarilla-vs-cortez-negro.mdx
@@ -331,5 +331,5 @@ Both make excellent landscape trees, but:
 
 ## Related Comparisons
 
-- [Corteza Amarilla vs. Roble de Sabana](/comparisons/corteza-amarilla-vs-roble-de-sabana) - Yellow vs. light pink Cortez
-- [Guayacán Real vs. Madero Negro](/comparisons/guayacan-real-vs-madero-negro) - More timber tree comparisons
+- [Corteza Amarilla vs. Roble de Sabana](/en/comparisons/corteza-amarilla-vs-roble-de-sabana) - Yellow vs. light pink Cortez
+- [Guayacán Real vs. Madero Negro](/en/comparisons/guayacan-real-vs-madero-negro) - More timber tree comparisons

--- a/content/comparisons/en/guayacan-real-vs-madero-negro.mdx
+++ b/content/comparisons/en/guayacan-real-vs-madero-negro.mdx
@@ -885,8 +885,8 @@ One teaches patience and conservation. The other provides immediate, tangible be
 
 ## Learn More
 
-- [Full Guayacán Real Profile](/trees/guayacan-real) - Endangered species care, CITES status
-- [Full Madero Negro Profile](/trees/madero-negro) - Agroforestry uses, propagation guide
-- [Conservation Guide](/conservation) - Protecting endangered trees
-- [Tree Safety Information](/safety) - Toxicity of Madero Negro seeds
+- [Full Guayacán Real Profile](/en/trees/guayacan-real) - Endangered species care, CITES status
+- [Full Madero Negro Profile](/en/trees/madero-negro) - Agroforestry uses, propagation guide
+- [Conservation Guide](/en/conservation) - Protecting endangered trees
+- [Tree Safety Information](/en/safety) - Toxicity of Madero Negro seeds
 - [CITES Species Database](https://www.speciesplus.net) - Trade restrictions for Guayacán

--- a/content/comparisons/en/jobo-vs-jocote.mdx
+++ b/content/comparisons/en/jobo-vs-jocote.mdx
@@ -337,5 +337,5 @@ These two native Spondias species share similar names, belong to the same genus,
 
 ## Related Comparisons
 
-- [Mango vs. Marañón](/comparisons/mango-vs-maranon) - Other Anacardiaceae fruits
-- [Mango vs. Espavel](/comparisons/mango-vs-espavel) - Cultivated vs. wild Anacardiaceae
+- [Mango vs. Marañón](/en/comparisons/mango-vs-maranon) - Other Anacardiaceae fruits
+- [Mango vs. Espavel](/en/comparisons/mango-vs-espavel) - Cultivated vs. wild Anacardiaceae

--- a/content/comparisons/en/laurel-vs-laurel-negro.mdx
+++ b/content/comparisons/en/laurel-vs-laurel-negro.mdx
@@ -289,5 +289,5 @@ These two native Boraginaceae species share the "Laurel" name and are both prize
 
 ## Related Comparisons
 
-- [Cedro Amargo vs. Cedro María](/comparisons/cedro-amargo-vs-cedro-maria) - Another pair of trees sharing a name
-- [Teak vs. Gmelina](/comparisons/teak-vs-gmelina) - Timber tree comparison
+- [Cedro Amargo vs. Cedro María](/en/comparisons/cedro-amargo-vs-cedro-maria) - Another pair of trees sharing a name
+- [Teak vs. Gmelina](/en/comparisons/teak-vs-gmelina) - Timber tree comparison

--- a/content/comparisons/en/mamon-vs-mamon-chino.mdx
+++ b/content/comparisons/en/mamon-vs-mamon-chino.mdx
@@ -311,5 +311,5 @@ Both seeds are large and obvious, presenting a **choking hazard for young childr
 
 ## Related Comparisons
 
-- [Jobo vs. Jocote](/comparisons/jobo-vs-jocote) - Another pair with similar names
-- [Guanábana vs. Anona](/comparisons/guanabana-vs-anona) - Tropical fruit comparison
+- [Jobo vs. Jocote](/en/comparisons/jobo-vs-jocote) - Another pair with similar names
+- [Guanábana vs. Anona](/en/comparisons/guanabana-vs-anona) - Tropical fruit comparison

--- a/content/comparisons/en/ojoche-vs-javillo.mdx
+++ b/content/comparisons/en/ojoche-vs-javillo.mdx
@@ -525,7 +525,7 @@ When in doubt, observe from a distance and look for trunk spines. If you see spi
 
 ## Learn More
 
-- [Full Ojoche Profile](/trees/ojoche) - Complete care guide, propagation, recipes
-- [Full Javillo Profile](/trees/javillo) - Detailed safety information, ecology
+- [Full Ojoche Profile](/en/trees/ojoche) - Complete care guide, propagation, recipes
+- [Full Javillo Profile](/en/trees/javillo) - Detailed safety information, ecology
 - [Maya Nut Institute](http://mayanut.org) - Organization promoting Ojoche cultivation
-- [Tree Safety Guide](/safety) - Toxicity levels, emergency contacts
+- [Tree Safety Guide](/en/safety) - Toxicity levels, emergency contacts

--- a/content/comparisons/en/teca-vs-melina.mdx
+++ b/content/comparisons/en/teca-vs-melina.mdx
@@ -486,7 +486,7 @@ The real question isn't "Which should I plant?" but rather "What is my timeline,
 
 ## Related Content
 
-- [Teak Tree Profile](/trees/teca)
-- [Gmelina Tree Profile](/trees/melina)
-- [Forestry & Timber Use Cases](/use-cases)
-- [Costa Rica Timber Species Guide](/trees?tags=timber)
+- [Teak Tree Profile](/en/trees/teca)
+- [Gmelina Tree Profile](/en/trees/melina)
+- [Forestry & Timber Use Cases](/en/use-cases)
+- [Costa Rica Timber Species Guide](/en/trees?tags=timber)

--- a/content/comparisons/en/zapote-vs-nispero.mdx
+++ b/content/comparisons/en/zapote-vs-nispero.mdx
@@ -528,7 +528,7 @@ If you can only choose one, let your **location and taste preference** decide:
 
 ## Related Content
 
-- [Zapote Tree Profile](/trees/zapote)
-- [Níspero Tree Profile](/trees/nispero)
-- [Edible Fruits Use Case](/use-cases)
-- [Fruit Trees of Costa Rica](/trees?tags=fruit-bearing)
+- [Zapote Tree Profile](/en/trees/zapote)
+- [Níspero Tree Profile](/en/trees/nispero)
+- [Edible Fruits Use Case](/en/use-cases)
+- [Fruit Trees of Costa Rica](/en/trees?tags=fruit-bearing)

--- a/content/comparisons/es/aguacate-vs-aguacatillo.mdx
+++ b/content/comparisons/es/aguacate-vs-aguacatillo.mdx
@@ -349,7 +349,7 @@ Recuerde: Aguacate alimenta personas, Aguacatillo alimenta al Quetzal Resplandec
 
 ## Aprenda Más
 
-- [Perfil Completo Aguacate](/trees/aguacate) - Guía completa cuidado, variedades, propagación
-- [Perfil Completo Aguacatillo](/trees/aguacatillo) - Ecología bosque nuboso, relación quetzal
-- [Guía Seguridad Árboles](/safety) - Toxicidad persina, seguridad mascotas
-- [Tablero Conservación](/conservation) - Protección bosque nuboso, hábitat quetzal
+- [Perfil Completo Aguacate](/es/trees/aguacate) - Guía completa cuidado, variedades, propagación
+- [Perfil Completo Aguacatillo](/es/trees/aguacatillo) - Ecología bosque nuboso, relación quetzal
+- [Guía Seguridad Árboles](/es/safety) - Toxicidad persina, seguridad mascotas
+- [Tablero Conservación](/es/conservation) - Protección bosque nuboso, hábitat quetzal

--- a/content/comparisons/es/cedro-amargo-vs-cedro-maria.mdx
+++ b/content/comparisons/es/cedro-amargo-vs-cedro-maria.mdx
@@ -414,8 +414,8 @@ La forma más fácil de distinguirlos: **verifica las hojas** (compuestas vs. si
 
 ## Aprende Más
 
-- [Perfil Completo de Cedro Amargo](/trees/cedro-amargo)
-- [Perfil Completo de Cedro María](/trees/cedro-maria)
-- [Todas las Comparaciones de Árboles](/compare)
-- [Glosario Botánico: Hoja Compuesta](/glossary/compound-leaf)
-- [Glosario Botánico: Látex](/glossary/latex)
+- [Perfil Completo de Cedro Amargo](/es/trees/cedro-amargo)
+- [Perfil Completo de Cedro María](/es/trees/cedro-maria)
+- [Todas las Comparaciones de Árboles](/es/compare)
+- [Glosario Botánico: Hoja Compuesta](/es/glossary/compound-leaf)
+- [Glosario Botánico: Látex](/es/glossary/latex)

--- a/content/comparisons/es/guayacan-real-vs-madero-negro.mdx
+++ b/content/comparisons/es/guayacan-real-vs-madero-negro.mdx
@@ -434,8 +434,8 @@ Uno enseña paciencia y conservación. El otro proporciona beneficios inmediatos
 
 ## Aprenda Más
 
-- [Perfil Completo Guayacán Real](/trees/guayacan-real) - Cuidado especies en peligro, estado CITES
-- [Perfil Completo Madero Negro](/trees/madero-negro) - Usos agroforestería, guía propagación
-- [Guía Conservación](/conservation) - Protegiendo árboles en peligro
-- [Información Seguridad Árboles](/safety) - Toxicidad semillas Madero Negro
+- [Perfil Completo Guayacán Real](/es/trees/guayacan-real) - Cuidado especies en peligro, estado CITES
+- [Perfil Completo Madero Negro](/es/trees/madero-negro) - Usos agroforestería, guía propagación
+- [Guía Conservación](/es/conservation) - Protegiendo árboles en peligro
+- [Información Seguridad Árboles](/es/safety) - Toxicidad semillas Madero Negro
 - [Base Datos Especies CITES](https://www.speciesplus.net) - Restricciones comercio Guayacán

--- a/content/comparisons/es/ojoche-vs-javillo.mdx
+++ b/content/comparisons/es/ojoche-vs-javillo.mdx
@@ -528,7 +528,7 @@ Cuando tenga duda, observe desde distancia y busque espinas en tronco. Si ve esp
 
 ## Aprenda Más
 
-- [Perfil Completo del Ojoche](/trees/ojoche) - Guía completa de cuidado, propagación, recetas
-- [Perfil Completo del Javillo](/trees/javillo) - Información detallada de seguridad, ecología
+- [Perfil Completo del Ojoche](/es/trees/ojoche) - Guía completa de cuidado, propagación, recetas
+- [Perfil Completo del Javillo](/es/trees/javillo) - Información detallada de seguridad, ecología
 - [Instituto Maya Nut](http://mayanut.org) - Organización promoviendo cultivo de Ojoche
-- [Guía de Seguridad de Árboles](/safety) - Niveles de toxicidad, contactos de emergencia
+- [Guía de Seguridad de Árboles](/es/safety) - Niveles de toxicidad, contactos de emergencia

--- a/content/comparisons/es/teca-vs-melina.mdx
+++ b/content/comparisons/es/teca-vs-melina.mdx
@@ -488,7 +488,7 @@ La pregunta real no es "¿Cuál debería plantar?" sino más bien "¿Cuál es mi
 
 ## Contenido Relacionado
 
-- [Perfil del Árbol de Teca](/trees/teca)
-- [Perfil del Árbol de Melina](/trees/melina)
-- [Casos de Uso de Silvicultura y Madera](/use-cases)
-- [Guía de Especies Madereras de Costa Rica](/trees?tags=timber)
+- [Perfil del Árbol de Teca](/es/trees/teca)
+- [Perfil del Árbol de Melina](/es/trees/melina)
+- [Casos de Uso de Silvicultura y Madera](/es/use-cases)
+- [Guía de Especies Madereras de Costa Rica](/es/trees?tags=timber)

--- a/content/comparisons/es/zapote-vs-nispero.mdx
+++ b/content/comparisons/es/zapote-vs-nispero.mdx
@@ -269,7 +269,7 @@ Zapote y Níspero son ambos **árboles frutales nativos excepcionales de Costa R
 
 ## Contenido Relacionado
 
-- [Perfil del Árbol de Zapote](/trees/zapote)
-- [Perfil del Árbol de Níspero](/trees/nispero)
-- [Caso de Uso de Frutas Comestibles](/use-cases)
-- [Árboles Frutales de Costa Rica](/trees?tags=fruit-bearing)
+- [Perfil del Árbol de Zapote](/es/trees/zapote)
+- [Perfil del Árbol de Níspero](/es/trees/nispero)
+- [Caso de Uso de Frutas Comestibles](/es/use-cases)
+- [Árboles Frutales de Costa Rica](/es/trees?tags=fruit-bearing)


### PR DESCRIPTION
## Summary
- Fixes the same locale-prefix bug flagged in the [#789](https://github.com/sandgraal/Costa-Rica-Tree-Atlas/pull/789) review for `content/trees`, now for `content/comparisons`
- Root-relative internal markdown links (e.g. `/trees/teca`, `/safety`, `/comparisons/jobo-vs-jocote`) 404 because the middleware matcher only covers `/(en|es)/...` routes
- Prepended `/en/` or `/es/` to each un-prefixed internal link, matching the locale of the file it lives in — 56 links across 16 files (10 en/, 6 es/)
- Left external URLs (speciesplus.net, cloudforestalliance.org, mayanut.org) and anchor links untouched

## Test plan
- [x] `npx contentlayer2 build` — 694 documents generated, no errors
- [x] `npx vitest run tests/content-validation.test.ts tests/conservation-status-i18n.test.tsx tests/route-regression.test.ts` — 71/71 passed
- [x] Re-grep confirms no un-prefixed root-relative links remain in `content/comparisons`: `grep -rnE '\]\(/[a-zA-Z]' --include="*.mdx" content/comparisons | grep -vE '\]\((/en/|/es/)'` returns nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)